### PR TITLE
Add `BIP32_Ed25519` modules

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
@@ -1,0 +1,135 @@
+{-# OPTIONS --erasure #-}
+
+module Cardano.Wallet.Address.BIP32_Ed25519 where
+
+open import Haskell.Prelude
+
+open import Haskell.Data.ByteString using
+  ( ByteString
+  )
+open import Haskell.Data.Word.Odd using
+  ( Word31
+  )
+
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE UnicodeSyntax #-}
+import Cardano.Crypto.Wallet
+  ( XPrv
+  , XPub
+  , XSignature
+  , toXPub
+  )
+import Data.ByteString
+  ( ByteString
+  )
+import Data.Maybe
+  ( fromJust
+  )
+import Data.Word
+  ( Word32
+  )
+import Data.Word.Odd
+  ( Word31
+  )
+import qualified Cardano.Crypto.Wallet as CC
+import qualified Data.ByteString as BS
+#-}
+
+dummy : Int
+dummy = 12 -- needed for Agda2hs to add sufficient imports
+
+{-----------------------------------------------------------------------------
+    Extended private and public keys
+------------------------------------------------------------------------------}
+
+-- TODO: Extend to encrypted keys
+postulate
+  XPub : Set  -- plaintext public key
+  XPrv : Set  -- plaintext private key
+
+  toXPub : XPrv → XPub
+
+  XSignature : Set
+  sign   : XPrv → ByteString → XSignature
+  verify : XPub → ByteString → XSignature → Bool
+
+  prop-verify-sign
+    : ∀ (xprv : XPrv)
+        (msg  : ByteString)
+    → let xpub = toXPub xprv
+      in  verify xpub msg (sign xprv msg) ≡ True
+
+{-# FOREIGN AGDA2HS
+sign :: XPrv → ByteString → XSignature
+sign = CC.sign BS.empty
+
+verify :: XPub → ByteString → XSignature → Bool
+verify = CC.verify
+#-}
+
+{-----------------------------------------------------------------------------
+    Key derivation
+------------------------------------------------------------------------------}
+
+postulate
+  deriveXPubSoft : XPub → Word31 → XPub
+  deriveXPrvSoft : XPrv → Word31 → XPrv
+  deriveXPrvHard : XPrv → Word31 → XPrv
+
+  prop-derive-soft
+    : ∀ (xprv : XPrv)
+        (ix   : Word31)
+    → deriveXPubSoft (toXPub xprv) ix
+      ≡ toXPub (deriveXPrvSoft xprv ix)
+
+  -- The following properties about injectivity
+  -- are not true in the strict sense,
+  -- only cryptographically hard.
+  prop-deriveXPubSoft-injective
+    : ∀ (xpub    : XPub)
+        (ix1 ix2 : Word31)
+    → deriveXPubSoft xpub ix1 ≡ deriveXPubSoft xpub ix2
+    → ix1 ≡ ix2
+
+  prop-deriveXPrvSoft-injective
+    : ∀ (xprv    : XPrv)
+        (ix1 ix2 : Word31)
+    → deriveXPrvSoft xprv ix1 ≡ deriveXPrvSoft xprv ix2
+    → ix1 ≡ ix2
+
+  prop-deriveXPrvHard-injective
+    : ∀ (xprv    : XPrv)
+        (ix1 ix2 : Word31)
+    → deriveXPrvHard xprv ix1 ≡ deriveXPrvHard xprv ix2
+    → ix1 ≡ ix2
+
+{-# FOREIGN AGDA2HS
+word32fromWord31 :: Word31 → Word32
+word32fromWord31 = fromInteger . toInteger
+
+deriveXPubSoft :: XPub → Word31 → XPub
+deriveXPubSoft xpub ix =
+  fromJust 
+    (CC.deriveXPub
+      CC.DerivationScheme2
+      xpub
+      (word32fromWord31 ix)
+    )
+  -- deriveXPub always returns Just on Word31
+
+deriveXPrvSoft :: XPrv → Word31 → XPrv
+deriveXPrvSoft xprv ix = 
+  CC.deriveXPrv
+    CC.DerivationScheme2
+    BS.empty
+    xprv
+    (word32fromWord31 ix)
+
+deriveXPrvHard :: XPrv → Word31 → XPrv
+deriveXPrvHard xprv ix =
+  CC.deriveXPrv
+    CC.DerivationScheme2
+    BS.empty
+    xprv
+    (0x80000000 + word32fromWord31 ix)
+#-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -8,3 +8,5 @@ import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO
 import Cardano.Wallet.Deposit.Pure.UTxO.Tx
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
+
+import Haskell.Data.Word.Odd

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -1,5 +1,7 @@
 module Cardano.Wallet.Deposit.Everything where
 
+import Cardano.Wallet.Address.BIP32_Ed25519
+
 import Cardano.Wallet.Deposit.Pure
 import Cardano.Wallet.Deposit.Pure.Timeline
 import Cardano.Wallet.Deposit.Pure.TxSummary

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Word.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Word.agda
@@ -46,7 +46,7 @@ instance
   iBoundedBelowWord8 .minBound = 0
 
   iBoundedAboveWord8 : BoundedAbove Word8
-  iBoundedAboveWord8 .maxBound = Word8C (256 - 1)
+  iBoundedAboveWord8 .maxBound = Word8C (primWord64FromNat (2⁸ - 1))
 
   iEnumWord8 : Enum Word8
   iEnumWord8 = boundedEnumViaInteger integerFromWord8 word8FromInteger

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Word/Odd.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Word/Odd.agda
@@ -1,0 +1,52 @@
+{-# OPTIONS --erasure #-}
+
+module Haskell.Data.Word.Odd
+    {-
+    ; Word31
+    -}
+    where
+
+open import Haskell.Prelude
+open import Haskell.Prim
+open import Haskell.Prim.Integer
+
+open import Agda.Builtin.Word public using (Word64; primWord64FromNat)
+
+{-----------------------------------------------------------------------------
+    Word31
+------------------------------------------------------------------------------}
+2³¹ : Nat
+2³¹ = 256 * 256 * 256 * 128
+
+data Word31 : Set where
+    Word31C : Word64 → Word31
+
+instance
+  iNumberWord31 : Number Word31
+  iNumberWord31 .Number.Constraint n = IsTrue (ltNat n 2³¹)
+  iNumberWord31 .fromNat n = Word31C (n2w n)
+
+word31FromNat : Nat → Word31
+word31FromNat n = Word31C (primWord64FromNat n)
+
+word31FromInteger : Integer → Word31
+word31FromInteger n = Word31C (integerToWord n)
+
+integerFromWord31 : Word31 → Integer
+integerFromWord31 (Word31C n) = wordToInteger n
+
+instance
+  iEqWord31 : Eq Word31
+  iEqWord31 ._==_ (Word31C x) (Word31C y) = eqWord x y
+
+  iOrdWord31 : Ord Word31
+  iOrdWord31 = ordFromLessThan (λ {(Word31C x) (Word31C y) → ltWord x y})
+
+  iBoundedBelowWord31 : BoundedBelow Word31
+  iBoundedBelowWord31 .minBound = 0
+
+  iBoundedAboveWord31 : BoundedAbove Word31
+  iBoundedAboveWord31 .maxBound = Word31C (primWord64FromNat (2³¹ - 1))
+
+  iEnumWord31 : Enum Word31
+  iEnumWord31 = boundedEnumViaInteger integerFromWord31 word31FromInteger

--- a/lib/customer-deposit-wallet-pure/agda2hs-rewrites.yaml
+++ b/lib/customer-deposit-wallet-pure/agda2hs-rewrites.yaml
@@ -10,3 +10,6 @@ rewrites:
   - from: "Haskell.Data.Word.Word8"
     to: "Word8"
     importing: "Data.Word"
+  - from: "Haskell.Data.Word.Odd.Word31"
+    to: "Word31"
+    importing: "Data.Word.Odd"

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -33,6 +33,7 @@ common opts-lib
     -Wincomplete-record-updates
     -Wno-redundant-constraints
     -Wno-unused-matches
+    -Wno-unused-imports
 
   if flag(release)
     ghc-options: -O2 -Werror
@@ -53,11 +54,13 @@ library
   build-depends:
     , base >= 4.14.3.0 && < 4.20
     , bytestring >= 0.10.12.0 && < 0.13
+    , cardano-crypto >= 1.1.2 && < 1.2
     , containers >= 0.6.6 && < 0.8
     , deepseq >= 1.4.4 && < 1.6
     , text >= 1.2.4.1 && < 2.2
     , OddWord >= 1.0.1.1 && < 1.1
   exposed-modules:
+    Cardano.Wallet.Address.BIP32_Ed25519
     Cardano.Wallet.Deposit.Pure
     Cardano.Wallet.Deposit.Pure.Address
     Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -56,6 +56,7 @@ library
     , containers >= 0.6.6 && < 0.8
     , deepseq >= 1.4.4 && < 1.6
     , text >= 1.2.4.1 && < 2.2
+    , OddWord >= 1.0.1.1 && < 1.1
   exposed-modules:
     Cardano.Wallet.Deposit.Pure
     Cardano.Wallet.Deposit.Pure.Address
@@ -72,4 +73,6 @@ library
     Haskell.Data.Map
     Haskell.Data.Maybe
     Haskell.Data.Set
+    Haskell.Data.Word
+    Haskell.Data.Word.Odd
     Haskell.Crypto.Hash

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+module Cardano.Wallet.Address.BIP32_Ed25519 where
+
+
+import Cardano.Crypto.Wallet
+  ( XPrv
+  , XPub
+  , XSignature
+  , toXPub
+  )
+import Data.ByteString
+  ( ByteString
+  )
+import Data.Maybe
+  ( fromJust
+  )
+import Data.Word.Odd
+  ( Word31
+  )
+import qualified Cardano.Crypto.Wallet as CC
+import qualified Data.ByteString as BS
+
+sign :: XPrv ->ByteString ->XSignature
+sign = CC.sign mempty
+
+verify :: XPub ->ByteString ->XSignature ->Bool
+verify = CC.verify
+
+word32fromWord31 :: Word31 ->Word32
+word32fromWord31 = fromInteger . toInteger
+
+deriveXPubSoft :: XPub ->Word31 ->XPub
+deriveXPubSoft xpub ix =
+  fromJust
+    (CC.deriveXPub
+      CC.DerivationScheme2
+      xpub
+      (word32fromWord31 ix)
+    )
+  -- deriveXPub always returns Just on Word31
+
+deriveXPrvSoft :: XPrv ->Word31 ->XPrv
+deriveXPrvSoft xprv ix =
+  CC.deriveXPrv
+    CC.DerivationScheme2
+    mempty
+    xprv
+    (word32fromWord31 ix)
+
+deriveXPrvHard :: XPrv ->Word31 ->XPrv
+deriveXPrvHard xprv ix =
+  CC.deriveXPrv
+    CC.DerivationScheme2
+    mempty
+    xprv
+    (0x80000000 + word32fromWord31 ix)
+

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Word/Odd.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Word/Odd.hs
@@ -1,0 +1,5 @@
+module Haskell.Data.Word.Odd
+    ( module Data.Word.Odd
+    ) where
+
+import Data.Word.Odd


### PR DESCRIPTION
This pull request adds a module `Cardano.Wallet.Address.BIP32_Ed25519` which imports / `postulate`s address derivation functionality from `cardano-crypto`.