### PR TITLE
Implement `rollForwardOne `

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read.agda
@@ -174,3 +174,11 @@ data ChainPoint : Set where
   BlockPoint   : Slot → HashHeader → ChainPoint
 
 {-# COMPILE AGDA2HS ChainPoint #-}
+
+chainPointFromBlock : Block → ChainPoint
+chainPointFromBlock block =
+    BlockPoint (slot (blockHeaderBody bh)) (bhHash bh)
+  where
+    bh = blockHeader block
+
+{-# COMPILE AGDA2HS chainPointFromBlock #-}

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read.hs
@@ -50,8 +50,21 @@ type Sig = ()
 data BHeader = BHeader{blockHeaderBody :: BHBody,
                        blockHeaderSignature :: Sig}
 
+bhHash :: BHeader -> HashHeader
+bhHash _ = ()
+
 dummyBHeader :: BHeader
 dummyBHeader = BHeader dummyBHBody ()
 
 data Block = Block{blockHeader :: BHeader, transactions :: [Tx]}
+
+data ChainPoint = GenesisPoint
+                | BlockPoint Slot HashHeader
+
+chainPointFromBlock :: Block -> ChainPoint
+chainPointFromBlock block
+  = BlockPoint (slot (blockHeaderBody bh)) (bhHash bh)
+  where
+    bh :: BHeader
+    bh = blockHeader block
 


### PR DESCRIPTION
This pull requests implements the function `rollForwardOne` which rolls the `WalletState` forward by one `Block`. In addition, the `WalletState` now keeps track of a `localTip`.

Rollbacks will be implemented at a later time.