### PR TITLE
Add initial implementation of `UTxOHistory`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -11,6 +11,7 @@ import Cardano.Wallet.Deposit.Pure.TxSummary
 import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO
 import Cardano.Wallet.Deposit.Pure.UTxO.Tx
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
 
 import Haskell.Data.Word.Odd

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory.agda
@@ -1,0 +1,3 @@
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory where
+
+open import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type public

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory.agda
@@ -1,3 +1,4 @@
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory where
 
+open import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core public
 open import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type public

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
@@ -1,0 +1,382 @@
+-- |
+-- 'UTxOHistory' represents a history of a UTxO set that can be rolled
+-- back (up to the 'finality' point).
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core
+    {-
+      -- * Types
+      UTxOHistory
+    , Pruned (..)
+    , Spent (..)
+
+      -- * Observations
+    , getTip
+    , getFinality
+    , empty
+    , getUTxO
+
+      -- * Changes
+    , DeltaUTxOHistory (..)
+
+      -- * For testing
+    , getSpent
+
+      -- * Store helpers
+    , constrainingPrune
+    , constrainingRollback
+    , constrainingAppendBlock
+    , reverseMapOfSets
+    -}
+    where
+
+open import Haskell.Prelude
+
+open import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO using
+    ( DeltaUTxO
+    )
+open import Cardano.Wallet.Deposit.Pure.UTxO.UTxO using
+    ( UTxO
+    ; dom
+    ; excluding
+    )
+open import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type using
+    ( Pruned
+    ; UTxOHistory
+    )
+open import Cardano.Wallet.Deposit.Read using
+    ( Slot
+    ; SlotNo
+    ; TxIn
+    ; WithOrigin
+    )
+open import Haskell.Data.Maybe using
+    ( fromMaybe
+    )
+open import Haskell.Data.Map using
+    ( Map
+    )
+open import Haskell.Data.Set using
+    ( ℙ
+    )
+
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
+import Haskell.Data.Map as Map
+import Haskell.Data.Set as Set
+
+{-# FOREIGN AGDA2HS
+-- Working around a limitation in agda2hs.
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
+    ( UTxOHistory (..)
+    )
+#-}
+
+{-----------------------------------------------------------------------------
+    Helper stuff
+------------------------------------------------------------------------------}
+
+variable
+  key v : Set
+
+guard : Bool → Maybe ⊤
+guard True = Just tt
+guard False = Nothing
+
+{-# COMPILE AGDA2HS guard #-}
+
+foldl'
+    : ∀ {t : Set → Set} {{_ : Foldable t}}
+    → (b -> a -> b) -> b -> t a -> b
+foldl' = foldl
+
+{-# COMPILE AGDA2HS foldl' #-}
+
+fold
+    : ∀ {t : Set → Set} {m : Set} {{_ : Foldable t}} → {{Monoid m}}
+    → t m → m
+fold = foldMap id
+
+{-# COMPILE AGDA2HS fold #-}
+
+{-----------------------------------------------------------------------------
+    Helper functions
+------------------------------------------------------------------------------}
+
+-- | Insert a 'Set' into a 'Map' of 'Set' — but only if the 'Set' is nonempty.
+insertNonEmpty
+    : {{_ : Ord key}} → {{_ : Ord v}}
+    → key → ℙ v → Map key (ℙ v) → Map key (ℙ v)
+insertNonEmpty key x = if Set.null x then id else Map.insert key x
+
+{-# COMPILE AGDA2HS insertNonEmpty #-}
+
+-- | Reverse the roles of key and values for a 'Map' of 'Set's.
+reverseMapOfSets
+    : {{_ : Ord key}} → {{_ : Ord v}}
+    → Map key (ℙ v) → Map v key
+reverseMapOfSets m = Map.fromList $ do
+    (k , vs) <- Map.toAscList m
+    v <- Set.toAscList vs
+    pure (v , k)
+
+{-# COMPILE AGDA2HS reverseMapOfSets #-}
+
+-- | Insert a 'Set' of items into a 'Map' that is
+-- the result of 'reverseMapOfSets'.
+insertNonEmptyReversedMap
+    : {{_ : Ord key}} → {{_ : Ord v}}
+    → key → ℙ v → Map v key → Map v key
+insertNonEmptyReversedMap key vs m0 =
+    foldl' (\m v → Map.insert v key m) m0 vs
+
+{-# COMPILE AGDA2HS insertNonEmptyReversedMap #-}
+
+deleteFromSet
+    : ∀ {v : Set} {{_ : Ord v}}
+    → v → ℙ v → Maybe (ℙ v)
+deleteFromSet x vs =
+    let vs' = Set.delete x vs
+    in  if Set.null vs' then Nothing else Just vs'
+
+{-# COMPILE AGDA2HS deleteFromSet #-}
+
+deleteFromMap
+    : {v key : Set} → {{_ : Ord v}} → {{_ : Ord key}}
+    → v × key → Map key (ℙ v) → Map key (ℙ v)
+deleteFromMap (x , key) = Map.update (deleteFromSet x) key
+
+{-# COMPILE AGDA2HS deleteFromMap #-}
+
+-- | Take the difference between a 'Map' and another 'Map'
+-- that was created by using 'reverseMapOfSets'.
+differenceReversedMap
+    : {v key : Set} → {{_ : Ord v}} → {{_ : Ord key}}
+    → Map key (ℙ v) → Map v key → Map key (ℙ v)
+differenceReversedMap whole part =
+    foldl' (flip deleteFromMap) whole $ Map.toAscList part
+
+{-# COMPILE AGDA2HS differenceReversedMap #-}
+
+{-----------------------------------------------------------------------------
+    Basic functions
+------------------------------------------------------------------------------}
+
+-- | An empty UTxO history
+empty : UTxO → UTxOHistory
+empty utxo =
+    record
+        { history = utxo
+        ; creationSlots = creationSlots'
+        ; creationTxIns = reverseMapOfSets creationSlots'
+        ; spentSlots = Map.empty
+        ; spentTxIns = Map.empty
+        ; tip = WithOrigin.Origin
+        ; finality = Pruned.NotPruned
+        ; boot = utxo
+        }
+  where
+    creationSlots' = Map.singleton WithOrigin.Origin $ dom utxo
+
+{-# COMPILE AGDA2HS empty #-}
+
+-- | Returns the UTxO.
+getUTxO : UTxOHistory → UTxO
+getUTxO us = excluding history (fold spentSlots)
+  where open UTxOHistory us
+
+-- | Returns the tip slot.
+getTip : UTxOHistory → Slot
+getTip = UTxOHistory.tip
+
+-- | Returns the finality slot.
+getFinality : UTxOHistory → Pruned
+getFinality = UTxOHistory.finality
+
+-- | Returns the spent TxIns that can be rolled back.
+getSpent : UTxOHistory → Map TxIn SlotNo
+getSpent = UTxOHistory.spentTxIns
+
+{-# COMPILE AGDA2HS getUTxO #-}
+{-# COMPILE AGDA2HS getTip #-}
+{-# COMPILE AGDA2HS getFinality #-}
+{-# COMPILE AGDA2HS getSpent #-}
+
+{-----------------------------------------------------------------------------
+    Helper functions
+------------------------------------------------------------------------------}
+
+-- | Helper to constraint the slot of an AppendBlock.
+constrainingAppendBlock : a → UTxOHistory → SlotNo → a → a
+constrainingAppendBlock noop us newTip f =
+    if WithOrigin.At newTip <= UTxOHistory.tip us
+    then noop
+    else f
+
+{-# COMPILE AGDA2HS constrainingAppendBlock #-}
+
+-- | Helper to constrain the slot of a Rollback.
+constrainingRollback : a → UTxOHistory → Slot → (Maybe Slot → a) → a
+constrainingRollback noop us newTip f =
+    if newTip >= tip
+    then noop
+    else f (case finality of λ
+        { Pruned.NotPruned → Just newTip
+        ; (Pruned.PrunedUpTo finality') → 
+            if newTip >= WithOrigin.At finality'
+                then Just newTip
+                else Nothing
+        })
+  where
+    open UTxOHistory us
+
+{-# COMPILE AGDA2HS constrainingRollback #-}
+
+-- | Helper to constraint the slot of a Prune.
+constrainingPrune : a → UTxOHistory → SlotNo → (SlotNo → a) → a
+constrainingPrune noop us newFinality f =
+    fromMaybe noop $ do
+        case finality of λ
+            { Pruned.NotPruned → pure tt
+            ; (Pruned.PrunedUpTo finality') → guard $ newFinality > finality'
+            }
+        case tip of λ
+            { WithOrigin.Origin → Nothing
+            ; (WithOrigin.At tip') → pure $ f $ min newFinality tip'
+            }
+  where
+    open UTxOHistory us
+
+{-# COMPILE AGDA2HS constrainingPrune #-}
+
+{-----------------------------------------------------------------------------
+    DeltaUTxOHistory
+------------------------------------------------------------------------------}
+
+-- | Changes to the UTxO history.
+data DeltaUTxOHistory : Set where
+    AppendBlock : SlotNo → DeltaUTxO → DeltaUTxOHistory
+        -- ^ New slot tip, changes within that block.
+    Rollback : Slot → DeltaUTxOHistory
+        -- ^ Rollback tip.
+    Prune : SlotNo → DeltaUTxOHistory
+        -- ^ Move finality forward.
+
+{-# COMPILE AGDA2HS DeltaUTxOHistory #-}
+
+appendBlock : SlotNo → DeltaUTxO → UTxOHistory → UTxOHistory
+appendBlock newTip delta noop =
+    constrainingAppendBlock noop noop newTip
+      record
+        { history = UTxO.union history (DeltaUTxO.received delta)
+        ; creationSlots =
+            insertNonEmpty (WithOrigin.At newTip) receivedTxIns creationSlots
+        ; creationTxIns =
+            insertNonEmptyReversedMap
+                (WithOrigin.At newTip) receivedTxIns creationTxIns
+        ; spentSlots =
+            insertNonEmpty newTip excludedTxIns spentSlots
+        ; spentTxIns =
+            insertNonEmptyReversedMap newTip excludedTxIns spentTxIns
+        ; tip = WithOrigin.At newTip
+        ; finality = finality
+        ; boot = boot
+        }
+  where
+    open UTxOHistory noop
+    receivedTxIns =
+        Set.difference
+            (dom (DeltaUTxO.received delta))
+            (dom history)
+    excludedTxIns =
+        Set.difference
+            (Set.intersection (DeltaUTxO.excluded delta) (dom history))
+            (fold spentSlots)
+
+{-# COMPILE AGDA2HS appendBlock #-}
+
+rollback : Slot → UTxOHistory → UTxOHistory
+rollback newTip noop =
+  constrainingRollback noop noop newTip λ
+    { (Just newTip') →
+        let
+            (leftCreationSlots , rolledCreatedSlots) =
+                Map.spanAntitone (_<= newTip') creationSlots
+            rolledSpentTxIns = fold (case newTip' of λ
+                { WithOrigin.Origin → spentSlots
+                ; (WithOrigin.At slot'') →
+                    Map.dropWhileAntitone
+                        (_<= slot'')
+                        spentSlots
+                })
+            rolledCreatedTxIns = fold rolledCreatedSlots
+        in
+            record
+                { history = excluding history rolledCreatedTxIns
+                ; spentSlots = case newTip' of λ
+                    { WithOrigin.Origin → Map.empty
+                    ; (WithOrigin.At slot'') →
+                        Map.takeWhileAntitone
+                            (_<= slot'')
+                            spentSlots
+                    }
+                ; creationSlots = leftCreationSlots
+                ; creationTxIns =
+                    Map.withoutKeys
+                        creationTxIns
+                        rolledCreatedTxIns
+                ; spentTxIns =
+                    Map.withoutKeys
+                        spentTxIns
+                        rolledSpentTxIns
+                ; tip = newTip'
+                ; finality = finality
+                ; boot = boot
+                }
+    ; Nothing → empty boot
+    }
+  where
+    open UTxOHistory noop
+
+{-# COMPILE AGDA2HS rollback #-}
+
+prune : SlotNo → UTxOHistory → UTxOHistory
+prune newFinality noop =
+  constrainingPrune noop noop newFinality $ \newFinality' →
+    let
+        (prunedSpentSlots , leftSpentSlots) =
+            Map.spanAntitone
+                (_<= newFinality')
+                spentSlots
+        prunedTxIns = fold prunedSpentSlots
+    in
+        record
+            { history = excluding history prunedTxIns
+            ; creationSlots =
+                differenceReversedMap
+                    creationSlots
+                    (Map.restrictKeys creationTxIns prunedTxIns)
+            ; creationTxIns =
+                Map.withoutKeys
+                    creationTxIns
+                    prunedTxIns
+            ; spentSlots = leftSpentSlots
+            ; spentTxIns =
+                Map.withoutKeys
+                    spentTxIns
+                    prunedTxIns
+            ; tip = tip
+            ; finality = Pruned.PrunedUpTo newFinality'
+            ; boot = boot
+            }
+  where
+    open UTxOHistory noop
+
+{-# COMPILE AGDA2HS prune #-}
+
+-- | How to apply a DeltaUTxOHistory to a UTxOHistory
+applyDeltaUTxOHistory
+    : DeltaUTxOHistory → UTxOHistory → UTxOHistory
+applyDeltaUTxOHistory (AppendBlock newTip delta) =
+    appendBlock newTip delta
+applyDeltaUTxOHistory (Rollback newTip) =
+    rollback newTip
+applyDeltaUTxOHistory (Prune newFinality) =
+    prune newFinality

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.agda
@@ -1,0 +1,77 @@
+-- | Definition of 'UTxOHistory'.
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type where
+
+open import Haskell.Prelude
+
+open import Cardano.Wallet.Deposit.Read using
+    ( Slot
+    ; SlotNo
+    ; TxIn
+    )
+open import Cardano.Wallet.Deposit.Pure.UTxO.UTxO using
+    ( UTxO
+    )
+open import Haskell.Data.Map using
+    ( Map
+    )
+open import Haskell.Data.Set using
+    ( ℙ
+    )
+
+{-----------------------------------------------------------------------------
+    Pruned
+------------------------------------------------------------------------------}
+
+-- | The finality of the UTxO history.
+data Pruned : Set where
+    PrunedUpTo : SlotNo → Pruned
+    NotPruned  : Pruned
+
+instance
+  iEqPruned : Eq Pruned
+  iEqPruned ._==_ NotPruned NotPruned = True
+  iEqPruned ._==_ (PrunedUpTo x) (PrunedUpTo y) = x == y
+  iEqPruned ._==_ _ _ = False
+
+  iShowPruned : Show Pruned
+  iShowPruned = record {Show₂ (record {show = showPruned})}
+    where
+      showPruned : Pruned → String
+      showPruned (PrunedUpTo x) = "PrunedUpTo _"
+      showPruned NotPruned = "NotPruned"
+
+{-# COMPILE AGDA2HS Pruned #-}
+{-# COMPILE AGDA2HS iEqPruned derive #-}
+{-# COMPILE AGDA2HS iShowPruned derive #-}
+
+{-----------------------------------------------------------------------------
+    UTxOHistory
+------------------------------------------------------------------------------}
+
+-- | UTxO history.
+-- Abstract history of the UTxO. We keep track of the creation
+-- and spending of slot of each TxIn.
+-- This allows us to rollback to a given slot
+-- and prune the history to a given slot.
+record UTxOHistory : Set where
+  field
+    history : UTxO
+        -- ^ All UTxO , spent and unspent.
+    creationSlots : Map Slot (ℙ TxIn)
+        -- ^ All TxIn, indexed by creation slot.
+    creationTxIns : Map TxIn Slot
+        -- ^ Reverse map of the `creationSlots` map
+    spentSlots : Map SlotNo (ℙ TxIn)
+        -- ^ All spent TxIn, indexed by spent slot.
+    spentTxIns : Map TxIn SlotNo
+        -- ^ Reverse map of the `spentSlots` map.
+    tip : Slot
+        -- ^ Current tip slot.
+    finality : Pruned
+        -- ^ Finality slot.
+    boot : UTxO
+        -- ^ UTxO created at genesis.
+
+open UTxOHistory public
+
+{-# COMPILE AGDA2HS UTxOHistory #-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read.agda
@@ -86,14 +86,46 @@ open Tx public
 {-# COMPILE AGDA2HS TxBody #-}
 {-# COMPILE AGDA2HS Tx #-}
 
+
+{-----------------------------------------------------------------------------
+    Slot
+------------------------------------------------------------------------------}
+SlotNo = Nat
+
+{-# COMPILE AGDA2HS SlotNo #-}
+
+data WithOrigin (a : Set) : Set where
+  Origin : WithOrigin a
+  At     : a → WithOrigin a
+
+instance
+  iEqWithOrigin : {{Eq a}} → Eq (WithOrigin a)
+  iEqWithOrigin ._==_ Origin Origin = True
+  iEqWithOrigin ._==_ (At x) (At y) = x == y
+  iEqWithOrigin ._==_ _      _      = False
+
+  iOrdWithOrigin : {{Ord a}} → Ord (WithOrigin a)
+  iOrdWithOrigin = ordFromCompare λ where
+    Origin Origin → EQ
+    Origin (At _) → LT
+    (At _) Origin → GT
+    (At x) (At y) → compare x y
+
+{-# COMPILE AGDA2HS WithOrigin #-}
+{-# COMPILE AGDA2HS iEqWithOrigin derive #-}
+{-# COMPILE AGDA2HS iOrdWithOrigin derive #-}
+
+Slot : Set
+Slot = WithOrigin SlotNo
+
+{-# COMPILE AGDA2HS Slot #-}
+
 {-----------------------------------------------------------------------------
     Blocks
 ------------------------------------------------------------------------------}
 BlockNo = Nat
-Slot = Nat
 
 {-# COMPILE AGDA2HS BlockNo #-}
-{-# COMPILE AGDA2HS Slot #-}
 
 HashHeader = ⊤
 HashBBody = ⊤
@@ -105,7 +137,7 @@ record BHBody : Set where
   field
     prev    : Maybe HashHeader
     blockno : BlockNo
-    slot    : Slot
+    slot    : SlotNo
     bhash   : HashBBody
 open BHBody public
 
@@ -162,7 +194,7 @@ open Block public
 ------------------------------------------------------------------------------}
 data ChainPoint : Set where
   GenesisPoint : ChainPoint
-  BlockPoint   : Slot → HashHeader → ChainPoint
+  BlockPoint   : SlotNo → HashHeader → ChainPoint
 
 {-# COMPILE AGDA2HS ChainPoint #-}
 

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -70,6 +70,8 @@ library
     Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     Cardano.Wallet.Deposit.Pure.UTxO.Tx
     Cardano.Wallet.Deposit.Pure.UTxO.UTxO
+    Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
+    Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
     Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
     Cardano.Wallet.Deposit.Pure.Timeline
     Cardano.Wallet.Deposit.Pure.TxSummary

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -71,6 +71,7 @@ library
     Cardano.Wallet.Deposit.Pure.UTxO.Tx
     Cardano.Wallet.Deposit.Pure.UTxO.UTxO
     Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
+    Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core
     Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
     Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
     Cardano.Wallet.Deposit.Pure.Timeline

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory.hs
@@ -1,5 +1,7 @@
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
-    ( module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
+    ( module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core
+    , module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
     ) where
 
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory.hs
@@ -1,0 +1,5 @@
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
+    ( module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
+    ) where
+
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE LambdaCase #-}
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core where
+
+import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO (DeltaUTxO(excluded, received))
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO, dom, excluding)
+import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO (union)
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type (Pruned(NotPruned, PrunedUpTo), UTxOHistory(boot, creationSlots, creationTxIns, finality, history, spentSlots, spentTxIns, tip))
+import Cardano.Wallet.Deposit.Read (Slot, SlotNo, TxIn, WithOrigin(At, Origin))
+import Data.Set (Set)
+import Haskell.Data.Map (Map)
+import qualified Haskell.Data.Map as Map (dropWhileAntitone, empty, fromList, insert, restrictKeys, singleton, spanAntitone, takeWhileAntitone, toAscList, update, withoutKeys)
+import Haskell.Data.Maybe (fromMaybe)
+import qualified Haskell.Data.Set as Set (delete, difference, intersection, null, toAscList)
+
+-- Working around a limitation in agda2hs.
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
+    ( UTxOHistory (..)
+    )
+
+guard :: Bool -> Maybe ()
+guard True = Just ()
+guard False = Nothing
+
+foldl' :: Foldable t => (b -> a -> b) -> b -> t a -> b
+foldl' = foldl
+
+fold :: (Foldable t, Monoid m) => t m -> m
+fold = foldMap id
+
+insertNonEmpty ::
+                 (Ord key, Ord v) =>
+                 key -> Set v -> Map key (Set v) -> Map key (Set v)
+insertNonEmpty key x = if Set.null x then id else Map.insert key x
+
+reverseMapOfSets ::
+                   (Ord key, Ord v) => Map key (Set v) -> Map v key
+reverseMapOfSets m
+  = Map.fromList $
+      do (k, vs) <- Map.toAscList m
+         v <- Set.toAscList vs
+         pure (v, k)
+
+insertNonEmptyReversedMap ::
+                            (Ord key, Ord v) => key -> Set v -> Map v key -> Map v key
+insertNonEmptyReversedMap key vs m0
+  = foldl' (\ m v -> Map.insert v key m) m0 vs
+
+deleteFromSet :: Ord v => v -> Set v -> Maybe (Set v)
+deleteFromSet x vs
+  = if Set.null (Set.delete x vs) then Nothing else
+      Just (Set.delete x vs)
+
+deleteFromMap ::
+                (Ord v, Ord key) => (v, key) -> Map key (Set v) -> Map key (Set v)
+deleteFromMap (x, key) = Map.update (deleteFromSet x) key
+
+differenceReversedMap ::
+                        (Ord v, Ord key) => Map key (Set v) -> Map v key -> Map key (Set v)
+differenceReversedMap whole part
+  = foldl' (flip deleteFromMap) whole $ Map.toAscList part
+
+empty :: UTxO -> UTxOHistory
+empty utxo
+  = UTxOHistory utxo creationSlots' (reverseMapOfSets creationSlots')
+      Map.empty
+      Map.empty
+      Origin
+      NotPruned
+      utxo
+  where
+    creationSlots' :: Map (WithOrigin SlotNo) (Set TxIn)
+    creationSlots' = Map.singleton Origin $ dom utxo
+
+getUTxO :: UTxOHistory -> UTxO
+getUTxO us = excluding (history us) (fold (spentSlots us))
+
+getTip :: UTxOHistory -> Slot
+getTip = \ r -> tip r
+
+getFinality :: UTxOHistory -> Pruned
+getFinality = \ r -> finality r
+
+getSpent :: UTxOHistory -> Map TxIn SlotNo
+getSpent = \ r -> spentTxIns r
+
+constrainingAppendBlock :: a -> UTxOHistory -> SlotNo -> a -> a
+constrainingAppendBlock noop us newTip f
+  = if At newTip <= tip us then noop else f
+
+constrainingRollback ::
+                     a -> UTxOHistory -> Slot -> (Maybe Slot -> a) -> a
+constrainingRollback noop us newTip f
+  = if newTip >= tip us then noop else
+      f (case finality us of
+             NotPruned -> Just newTip
+             PrunedUpTo finality' -> if newTip >= At finality' then Just newTip
+                                       else Nothing)
+
+constrainingPrune ::
+                  a -> UTxOHistory -> SlotNo -> (SlotNo -> a) -> a
+constrainingPrune noop us newFinality f
+  = fromMaybe noop $
+      do case finality us of
+             NotPruned -> pure ()
+             PrunedUpTo finality' -> guard $ newFinality > finality'
+         case tip us of
+             Origin -> Nothing
+             At tip' -> pure $ f $ min newFinality tip'
+
+data DeltaUTxOHistory = AppendBlock SlotNo DeltaUTxO
+                      | Rollback Slot
+                      | Prune SlotNo
+
+appendBlock :: SlotNo -> DeltaUTxO -> UTxOHistory -> UTxOHistory
+appendBlock newTip delta noop
+  = constrainingAppendBlock noop noop newTip
+      (UTxOHistory (UTxO.union (history noop) (received delta))
+         (insertNonEmpty (At newTip) receivedTxIns (creationSlots noop))
+         (insertNonEmptyReversedMap (At newTip) receivedTxIns
+            (creationTxIns noop))
+         (insertNonEmpty newTip excludedTxIns (spentSlots noop))
+         (insertNonEmptyReversedMap newTip excludedTxIns (spentTxIns noop))
+         (At newTip)
+         (finality noop)
+         (boot noop))
+  where
+    receivedTxIns :: Set TxIn
+    receivedTxIns
+      = Set.difference (dom (received delta)) (dom (history noop))
+    excludedTxIns :: Set TxIn
+    excludedTxIns
+      = Set.difference
+          (Set.intersection (excluded delta) (dom (history noop)))
+          (fold (spentSlots noop))
+
+rollback :: Slot -> UTxOHistory -> UTxOHistory
+rollback newTip noop
+  = constrainingRollback noop noop newTip
+      (\case
+           Just newTip' -> UTxOHistory
+                             (excluding (history noop)
+                                (fold (snd (Map.spanAntitone (<= newTip') (creationSlots noop)))))
+                             (fst (Map.spanAntitone (<= newTip') (creationSlots noop)))
+                             (Map.withoutKeys (creationTxIns noop)
+                                (fold (snd (Map.spanAntitone (<= newTip') (creationSlots noop)))))
+                             (case newTip' of
+                                  Origin -> Map.empty
+                                  At slot'' -> Map.takeWhileAntitone (<= slot'') (spentSlots noop))
+                             (Map.withoutKeys (spentTxIns noop)
+                                (fold
+                                   (case newTip' of
+                                        Origin -> spentSlots noop
+                                        At slot'' -> Map.dropWhileAntitone (<= slot'')
+                                                       (spentSlots noop))))
+                             newTip'
+                             (finality noop)
+                             (boot noop)
+           Nothing -> empty (boot noop))
+
+prune :: SlotNo -> UTxOHistory -> UTxOHistory
+prune newFinality noop
+  = constrainingPrune noop noop newFinality $
+      \ newFinality' ->
+        UTxOHistory
+          (excluding (history noop)
+             (fold
+                (fst (Map.spanAntitone (<= newFinality') (spentSlots noop)))))
+          (differenceReversedMap (creationSlots noop)
+             (Map.restrictKeys (creationTxIns noop)
+                (fold
+                   (fst (Map.spanAntitone (<= newFinality') (spentSlots noop))))))
+          (Map.withoutKeys (creationTxIns noop)
+             (fold
+                (fst (Map.spanAntitone (<= newFinality') (spentSlots noop)))))
+          (snd (Map.spanAntitone (<= newFinality') (spentSlots noop)))
+          (Map.withoutKeys (spentTxIns noop)
+             (fold
+                (fst (Map.spanAntitone (<= newFinality') (spentSlots noop)))))
+          (tip noop)
+          (PrunedUpTo newFinality')
+          (boot noop)
+

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE StandaloneDeriving #-}
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type where
+
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO)
+import Cardano.Wallet.Deposit.Read (Slot, SlotNo, TxIn)
+import Data.Set (Set)
+import Haskell.Data.Map (Map)
+
+data Pruned = PrunedUpTo SlotNo
+            | NotPruned
+
+deriving instance Eq Pruned
+
+deriving instance Show Pruned
+
+data UTxOHistory = UTxOHistory{history :: UTxO,
+                               creationSlots :: Map Slot (Set TxIn),
+                               creationTxIns :: Map TxIn Slot,
+                               spentSlots :: Map SlotNo (Set TxIn), spentTxIns :: Map TxIn SlotNo,
+                               tip :: Slot, finality :: Pruned, boot :: UTxO}
+

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StandaloneDeriving #-}
 module Cardano.Wallet.Deposit.Read where
 
 import qualified Haskell.Data.ByteString as BS (ByteString)
@@ -24,16 +25,25 @@ data TxBody = TxBodyC{inputs :: [TxIn], outputs :: [TxOut]}
 
 data Tx = TxC{txid :: TxId, txbody :: TxBody}
 
-type BlockNo = Natural
+type SlotNo = Natural
 
-type Slot = Natural
+data WithOrigin a = Origin
+                  | At a
+
+deriving instance (Eq a) => Eq (WithOrigin a)
+
+deriving instance (Ord a) => Ord (WithOrigin a)
+
+type Slot = WithOrigin SlotNo
+
+type BlockNo = Natural
 
 type HashHeader = ()
 
 type HashBBody = ()
 
 data BHBody = BHBody{prev :: Maybe HashHeader, blockno :: BlockNo,
-                     slot :: Slot, bhash :: HashBBody}
+                     slot :: SlotNo, bhash :: HashBBody}
 
 dummyBHBody :: BHBody
 dummyBHBody = BHBody Nothing 128 42 ()
@@ -52,7 +62,7 @@ dummyBHeader = BHeader dummyBHBody ()
 data Block = Block{blockHeader :: BHeader, transactions :: [Tx]}
 
 data ChainPoint = GenesisPoint
-                | BlockPoint Slot HashHeader
+                | BlockPoint SlotNo HashHeader
 
 chainPointFromBlock :: Block -> ChainPoint
 chainPointFromBlock block


### PR DESCRIPTION
This pull request adds an initial implementation of the `UTxOHistory` type, copied from https://github.com/cardano-foundation/cardano-wallet/blob/eafaf8f522b1536f0ab6b9434d0471b9a2f6701e/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/Model.hs .