### PR TITLE
Use BIP32_Ed25519 in `createAddress`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
@@ -81,6 +81,8 @@ postulate
   deriveXPrvSoft : XPrv → Word31 → XPrv
   deriveXPrvHard : XPrv → Word31 → XPrv
 
+postulate
+
   prop-derive-soft
     : ∀ (xprv : XPrv)
         (ix   : Word31)
@@ -91,10 +93,14 @@ postulate
   -- are not true in the strict sense,
   -- only cryptographically hard.
   prop-deriveXPubSoft-injective
-    : ∀ (xpub    : XPub)
-        (ix1 ix2 : Word31)
-    → deriveXPubSoft xpub ix1 ≡ deriveXPubSoft xpub ix2
-    → ix1 ≡ ix2
+    : ∀ (xpub1 xpub2 : XPub)
+        (ix1   ix2   : Word31)
+    → deriveXPubSoft xpub1 ix1 ≡ deriveXPubSoft xpub2 ix2
+    → (xpub1 ≡ xpub2 ⋀ ix1 ≡ ix2)
+
+  prop-deriveXPubSoft-not-identity
+    : ∀ (xpub : XPub) (ix : Word31)
+    → ¬ (deriveXPubSoft xpub ix ≡ xpub)
 
   prop-deriveXPrvSoft-injective
     : ∀ (xprv    : XPrv)

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
@@ -72,6 +72,27 @@ verify :: XPub → ByteString → XSignature → Bool
 verify = CC.verify
 #-}
 
+postulate
+  rawSerialiseXPub : XPub → ByteString
+  rawSerialiseXPrv : XPrv → ByteString
+  rawSerialiseXSignature : XSignature → ByteString
+
+  prop-rawSerialiseXPub-injective
+    : ∀ (x y : XPub)
+    → rawSerialiseXPub x ≡ rawSerialiseXPub y
+    → x ≡ y
+
+{-# FOREIGN AGDA2HS
+rawSerialiseXPub :: XPub → ByteString
+rawSerialiseXPub = CC.unXPub
+
+rawSerialiseXPrv :: XPrv → ByteString
+rawSerialiseXPrv = CC.unXPrv
+
+rawSerialiseXSignature :: XSignature → ByteString
+rawSerialiseXSignature = CC.unXSignature
+#-}
+
 {-----------------------------------------------------------------------------
     Key derivation
 ------------------------------------------------------------------------------}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
@@ -3,6 +3,7 @@
 module Cardano.Wallet.Address.BIP32_Ed25519 where
 
 open import Haskell.Prelude
+open import Haskell.Reasoning
 
 open import Haskell.Data.ByteString using
   ( ByteString
@@ -13,12 +14,6 @@ open import Haskell.Data.Word.Odd using
 
 {-# FOREIGN AGDA2HS
 {-# LANGUAGE UnicodeSyntax #-}
-import Cardano.Crypto.Wallet
-  ( XPrv
-  , XPub
-  , XSignature
-  , toXPub
-  )
 import Data.ByteString
   ( ByteString
   )
@@ -60,6 +55,16 @@ postulate
       in  verify xpub msg (sign xprv msg) ≡ True
 
 {-# FOREIGN AGDA2HS
+-- FIXME: We define type synonyms here so that
+-- they can be exported. Ideally, we would re-export from
+-- the Cardano.Wallet.Crypto module.
+type XPub = CC.XPub
+type XPrv = CC.XPrv
+type XSignature = CC.XSignature
+
+toXPub :: XPrv → XPub
+toXPub = CC.toXPub
+
 sign :: XPrv → ByteString → XSignature
 sign = CC.sign BS.empty
 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure.agda
@@ -7,6 +7,8 @@ module Cardano.Wallet.Deposit.Pure
     ; ValueTransfer
       ; TxSummary
     ; WalletState
+      ; getXPub
+
       ; listCustomers
       ; isOurs
       ; knownCustomerAddress
@@ -44,6 +46,9 @@ import qualified Cardano.Wallet.Deposit.Pure.UTxO.Tx as UTxO
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 #-}
 
+open import Cardano.Wallet.Address.BIP32_Ed25519 using
+    ( XPub
+    )
 open import Cardano.Wallet.Deposit.Pure.Address using
     ( Customer
     ; deriveCustomerAddress
@@ -117,6 +122,11 @@ open WalletState public
 
 {-# COMPILE AGDA2HS WalletState #-}
 
+getXPub : WalletState → XPub
+getXPub = Addr.getXPub ∘ addresses
+
+{-# COMPILE AGDA2HS getXPub #-}
+
 {-----------------------------------------------------------------------------
     Mapping between Customers and Address
 ------------------------------------------------------------------------------}
@@ -179,7 +189,7 @@ prop-create-derive
   : ∀ (c : Customer)
       (s0 : WalletState)
   → let (address , _) = createAddress c s0
-    in  deriveCustomerAddress c ≡ address
+    in  deriveCustomerAddress (getXPub s0) c ≡ address
 --
 prop-create-derive c s0 = Addr.prop-create-derive c (addresses s0)
  

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
@@ -34,6 +34,15 @@ sign = CC.sign BS.empty
 verify :: XPub ->ByteString ->XSignature ->Bool
 verify = CC.verify
 
+rawSerialiseXPub :: XPub ->ByteString
+rawSerialiseXPub = CC.unXPub
+
+rawSerialiseXPrv :: XPrv ->ByteString
+rawSerialiseXPrv = CC.unXPrv
+
+rawSerialiseXSignature :: XSignature ->ByteString
+rawSerialiseXSignature = CC.unXSignature
+
 word32fromWord31 :: Word31 ->Word32
 word32fromWord31 = fromInteger . toInteger
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
@@ -3,12 +3,6 @@
 module Cardano.Wallet.Address.BIP32_Ed25519 where
 
 
-import Cardano.Crypto.Wallet
-  ( XPrv
-  , XPub
-  , XSignature
-  , toXPub
-  )
 import Data.ByteString
   ( ByteString
   )
@@ -23,6 +17,16 @@ import Data.Word.Odd
   )
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Data.ByteString as BS
+
+-- FIXME: We define type synonyms here so that
+-- they can be exported. Ideally, we would re-export from
+-- the Cardano.Wallet.Crypto module.
+type XPub = CC.XPub
+type XPrv = CC.XPrv
+type XSignature = CC.XSignature
+
+toXPub :: XPrv ->XPub
+toXPub = CC.toXPub
 
 sign :: XPrv ->ByteString ->XSignature
 sign = CC.sign BS.empty

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure.hs
@@ -1,5 +1,6 @@
 module Cardano.Wallet.Deposit.Pure where
 
+import Cardano.Wallet.Address.BIP32_Ed25519 (XPub)
 import Cardano.Wallet.Deposit.Read (Address, Block(transactions), ChainPoint, Tx, TxBody, TxOut(TxOutC), Value, chainPointFromBlock)
 import Cardano.Write.Tx.Balance (ChangeAddressGen, PartialTx(PartialTxC), balanceTransaction)
 import qualified Haskell.Data.Map as Map (Map, lookup)
@@ -22,6 +23,9 @@ import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 data WalletState = WalletState{addresses :: AddressState,
                                utxo :: UTxO, txSummaries :: Map.Map Customer [TxSummary],
                                localTip :: ChainPoint}
+
+getXPub :: WalletState -> XPub
+getXPub = Addr.getXPub . \ r -> addresses r
 
 listCustomers :: WalletState -> [(Customer, Address)]
 listCustomers = Addr.listCustomers . \ r -> addresses r


### PR DESCRIPTION
This pull request uses the actual BIP32_Ed25519 derivation scheme instead of a mock scheme in the definition of `AddressState.createAddress`. The proofs carry through if we postulate strong enough injectivity properties of the `deriveXPubSoft` function.

### Comments

* The mapping `XPub → Address` is still a mock version and does not yet use the actual binary representation of Cardano addresses.