### PR TITLE
Add `Eq` and `Ord` instances for `BIP32Path`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32.agda
@@ -16,8 +16,18 @@ data DerivationType : Set where
     Hardened : DerivationType
 
 open DerivationType public
-
 {-# COMPILE AGDA2HS DerivationType #-}
+
+instance
+  iEqDerivationType : Eq DerivationType
+  iEqDerivationType ._==_ Soft Soft = True
+  iEqDerivationType ._==_ Hardened Hardened = True
+  iEqDerivationType ._==_ _ _ = False
+{-# COMPILE AGDA2HS iEqDerivationType derive #-}
+
+postulate instance
+  iOrdDerivationType : Ord DerivationType
+{-# COMPILE AGDA2HS iOrdDerivationType #-}
 
 -- | An absolute BIP32 Path.
 data BIP32Path : Set where
@@ -25,5 +35,16 @@ data BIP32Path : Set where
     Segment : BIP32Path → DerivationType → Word31 → BIP32Path
 
 open BIP32Path public
-
 {-# COMPILE AGDA2HS BIP32Path #-}
+
+instance
+  iEqBIP32Path : Eq BIP32Path
+  iEqBIP32Path ._==_ Root Root = True
+  iEqBIP32Path ._==_ (Segment a1 b1 c1) (Segment a2 b2 c2) =
+    a1 == a2 && b1 == b2 && c1 == c2
+  iEqBIP32Path ._==_ _ _ = False
+{-# COMPILE AGDA2HS iEqBIP32Path derive #-}
+
+postulate instance
+  iOrdBIP32Path : Ord BIP32Path
+{-# COMPILE AGDA2HS iOrdBIP32Path #-}

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StandaloneDeriving #-}
 module Cardano.Wallet.Address.BIP32 where
 
 import Data.Word.Odd (Word31)
@@ -5,6 +6,14 @@ import Data.Word.Odd (Word31)
 data DerivationType = Soft
                     | Hardened
 
+deriving instance Eq DerivationType
+
+deriving instance Ord DerivationType
+
 data BIP32Path = Root
                | Segment BIP32Path DerivationType Word31
+
+deriving instance Eq BIP32Path
+
+deriving instance Ord BIP32Path
 


### PR DESCRIPTION
This pull request adds `Eq` and `Ord` class instances for `BIP32Path` so that this type can be used in a container type such as `Data.Set.Set`.