### PR TITLE
Add `getBIP32Path`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32.agda
@@ -1,0 +1,29 @@
+{-# OPTIONS --erasure #-}
+
+module Cardano.Wallet.Address.BIP32 where
+
+open import Haskell.Prelude
+
+open import Haskell.Data.Word.Odd using
+  ( Word31
+  )
+
+{-----------------------------------------------------------------------------
+    BIP32 Paths
+------------------------------------------------------------------------------}
+data DerivationType : Set where
+    Soft     : DerivationType
+    Hardened : DerivationType
+
+open DerivationType public
+
+{-# COMPILE AGDA2HS DerivationType #-}
+
+-- | An absolute BIP32 Path.
+data BIP32Path : Set where
+    Root    : BIP32Path
+    Segment : BIP32Path → DerivationType → Word31 → BIP32Path
+
+open BIP32Path public
+
+{-# COMPILE AGDA2HS BIP32Path #-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -1,5 +1,6 @@
 module Cardano.Wallet.Deposit.Everything where
 
+import Cardano.Wallet.Address.BIP32
 import Cardano.Wallet.Address.BIP32_Ed25519
 import Cardano.Wallet.Address.Hash
 

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -61,6 +61,7 @@ library
     , text >= 1.2.4.1 && < 2.2
     , OddWord >= 1.0.1.1 && < 1.1
   exposed-modules:
+    Cardano.Wallet.Address.BIP32
     Cardano.Wallet.Address.BIP32_Ed25519
     Cardano.Wallet.Address.Encoding
     Cardano.Wallet.Address.Hash

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
@@ -1,0 +1,10 @@
+module Cardano.Wallet.Address.BIP32 where
+
+import Data.Word.Odd (Word31)
+
+data DerivationType = Soft
+                    | Hardened
+
+data BIP32Path = Root
+               | Segment BIP32Path DerivationType Word31
+


### PR DESCRIPTION
This pull request adds a function `getBIP32Path` that returns a standardized `BIP32Path` for the addresses managed by `AddressState`.

We also prove a lemma that relates `isOurs` to the success of `getDerivationPath`:

```agda
@0 lemma-getDerivationPath-Just
  : ∀ (s : AddressState)
      (addr : Address)
  → isOurs s addr ≡ True
  → ∃ (λ path → getDerivationPath s addr ≡ Just path)
```
