### PR TITLE
Move `ValueTransfer` and `TxSummary` to separate modules

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -2,4 +2,5 @@ module Cardano.Wallet.Deposit.Everything where
 
 import Cardano.Wallet.Deposit.Pure
 import Cardano.Wallet.Deposit.Pure.Timeline
+import Cardano.Wallet.Deposit.Pure.TxSummary
 import Cardano.Wallet.Deposit.Pure.ValueTransfer

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -2,3 +2,4 @@ module Cardano.Wallet.Deposit.Everything where
 
 import Cardano.Wallet.Deposit.Pure
 import Cardano.Wallet.Deposit.Pure.Timeline
+import Cardano.Wallet.Deposit.Pure.ValueTransfer

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure.agda
@@ -36,6 +36,9 @@ import Cardano.Wallet.Deposit.Pure.Address
 import Cardano.Wallet.Deposit.Pure.UTxO
     ( UTxO
     )
+import Cardano.Wallet.Deposit.Pure.TxSummary
+    ( TxSummary
+    )
 import qualified Cardano.Wallet.Deposit.Pure.Address as Addr
 import qualified Cardano.Wallet.Deposit.Pure.Balance as Balance
 import qualified Cardano.Wallet.Deposit.Pure.UTxO as UTxO
@@ -53,6 +56,10 @@ open import Cardano.Wallet.Deposit.Pure.ValueTransfer using
     ( ValueTransfer
       ; fromSpent
       ; fromReceived
+    )
+open import Cardano.Wallet.Deposit.Pure.TxSummary using
+    ( TxSummary
+      ; mkTxSummary
     )
 open import Cardano.Wallet.Deposit.Read using
     ( Address
@@ -90,15 +97,6 @@ import Haskell.Data.Map as Map
 
 -- The import of the cong! tactic slows down type checking…
 open import Tactic.Cong using (cong!)
-
-{-----------------------------------------------------------------------------
-    Assumptions
-------------------------------------------------------------------------------}
-
-TxSummary : Set
-TxSummary = Slot × TxId × ValueTransfer
-
-{-# COMPILE AGDA2HS TxSummary #-}
 
 {-----------------------------------------------------------------------------
     Type definition
@@ -238,10 +236,6 @@ summarizeTx s tx =
   where
     ins  = Map.map fromSpent $ summarizeInputs s tx
     outs = Map.map fromReceived $ summarizeOutputs s tx
-
-mkTxSummary : Tx → ValueTransfer → TxSummary
-mkTxSummary = λ tx transfer → (0 , Tx.txid tx , transfer)
-
 
 getAddressSummary
   : Address → List (Address × TxSummary) → List TxSummary

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxSummary.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxSummary.agda
@@ -1,0 +1,37 @@
+module Cardano.Wallet.Deposit.Pure.TxSummary where
+
+open import Haskell.Prelude
+
+open import Cardano.Wallet.Deposit.Pure.ValueTransfer using
+    ( ValueTransfer
+    )
+open import Cardano.Wallet.Deposit.Read using
+    ( Tx
+    ; TxId
+    ; ChainPoint
+    )
+
+import Cardano.Wallet.Deposit.Read as Read
+
+{-----------------------------------------------------------------------------
+    TxSummary
+------------------------------------------------------------------------------}
+
+record TxSummary : Set where
+  field
+    summarizedTx : TxId
+    point : ChainPoint
+    transfer : ValueTransfer
+
+open TxSummary public
+
+-- This is a mock summary for now
+mkTxSummary : Tx → ValueTransfer → TxSummary
+mkTxSummary = λ tx transfer' → record
+    { summarizedTx = Tx.txid tx
+    ; point = ChainPoint.GenesisPoint
+    ; transfer = transfer'
+    }
+
+{-# COMPILE AGDA2HS TxSummary #-}
+{-# COMPILE AGDA2HS mkTxSummary #-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/ValueTransfer.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/ValueTransfer.agda
@@ -1,0 +1,46 @@
+module Cardano.Wallet.Deposit.Pure.ValueTransfer where
+
+open import Haskell.Prelude
+
+open import Cardano.Wallet.Deposit.Read using
+    ( Value
+    )
+
+import Cardano.Wallet.Deposit.Read as Read
+
+{-----------------------------------------------------------------------------
+    ValueTransfer
+------------------------------------------------------------------------------}
+
+record ValueTransfer : Set where
+  field
+    spent    : Value
+    received : Value
+
+open ValueTransfer public
+
+fromSpent : Value → ValueTransfer
+fromSpent = λ value → record { spent = value ; received = mempty }
+
+fromReceived : Value → ValueTransfer
+fromReceived = λ value → record { spent = mempty ; received = value }
+
+instance
+  iSemigroupValueTansfer : Semigroup ValueTransfer
+  _<>_ {{iSemigroupValueTansfer}} =
+    λ v1 v2 → record
+        { spent = spent v1 <> spent v2
+        ; received = received v1 <> received v2
+        }
+
+  iMonoidValueTransfer : Monoid ValueTransfer
+  iMonoidValueTransfer =
+    record { DefaultMonoid
+        (λ where .DefaultMonoid.mempty → record { spent = mempty ; received = mempty })
+    }
+
+{-# COMPILE AGDA2HS ValueTransfer #-}
+{-# COMPILE AGDA2HS fromSpent #-}
+{-# COMPILE AGDA2HS fromReceived #-}
+{-# COMPILE AGDA2HS iSemigroupValueTansfer #-}
+{-# COMPILE AGDA2HS iMonoidValueTransfer #-}

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -64,6 +64,7 @@ library
     Cardano.Wallet.Deposit.Pure.DeltaUTxO
     Cardano.Wallet.Deposit.Pure.UTxO
     Cardano.Wallet.Deposit.Pure.Timeline
+    Cardano.Wallet.Deposit.Pure.ValueTransfer
     Cardano.Wallet.Deposit.Read
     Cardano.Write.Tx.Balance
   other-modules:

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -64,6 +64,7 @@ library
     Cardano.Wallet.Deposit.Pure.DeltaUTxO
     Cardano.Wallet.Deposit.Pure.UTxO
     Cardano.Wallet.Deposit.Pure.Timeline
+    Cardano.Wallet.Deposit.Pure.TxSummary
     Cardano.Wallet.Deposit.Pure.ValueTransfer
     Cardano.Wallet.Deposit.Read
     Cardano.Write.Tx.Balance

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure.hs
@@ -1,6 +1,6 @@
 module Cardano.Wallet.Deposit.Pure where
 
-import Cardano.Wallet.Deposit.Read (Address, Block(transactions), ChainPoint, Slot, Tx, TxBody, TxId, TxOut(TxOutC), Value, chainPointFromBlock)
+import Cardano.Wallet.Deposit.Read (Address, Block(transactions), ChainPoint, Tx, TxBody, TxOut(TxOutC), Value, chainPointFromBlock)
 import Cardano.Write.Tx.Balance (ChangeAddressGen, PartialTx(PartialTxC), balanceTransaction)
 import qualified Haskell.Data.Map as Map (Map, lookup)
 
@@ -12,14 +12,12 @@ import Cardano.Wallet.Deposit.Pure.Address
 import Cardano.Wallet.Deposit.Pure.UTxO
     ( UTxO
     )
+import Cardano.Wallet.Deposit.Pure.TxSummary
+    ( TxSummary
+    )
 import qualified Cardano.Wallet.Deposit.Pure.Address as Addr
 import qualified Cardano.Wallet.Deposit.Pure.Balance as Balance
 import qualified Cardano.Wallet.Deposit.Pure.UTxO as UTxO
-
-data ValueTransfer = ValueTransfer{spent :: Value,
-                                   received :: Value}
-
-type TxSummary = (Slot, TxId, ValueTransfer)
 
 data WalletState = WalletState{addresses :: AddressState,
                                utxo :: UTxO, txSummaries :: Map.Map Customer [TxSummary],

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
@@ -1,0 +1,12 @@
+module Cardano.Wallet.Deposit.Pure.TxSummary where
+
+import Cardano.Wallet.Deposit.Pure.ValueTransfer (ValueTransfer)
+import Cardano.Wallet.Deposit.Read (ChainPoint(GenesisPoint), Tx(txid), TxId)
+
+data TxSummary = TxSummary{summarizedTx :: TxId,
+                           point :: ChainPoint, transfer :: ValueTransfer}
+
+mkTxSummary :: Tx -> ValueTransfer -> TxSummary
+mkTxSummary
+  = \ tx transfer' -> TxSummary (txid tx) GenesisPoint transfer'
+

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/ValueTransfer.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/ValueTransfer.hs
@@ -1,0 +1,21 @@
+module Cardano.Wallet.Deposit.Pure.ValueTransfer where
+
+import Cardano.Wallet.Deposit.Read (Value)
+
+data ValueTransfer = ValueTransfer{spent :: Value,
+                                   received :: Value}
+
+fromSpent :: Value -> ValueTransfer
+fromSpent = \ value -> ValueTransfer value mempty
+
+fromReceived :: Value -> ValueTransfer
+fromReceived = \ value -> ValueTransfer mempty value
+
+instance Semigroup ValueTransfer where
+    (<>)
+      = \ v1 v2 ->
+          ValueTransfer (spent v1 <> spent v2) (received v1 <> received v2)
+
+instance Monoid ValueTransfer where
+    mempty = ValueTransfer mempty mempty
+


### PR DESCRIPTION
This pull request moves the types `ValueTransfer` and `TxSummary` to separate modules in order to export them.