### PR TITLE
Add `CHaP` input to nix flake

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,10 +1,103 @@
+--------------------------------------------------------------------------------
+-- cardano-haskell-packages repository
+--------------------------------------------------------------------------------
+
+-- Custom repository for cardano haskell packages, see
+-- https://github.com/intersectmbo/cardano-haskell-packages
+-- for more information.
+repository cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
 -- repeating the index-state for hackage to work around hackage.nix parsing limitation
+index-state: 2024-03-19T15:29:53Z
 
 index-state:
-  , hackage.haskell.org 2023-12-18T14:05:14Z
+  , hackage.haskell.org 2024-03-19T15:29:53Z
+  , cardano-haskell-packages 2024-03-15T17:07:52Z
+
+--------------------------------------------------------------------------------
+-- Projects in the present repository
+--------------------------------------------------------------------------------
 
 packages:
     lib/customer-deposit-wallet-pure/
+
+
+--------------------------------------------------------------------------------
+-- BEGIN Constraints tweaking section
+
+-- cardano-addresses unit tests bring in some version constraint conflicts.
+--
+-- 1. hjsonschema and hjsonpointer deps have overly strict bounds.
+-- 2. it has strict aeson < 1.5 dep - this will be fixed in the next release.
+allow-newer:
+    hjsonschema:*
+  , hjsonpointer:*
+  , *:aeson
+  , *:hashable
+  , async-timer:unliftio-core
+  , ekg:*
+  , ntp-client:*
+  , libsystemd-journal:base
+  , cardano-addresses-cli:mtl
+  , servant-openapi3:*
+
+constraints:
+    base == 4.18.2.0
+  , Cabal == 3.10.1.0
+  , bimap >= 0.4.0
+  , libsystemd-journal >= 1.4.4
+  , systemd >= 2.3.0
+  -- dependency of systemd-2.3.0
+  , network >= 3.1.1.1
+  -- choose versions that work with base >= 4.12
+  , hjsonpointer >= 1.5.0
+  , hjsonschema >= 1.10.0
+  , async-timer >= 0.2.0.0
+  , generic-arbitrary >= 0.2.2
+  , iohk-monitoring >= 0.1.11
+
+  -- lower versions of katip won't build with the Win32-2.12.0.1
+  -- which is shipped with the ghc-9.2.8
+  , katip >= 0.8.7.4
+
+  -- Cave: This version of `bech32`
+  -- does not work with optparse-applicative >= 0.18.1.0
+  , bech32 == 1.1.3
+
+  -- Cardano Node dependencies:
+  , cardano-node == 8.9.2
+  , cardano-api ^>=8.39.2.0
+  , cardano-crypto-class >=2.1.4.0
+  , cardano-crypto-class +secp256k1-support
+  , cardano-slotting ^>= 0.1.2
+  , optparse-applicative-fork >= 0.18.1
+  , ouroboros-network ^>= 0.12
+  , plutus-core ==1.21.0.0
+  , plutus-core -with-cert -with-inline-r
+  , plutus-ledger-api ==1.21.0.0
+
+  -- TH Name shadowing warnings need to be addressed when bumping to 2.13.3.5
+  , persistent ^>= 2.14.6.0
+
+  -- warp-tls specifies incorrect upper bound on tls
+  , any.warp-tls ==3.3.6
+  , any.tls ==1.6.0
+
+-- END Constraints tweaking section
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+-- Default settings for all packages
+--------------------------------------------------------------------------------
 
 tests:
   True

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712590917,
+        "narHash": "sha256-DgXSWHF5b/UtM+ACBWLPNtMNTSGQrmtl/ME7e7dheLo=",
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "251738d00d5799850c6eb610c4ab7b175b66224a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intersectmbo",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -268,33 +285,33 @@
         "type": "github"
       }
     },
-    "ghc98X": {
+    "ghc910X": {
       "flake": false,
       "locked": {
-        "lastModified": 1696643148,
-        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
-        "ref": "ghc-9.8",
-        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
-        "revCount": 61642,
+        "lastModified": 1711543129,
+        "narHash": "sha256-MUI07CxYOng7ZwHnMCw0ugY3HmWo2p/f4r07CGV7OAM=",
+        "ref": "ghc-9.10",
+        "rev": "6ecd5f2ff97af53c7334f2d8581651203a2c6b7d",
+        "revCount": 62607,
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
       },
       "original": {
-        "ref": "ghc-9.8",
+        "ref": "ghc-9.10",
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
       }
     },
-    "ghc99": {
+    "ghc911": {
       "flake": false,
       "locked": {
-        "lastModified": 1701580282,
-        "narHash": "sha256-drA01r3JrXnkKyzI+owMZGxX0JameMzjK0W5jJE/+V4=",
+        "lastModified": 1711538967,
+        "narHash": "sha256-KSdOJ8seP3g30FaC2du8QjU9vumMnmzPR5wfkVRXQMk=",
         "ref": "refs/heads/master",
-        "rev": "f5eb0f2982e9cf27515e892c4bdf634bcfb28459",
-        "revCount": 62197,
+        "rev": "0acfe391583d77a72051d505f05fab0ada056c49",
+        "revCount": 62632,
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
@@ -308,11 +325,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1702859030,
-        "narHash": "sha256-W5IMCeXNvFV8YUIuYh+VTE5zRhCIdodg8inKUwwQGjg=",
+        "lastModified": 1713745521,
+        "narHash": "sha256-Y3TXjRw3cq0V0NwSnwvGWycLgZyhlwQooZ6KIKTO59I=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "998fd3cc7447726ad57b28b7270c2b4b51b7af18",
+        "rev": "8f0dc3e6f57a855f805707ad4560719cf0acd273",
         "type": "github"
       },
       "original": {
@@ -330,14 +347,17 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc98X": "ghc98X",
-        "ghc99": "ghc99",
+        "ghc910X": "ghc910X",
+        "ghc911": "ghc911",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -357,11 +377,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1702860573,
-        "narHash": "sha256-rwZElE6j+6pYKAI3m5/H3neeaw2v7TMpbgmUULhYEic=",
+        "lastModified": 1713747022,
+        "narHash": "sha256-oe9/SeiLxi7/A5M7wGVa9yRm/CXifVeA/2o8Lthptic=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a205d3dcdab9a0ee3c0b9d5119cf9e41b970dbe5",
+        "rev": "0a83cdb610912c83e4c2678235afd2a5700c5cf0",
         "type": "github"
       },
       "original": {
@@ -441,16 +461,67 @@
     "hls-2.4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696939266,
-        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.4.0.0",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -520,18 +591,18 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1691634696,
-        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
-        "ref": "hkm/remote-iserv",
-        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
-        "revCount": 14,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "lastModified": 1708894040,
+        "narHash": "sha256-Rv+PajrnuJ6AeyhtqzMN+bcR8z9+aEnrUass+N951CQ=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2f2a318fd8837f8063a0d91f329aeae29055fba9",
+        "type": "github"
       },
       "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
       }
     },
     "lowdown-src": {
@@ -716,17 +787,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1701336116,
-        "narHash": "sha256-kEmpezCR/FpITc6yMbAh4WrOCiT2zg5pSjnKrq51h5Y=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5c27c6136db4d76c30e533c20517df6864c46ee",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -765,6 +836,7 @@
     },
     "root": {
       "inputs": {
+        "CHaP": "CHaP",
         "agda-tools": "agda-tools",
         "flake-utils": "flake-utils_3",
         "haskellNix": "haskellNix",
@@ -812,11 +884,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1702858193,
-        "narHash": "sha256-tn526nIVerkS0t73QoC9rWyjd6gpQVOhk700P5+cQjo=",
+        "lastModified": 1713744690,
+        "narHash": "sha256-D6OeMgFlwynlGND7AB+NRrbXlMYqCDJghpP/3XBjnnI=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "a577402c8ae1f81507a4dcab60ca3fb3eb810726",
+        "rev": "bc4e7b2ffe62c54dc91d983844acb21b565ac97e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,9 @@
     iohkNix.url = "github:input-output-hk/iohk-nix";
     iohkNix.inputs.nixpkgs.follows = "nixpkgs";
 
+    CHaP.url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
+    CHaP.flake = false;
+
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
 
     agda-tools.url = "github:HeinrichApfelmus/agda-notes?dir=nix/agda-hs-tools";
@@ -37,20 +40,24 @@
           inherit (inputs.haskellNix) config;
         };
 
+        indexState = "2024-03-15T17:07:52Z";
+
         # ... and construct a flake from the cabal.project file.
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
         flake = (nixpkgs.haskell-nix.cabalProject' rec {
           src = ./.;
           name = "customer-deposit-wallet-pure";
-          compiler-nix-name = "ghc963";
+          compiler-nix-name = "ghc964";
+
+          inputMap = { "https://chap.intersectmbo.org/" = inputs.CHaP; };
 
           # tools we want in our shell
           shell.tools = {
-            cabal = "3.10.2.0";
-            ghcid = "0.8.9";
-            haskell-language-server = "latest";
-            hlint = "3.6.1";
+            cabal = {
+              version = "3.10.2.1";
+              index-state = indexState;
+            };
             fourmolu = "0.14.1.0";
           };
           shell.withHoogle = true;
@@ -58,6 +65,8 @@
           shell.buildInputs = [
             nixpkgs.just
             nixpkgs.gitAndTools.git
+            nixpkgs.haskellPackages.ghcid
+            nixpkgs.haskellPackages.hlint
 
             inputs.agda-tools.packages.${system}.agda
             inputs.agda-tools.packages.${system}.agda2hs


### PR DESCRIPTION
This pull request makes available the Cardano Haskell Packages via a nix input.