### PR TITLE
Constrain version numbers for dependencies

### DIFF
--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -51,12 +51,11 @@ library
   hs-source-dirs:
     haskell
   build-depends:
-    , base >=4.14.3.0
-    , bytestring
-    , containers
-    , deepseq >= 1.4.4
-    , text
-    , time
+    , base >= 4.14.3.0 && < 4.20
+    , bytestring >= 0.10.12.0 && < 0.13
+    , containers >= 0.6.6 && < 0.8
+    , deepseq >= 1.4.4 && < 1.6
+    , text >= 1.2.4.1 && < 2.2
   exposed-modules:
     Cardano.Wallet.Deposit.Pure
     Cardano.Wallet.Deposit.Pure.Address


### PR DESCRIPTION
This pull request constrains version numbers for the dependencies of the `customer-deposit-wallet-pure.cabal` package.