### PR TITLE
Add Blake2b_224 and Blake2b_256

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/Hash.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/Hash.agda
@@ -1,0 +1,89 @@
+{-# OPTIONS --erasure #-}
+
+-- | Specific hash algorithms.
+module Cardano.Wallet.Address.Hash
+    {-
+    ; blake2b'224
+    ; blake2b'256
+    -}
+    where
+
+open import Haskell.Prelude
+
+open import Haskell.Data.ByteString using
+    ( ByteString
+    )
+
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE UnicodeSyntax #-}
+import Cardano.Crypto.Hash
+  ( Blake2b_224
+  , Blake2b_256
+  , HashAlgorithm (digest)
+  )
+import Data.ByteString
+  ( ByteString
+  )
+import Data.Proxy
+  ( Proxy (..)
+  )
+#-}
+
+{- Note [HashInjective]
+
+Cryptographic hash functions are injective !?
+
+The following postulate is the most important postulate about
+cryptographic Hash functions — we postulate that they are *injective*,
+i.e. that the hash values of two distinct inputs do not collide.
+
+Of course, any practical hash function that maps arbitrary ByteStrings to
+a finite codomain cannot be injective — there are not enough elements
+in the codomain to distinguish the infinite number of possible elements
+of the domain.
+So, this postulate is actually *inconsistent* when applied to actual
+hash functions.
+
+However!
+We take care to allow an infinite codomain for the hash
+function. Thus, there exists at least one "hash" function which
+is injective — the "trivial hash" that maps the input to a complete
+encoding of itself, discarding no information.
+Hence, the postulate is independent of Agda
+— it is true for some hash functions, but not for others.
+
+As long as we hide the implementation details of the specific
+Hash algorithm, we can pretend that we work in a model
+where the postulate is true.
+
+TODO: Find an even better to do this postulate in Agda.
+This postulate is generally assumed about cryptographic Hash functions,
+but I would like to pinpoint the fact that it's not possible
+to derive a contradiction in Agda.
+-}
+
+{-----------------------------------------------------------------------------
+    Blake2b
+------------------------------------------------------------------------------}
+
+postulate
+  blake2b'224 : ByteString → ByteString
+  blake2b'256 : ByteString → ByteString
+
+  prop-blake2b'224-injective
+    : ∀ (x y : ByteString)
+    → blake2b'224 x ≡ blake2b'224 y
+    → x ≡ y
+
+  prop-blake2b'256-injective
+    : ∀ (x y : ByteString)
+    → blake2b'256 x ≡ blake2b'256 y
+    → x ≡ y
+
+{-# FOREIGN AGDA2HS
+blake2b'224 :: ByteString → ByteString
+blake2b'224 = digest (Proxy :: Proxy Blake2b_224)
+
+blake2b'256 :: ByteString → ByteString
+blake2b'256 = digest (Proxy :: Proxy Blake2b_256)
+#-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -1,6 +1,7 @@
 module Cardano.Wallet.Deposit.Everything where
 
 import Cardano.Wallet.Address.BIP32_Ed25519
+import Cardano.Wallet.Address.Hash
 
 import Cardano.Wallet.Deposit.Pure
 import Cardano.Wallet.Deposit.Pure.Timeline

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -23,6 +23,10 @@ module Cardano.Wallet.Deposit.Pure.Address
 open import Haskell.Prelude
 open import Haskell.Reasoning
 
+open import Cardano.Wallet.Address.Hash using
+    ( blake2b'256
+    ; prop-blake2b'256-injective
+    )
 open import Cardano.Wallet.Deposit.Read using
     ( Address
     )
@@ -30,15 +34,6 @@ open import Cardano.Write.Tx.Balance using
     ( ChangeAddressGen
     ; isChange
     )
-open import Haskell.Crypto.Hash using
-    ( Digest
-      ; encodeDigest
-      ; prop-encodeDigest-injective
-    ; HashAlgorithm
-    ; TrivialHash
-      ; iTrivialHashAlgorithm
-    )
-open HashAlgorithm
 open import Haskell.Data.List.Prop using
     ( _∈_ )
 open import Haskell.Data.Maybe using
@@ -65,10 +60,7 @@ Customer = Word8
 {-# COMPILE AGDA2HS Customer #-}
 
 hashFromList : List Word8 → BS.ByteString
-hashFromList xs = encodeDigest digest
-  where
-    digest : Digest TrivialHash
-    digest = hash iTrivialHashAlgorithm (BS.pack xs)
+hashFromList = blake2b'256 ∘ BS.pack
 
 {-# COMPILE AGDA2HS hashFromList #-}
 
@@ -114,8 +106,7 @@ lemma-listFromDerivationPath-injective {DerivationChange} {DerivationChange} ref
 lemma-derive-injective =
   lemma-listFromDerivationPath-injective
   ∘ BS.prop-pack-injective _ _
-  ∘ prop-hash-injective iTrivialHashAlgorithm _ _
-  ∘ prop-encodeDigest-injective _ _
+  ∘ prop-blake2b'256-injective _ _
 
 --
 @0 lemma-derive-notCustomer

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -55,12 +55,14 @@ library
     , base >= 4.14.3.0 && < 4.20
     , bytestring >= 0.10.12.0 && < 0.13
     , cardano-crypto >= 1.1.2 && < 1.2
+    , cardano-crypto-class >= 2.1.1.0 && < 2.2
     , containers >= 0.6.6 && < 0.8
     , deepseq >= 1.4.4 && < 1.6
     , text >= 1.2.4.1 && < 2.2
     , OddWord >= 1.0.1.1 && < 1.1
   exposed-modules:
     Cardano.Wallet.Address.BIP32_Ed25519
+    Cardano.Wallet.Address.Hash
     Cardano.Wallet.Deposit.Pure
     Cardano.Wallet.Deposit.Pure.Address
     Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Hash.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Hash.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+module Cardano.Wallet.Address.Hash where
+
+
+import Cardano.Crypto.Hash
+  ( Blake2b_224
+  , Blake2b_256
+  , HashAlgorithm (digest)
+  )
+import Data.ByteString
+  ( ByteString
+  )
+import Data.Proxy
+  ( Proxy (..)
+  )
+
+blake2b'224 :: ByteString ->ByteString
+blake2b'224 = digest (Proxy :: Proxy Blake2b_224)
+
+blake2b'256 :: ByteString ->ByteString
+blake2b'256 = digest (Proxy :: Proxy Blake2b_256)
+

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -1,9 +1,9 @@
 module Cardano.Wallet.Deposit.Pure.Address where
 
+import Cardano.Wallet.Address.Hash (blake2b'256)
 import Cardano.Wallet.Deposit.Read (Address)
 import Cardano.Write.Tx.Balance (ChangeAddressGen)
 import Data.Word (Word8)
-import Haskell.Crypto.Hash (Digest, HashAlgorithm(hash), TrivialHash, encodeDigest)
 import qualified Haskell.Data.ByteString as BS (ByteString, pack)
 import qualified Haskell.Data.Map as Map (Map, insert, lookup, toAscList)
 import Haskell.Data.Maybe (isJust)
@@ -11,10 +11,7 @@ import Haskell.Data.Maybe (isJust)
 type Customer = Word8
 
 hashFromList :: [Word8] -> BS.ByteString
-hashFromList xs = encodeDigest digest
-  where
-    digest :: Digest TrivialHash
-    digest = hash (BS.pack xs)
+hashFromList = blake2b'256 . BS.pack
 
 data DerivationPath = DerivationCustomer Customer
                     | DerivationChange


### PR DESCRIPTION
This pull request imports the `Blake2b_224` and `Blake2b_256` hash functionalities from the `cardano-crypto-class` package. 