### PR TITLE
Add dependency on `cardano-wallet-read`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -30,6 +30,29 @@ index-state:
 packages:
     lib/customer-deposit-wallet-pure/
 
+--------------------------------------------------------------------------------
+-- Packages from cardano-wallet
+--------------------------------------------------------------------------------
+source-repository-package
+  type: git
+  location: https://github.com/cardano-foundation/cardano-wallet
+  tag: 2bd29c4f157409b3d660e04cbb12c0ef8c420938
+  subdir: lib/test-utils
+  --sha256: 0q61jv6m8bmnkayp96igjszyyc22a55drx9v2w6wcrpnkykjf61m
+
+source-repository-package
+  type: git
+  location: https://github.com/cardano-foundation/cardano-wallet
+  tag: 2bd29c4f157409b3d660e04cbb12c0ef8c420938
+  subdir: lib/text-class
+  --sha256: NRgnp5/2ZsYNFzv13EpRQjDvv5YvmnS9mrYuVM2WwWA=
+
+source-repository-package
+  type: git
+  location: https://github.com/cardano-foundation/cardano-wallet
+  tag: 2bd29c4f157409b3d660e04cbb12c0ef8c420938
+  subdir: lib/read
+  --sha256: NRgnp5/2ZsYNFzv13EpRQjDvv5YvmnS9mrYuVM2WwWA=
 
 --------------------------------------------------------------------------------
 -- BEGIN Constraints tweaking section

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -55,6 +55,7 @@ library
     , base >= 4.14.3.0 && < 4.20
     , bytestring >= 0.10.12.0 && < 0.13
     , cardano-crypto >= 1.1.2 && < 1.2
+    , cardano-wallet-read
     , containers >= 0.6.6 && < 0.8
     , deepseq >= 1.4.4 && < 1.6
     , text >= 1.2.4.1 && < 2.2


### PR DESCRIPTION
This pull request experiments with adding a dependency on `cardano-wallet-read`.

### Comments

* We need to use a `source-repository-package` in order to access `cardano-wallet`. This is the drawback of not being in the same repo. However, the upshot of being in a different repo is that `cardano-wallet` doesn't need to pull in the agda dependencies (which take some time to compile for the nix store).