### PR TITLE
AddressState and proofs

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -1,0 +1,318 @@
+{-# OPTIONS --erasure #-}
+
+-- Address management for the Customer Deposit Wallet
+module Cardano.Wallet.Deposit.Pure.Address
+    {-
+    ; Customer
+    ; AddressState
+      ; listCustomers
+      ; knownCustomerAddress
+
+      ; createAddress
+
+      ; newChangeAddress
+      ; prop-changeAddress-not-Customer
+    -}
+    where
+
+open import Haskell.Prelude
+open import Haskell.Reasoning
+
+open import Cardano.Wallet.Deposit.Read using
+    ( Address
+    )
+open import Cardano.Write.Tx.Balance using
+    ( ChangeAddressGen
+    ; isChange
+    )
+open import Haskell.Data.List.Prop using
+    ( _∈_ )
+open import Haskell.Data.Maybe using
+    ( isJust
+    ; catMaybes
+    )
+
+import Haskell.Data.Map as Map
+
+{-----------------------------------------------------------------------------
+    Assumptions
+------------------------------------------------------------------------------}
+
+deriveAddress : Nat → Address
+deriveAddress ix = suc ix
+
+{-----------------------------------------------------------------------------
+    Type definition
+------------------------------------------------------------------------------}
+
+Customer = Nat
+
+record AddressState : Set where
+  field
+    addresses : Map.Map Address Customer
+--    customers : Map.Map Customer Address
+
+    change    : Address
+
+  isCustomerAddress : Address → Bool
+  isCustomerAddress = λ addr → isJust $ Map.lookup addr addresses
+
+  field
+    @0 invariant-change
+      : change ≡ deriveAddress 0
+
+    @0 invariant-customer
+      : ∀ (addr : Address)
+      → isCustomerAddress addr ≡ True
+      → ∃ (λ ix → (addr ≡ deriveAddress ix) ⋀ ¬(ix ≡ 0))
+
+open AddressState
+
+{-----------------------------------------------------------------------------
+    Observations, basic
+------------------------------------------------------------------------------}
+
+-- isCustomerAddress : AddressState → Address → Bool
+
+isChangeAddress : AddressState → Address → Bool
+isChangeAddress = λ s addr → change s == addr
+
+isOurs : AddressState → Address → Bool
+isOurs = λ s addr → isChangeAddress s addr || isCustomerAddress s addr
+
+suc-injective : ∀ {x y : Nat} → suc x ≡ suc y → x ≡ y
+suc-injective refl = refl
+
+--
+@0 lemma-change-not-known
+  : ∀ (s : AddressState)
+  → Map.lookup (change s) (addresses s) ≡ Nothing
+--
+lemma-change-not-known s =
+  case Map.lookup (change s) (addresses s) of λ
+    { (Just _) {{eq}} →
+        let (ix `witness` (eq `and` not0)) =
+              invariant-customer s (change s) (cong isJust eq)
+
+            eq0 : ix ≡ 0
+            eq0 = suc-injective (trans (sym eq) (invariant-change s))
+        in  magic (not0 eq0)
+    ; Nothing {{eq}} → eq
+    }
+
+--
+@0 lemma-isChange-not-isCustomer
+  : ∀ (s : AddressState)
+      (addr : Address)
+  → isChangeAddress s addr ≡ True
+  → isCustomerAddress s addr ≡ False
+--
+lemma-isChange-not-isCustomer s a eq =
+  begin
+    isCustomerAddress s a
+  ≡⟨ cong (isCustomerAddress s) (sym (equality _ _ eq)) ⟩
+    isCustomerAddress s (change s)
+  ≡⟨ cong isJust (lemma-change-not-known s) ⟩
+    False
+  ∎
+
+--
+lemma-contra-Bool
+  : ∀ (x y : Bool)
+  → (x ≡ True → y ≡ False)
+  → (y ≡ True → x ≡ False)
+--
+lemma-contra-Bool False False impl1 = λ _ → refl
+lemma-contra-Bool False True impl1 = λ _ → refl
+lemma-contra-Bool True False impl1 = λ ()
+lemma-contra-Bool True True impl1 = λ _ → impl1 refl
+
+--
+@0 lemma-isCustomer-not-isChange
+  : ∀ (s : AddressState)
+      (addr : Address)
+  → isCustomerAddress s addr ≡ True
+  → isChangeAddress s addr ≡ False
+--
+lemma-isCustomer-not-isChange s addr =
+    lemma-contra-Bool _ _ (lemma-isChange-not-isCustomer s addr)
+
+{-----------------------------------------------------------------------------
+    Observations, specification
+------------------------------------------------------------------------------}
+
+-- Helper function
+swap : ∀ {a b : Set} → a × b → b × a
+swap (x , y) = (y , x)
+
+-- Specification
+listCustomers : AddressState → List (Customer × Address)
+listCustomers =
+    map swap ∘ Map.toAscList ∘ addresses
+
+knownCustomerAddress : Address → AddressState → Bool
+knownCustomerAddress address =
+    elem address ∘ map snd ∘ listCustomers
+
+-- alternate definition
+knownCustomerAddress' : Address → AddressState → Bool
+knownCustomerAddress' address =
+    elem address ∘ map fst ∘ Map.toAscList ∘ addresses
+
+--
+-- alternate definition and original definition coincide
+lemma-known-known'
+  : ∀ (s : AddressState)
+      (addr : Address)
+  → knownCustomerAddress addr s
+    ≡ knownCustomerAddress' addr s
+--
+lemma-known-known' s a =
+  begin
+    (elem a ∘ map snd ∘ listCustomers) s
+  ≡⟨⟩
+    (elem a ∘ map snd ∘ map swap ∘ Map.toAscList ∘ addresses) s
+  ≡⟨ cong (elem a) (sym (map-∘ snd swap (Map.toAscList (addresses s)))) ⟩
+    (elem a ∘ map (snd ∘ swap) ∘ Map.toAscList ∘ addresses) s
+  ≡⟨⟩
+    (elem a ∘ map fst ∘ Map.toAscList ∘ addresses) s
+  ∎
+
+--
+@0 lemma-isCustomerAddress-knownCustomerAddress'
+  : ∀ (s : AddressState)
+      (addr : Address)
+  → isCustomerAddress s addr
+    ≡ knownCustomerAddress' addr s
+--
+lemma-isCustomerAddress-knownCustomerAddress' s addr
+  = case Map.lookup addr (addresses s) of λ
+    { (Just x) {{eq}} →
+        begin
+          isCustomerAddress s addr
+        ≡⟨ cong isJust eq ⟩
+          True
+        ≡⟨ sym (Map.prop-lookup-toAscList-Just addr x (addresses s) eq) ⟩
+          knownCustomerAddress' addr s
+        ∎
+    ; Nothing {{eq}} →
+        begin
+          isCustomerAddress s addr
+        ≡⟨ cong isJust eq ⟩
+          False
+        ≡⟨ sym (Map.prop-lookup-toAscList-Nothing addr (addresses s) eq) ⟩
+          knownCustomerAddress' addr s
+        ∎
+    }
+
+--
+@0 lemma-isCustomerAddress-knownCustomerAddress
+  : ∀ (s : AddressState)
+      (addr : Address)
+  → isCustomerAddress s addr
+    ≡ knownCustomerAddress addr s
+--
+lemma-isCustomerAddress-knownCustomerAddress s addr =
+  begin
+    isCustomerAddress s addr
+  ≡⟨ lemma-isCustomerAddress-knownCustomerAddress' s addr ⟩
+    knownCustomerAddress' addr s
+  ≡⟨ sym (lemma-known-known' s addr ) ⟩
+    knownCustomerAddress addr s
+  ∎
+
+{-----------------------------------------------------------------------------
+    Operations
+    Create address
+------------------------------------------------------------------------------}
+
+-- Specification
+createAddress : Customer → AddressState → (Address × AddressState)
+createAddress c s0 = ( addr , s1 )
+  where
+    ix = suc c
+    addr = deriveAddress ix
+
+    addresses1 = Map.insert addr c (addresses s0)
+
+    lem1 : ¬ (ix ≡ 0)
+    lem1 = λ ()
+
+    @0 lem2
+      : ∀ (addr2 : Address)
+      → isJust (Map.lookup addr2 addresses1) ≡ True
+      → ∃ (λ ix → (addr2 ≡ deriveAddress ix) ⋀ ¬(ix ≡ 0))
+    lem2 addr2 isMember = case addr2 == addr of λ
+        { True {{eq}} → ix `witness` (equality addr2 addr eq `and` lem1)
+        ; False {{eq}} →
+            let lem3
+                  : Map.lookup addr2 addresses1
+                  ≡ Map.lookup addr2 (addresses s0)
+                lem3 =
+                  begin
+                    Map.lookup addr2 addresses1
+                  ≡⟨ Map.prop-lookup-insert _ _ c (addresses s0) ⟩
+                    (if (addr2 == addr) then Just c else Map.lookup addr2 (addresses s0))
+                  ≡⟨ cong (λ b → if b then Just c else Map.lookup addr2 (addresses s0)) eq ⟩
+                    (if False then Just c else Map.lookup addr2 (addresses s0))
+                  ≡⟨⟩
+                    Map.lookup addr2 (addresses s0)
+                  ∎
+
+                lem4 : isCustomerAddress s0 addr2 ≡ True
+                lem4 = trans (cong (isJust) (sym lem3)) isMember
+            in
+                invariant-customer s0 addr2 lem4
+        }
+
+    s1 : AddressState
+    s1 = record
+      { addresses = addresses1
+      ; change = change s0
+      ; invariant-change = invariant-change s0
+      ; invariant-customer = lem2
+      }
+
+{-----------------------------------------------------------------------------
+    Operations
+    Change address generation
+------------------------------------------------------------------------------}
+
+newChangeAddress : AddressState → ChangeAddressGen ⊤
+newChangeAddress s = λ _ → (change s , tt)
+
+--
+lemma-isChange-isChangeAddress
+  : ∀ (s : AddressState)
+      (addr : Address)
+  → isChange (newChangeAddress s) addr
+  → isChangeAddress s addr ≡ True
+--
+lemma-isChange-isChangeAddress s addr (_c0 `witness` eq) =
+  equality' _ _ eq
+
+--
+@0 prop-changeAddress-not-Customer
+  : ∀ (s : AddressState)
+      (addr : Address)
+  → knownCustomerAddress addr s ≡ True
+  → ¬(isChange (newChangeAddress s) addr)
+--
+prop-changeAddress-not-Customer s addr eq-known eq-change =
+    bang lem4
+  where
+    lem1 : isCustomerAddress s addr ≡ True
+    lem1 = trans (lemma-isCustomerAddress-knownCustomerAddress s addr) eq-known
+
+    lem2 : isChangeAddress s addr ≡ False
+    lem2 = lemma-isCustomer-not-isChange s addr lem1
+
+    lem3 : isChangeAddress s addr ≡ True
+    lem3 = lemma-isChange-isChangeAddress s addr eq-change
+
+    lem4 : False ≡ True
+    lem4 = trans (sym lem2) lem3
+
+    bang : False ≡ True → ⊥
+    bang ()
+ 

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
@@ -66,7 +66,7 @@ module
       → (elem key ∘ L.map fst ∘ toAscList) m ≡ True
 
     prop-lookup-toAscList-Nothing
-      : ∀ (key : k) (x : a) (m : Map k a)
+      : ∀ (key : k) (m : Map k a)
       → lookup key m ≡ Nothing
       → (elem key ∘ L.map fst ∘ toAscList) m ≡ False
 

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning.lagda.md
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning.lagda.md
@@ -81,18 +81,8 @@ open import Data.Product public using () renaming
   ( _×_ to _⋀_
   ; proj₁ to projl
   ; proj₂ to projr
-  ; _,′_ to _`and`_
+  ; _,_ to _`and`_
   )
-
-open import Data.Product public
-  using (∃; ∃-syntax)
-
-_`witness`_
-  : {A : Set} {B : A → Set}
-  → (x : A) → (y : B x) → ∃ B
-_`witness`_ = Data.Product._,_
-
-infixr 4 _`witness`_
 
 open import Haskell.Prim public using (⊥; magic)
 
@@ -100,6 +90,21 @@ infix 3 ¬_
 ¬_ : Set → Set
 ¬ A = A → ⊥
 ```
+
+Existential quantifications comes with a pattern synonym `witness`
+that can be used extract a witness of the property.
+
+```agda
+open import Data.Product public
+  using (∃; ∃-syntax)
+
+pattern _`witness`_ x y = Data.Product._,_ x y
+infixr 4 _`witness`_
+```
+
+    _`witness`_
+    : {A : Set} {B : A → Set}
+    → (x : A) → (y : B x) → ∃ B
 
 For example, here is the statement that the first case of a logical *or* must hold if the second case leads to a contradiction, and its proof:
 


### PR DESCRIPTION
This pull request adds a separate `AddressState` data type that

* keeps track of the mapping `Address → Customer` 
* keeps track of a single change address

Importantly, we prove that the change address is never used for any of the customer addresses (`prop-changeAddress-not-Customer`).