### PR TITLE
Add `InverseMap` type and use it in `UTxOHistory`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
@@ -59,6 +59,7 @@ open import Haskell.Data.Set using
     )
 
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
+import Haskell.Data.InverseMap as InverseMap
 import Haskell.Data.Map as Map
 import Haskell.Data.Set as Set
 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
@@ -130,32 +130,6 @@ insertNonEmptyReversedMap key vs m0 =
 
 {-# COMPILE AGDA2HS insertNonEmptyReversedMap #-}
 
-deleteFromSet
-    : ∀ {v : Set} {{_ : Ord v}}
-    → v → ℙ v → Maybe (ℙ v)
-deleteFromSet x vs =
-    let vs' = Set.delete x vs
-    in  if Set.null vs' then Nothing else Just vs'
-
-{-# COMPILE AGDA2HS deleteFromSet #-}
-
-deleteFromMap
-    : {v key : Set} → {{_ : Ord v}} → {{_ : Ord key}}
-    → v × key → Map key (ℙ v) → Map key (ℙ v)
-deleteFromMap (x , key) = Map.update (deleteFromSet x) key
-
-{-# COMPILE AGDA2HS deleteFromMap #-}
-
--- | Take the difference between a 'Map' and another 'Map'
--- that was created by using 'reverseMapOfSets'.
-differenceReversedMap
-    : {v key : Set} → {{_ : Ord v}} → {{_ : Ord key}}
-    → Map key (ℙ v) → Map v key → Map key (ℙ v)
-differenceReversedMap whole part =
-    foldl' (flip deleteFromMap) whole $ Map.toAscList part
-
-{-# COMPILE AGDA2HS differenceReversedMap #-}
-
 {-----------------------------------------------------------------------------
     Basic functions
 ------------------------------------------------------------------------------}
@@ -351,7 +325,7 @@ prune newFinality noop =
         record
             { history = excluding history prunedTxIns
             ; creationSlots =
-                differenceReversedMap
+                InverseMap.difference
                     creationSlots
                     (Map.restrictKeys creationTxIns prunedTxIns)
             ; creationTxIns =

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.agda
@@ -17,6 +17,9 @@ open import Haskell.Data.Map using
 open import Haskell.Data.Set using
     ( ℙ
     )
+open import Haskell.Data.InverseMap using
+    ( InverseMap
+    )
 
 {-----------------------------------------------------------------------------
     Pruned
@@ -57,14 +60,14 @@ record UTxOHistory : Set where
   field
     history : UTxO
         -- ^ All UTxO , spent and unspent.
-    creationSlots : Map Slot (ℙ TxIn)
-        -- ^ All TxIn, indexed by creation slot.
+    creationSlots : InverseMap TxIn Slot
+        -- ^ All TxIn, efficiently indexed by creation slot.
     creationTxIns : Map TxIn Slot
-        -- ^ Reverse map of the `creationSlots` map
-    spentSlots : Map SlotNo (ℙ TxIn)
-        -- ^ All spent TxIn, indexed by spent slot.
+        -- ^ Creation slot of each 'TxIn'.
+    spentSlots : InverseMap TxIn SlotNo
+        -- ^ All spent 'TxIn', efficiently indexed by spent slot.
     spentTxIns : Map TxIn SlotNo
-        -- ^ Reverse map of the `spentSlots` map.
+        -- ^ Spent slot of each spent 'TxIn'.
     tip : Slot
         -- ^ Current tip slot.
     finality : Pruned

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/InverseMap.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/InverseMap.agda
@@ -1,0 +1,95 @@
+-- | A type representing the inverse of a 'Map'
+module Haskell.Data.InverseMap where
+
+open import Haskell.Prelude
+
+open import Haskell.Data.Maybe using
+    ( fromMaybe
+    )
+open import Haskell.Data.Map using
+    ( Map
+    )
+open import Haskell.Data.Set using
+    ( ℙ
+    )
+
+import Haskell.Data.Map as Map
+import Haskell.Data.Set as Set
+
+foldl'
+    : ∀ {t : Set → Set} {{_ : Foldable t}}
+    → (b -> a -> b) -> b -> t a -> b
+foldl' = foldl
+
+{-# COMPILE AGDA2HS foldl' #-}
+
+{-----------------------------------------------------------------------------
+    Inverse Map
+------------------------------------------------------------------------------}
+
+variable
+  key v : Set
+
+InverseMap : ∀ (key v : Set) → {{_ : Ord key}} → {{_ : Ord v}} → Set
+InverseMap key v = Map v (ℙ key)
+
+{-# COMPILE AGDA2HS InverseMap #-}
+
+empty
+    : {{_ : Ord key}} → {{_ : Ord v}}
+    → InverseMap key v
+empty = Map.empty
+
+{-# COMPILE AGDA2HS empty #-}
+
+inverseMapFromMap
+    : {{_ : Ord key}} → {{_ : Ord v}}
+    → Map key v → InverseMap key v
+inverseMapFromMap m = Map.fromListWith Set.union $ do
+    (key , v) <- Map.toAscList m
+    pure (v , Set.singleton key)
+
+{-# COMPILE AGDA2HS inverseMapFromMap #-}
+
+-- | Insert a key-value pair into an 'InverseMap'.
+insert
+    : {{_ : Ord key}} {{_ : Ord v}}
+    → key → v → InverseMap key v → InverseMap key v
+insert key v = Map.insertWith (Set.union) v (Set.singleton key)
+
+{-# COMPILE AGDA2HS insert #-}
+
+-- | Insert a set of keys that all have the same value.
+insertManyKeys
+    : {{_ : Ord key}} {{_ : Ord v}}
+    → ℙ key → v → InverseMap key v → InverseMap key v
+insertManyKeys keys v =
+    if Set.null keys then id else Map.insertWith Set.union v keys
+
+{-# COMPILE AGDA2HS insertManyKeys #-}
+
+deleteFromSet
+    : ∀ {v : Set} {{_ : Ord v}}
+    → v → ℙ v → Maybe (ℙ v)
+deleteFromSet x vs =
+    let vs' = Set.delete x vs
+    in  if Set.null vs' then Nothing else Just vs'
+
+{-# COMPILE AGDA2HS deleteFromSet #-}
+
+delete
+    : {{_ : Ord v}} → {{_ : Ord key}}
+    → key → v → InverseMap key v → InverseMap key v
+delete key x = Map.update (deleteFromSet key) x
+
+{-# COMPILE AGDA2HS delete #-}
+
+-- | Take the difference between an 'InverseMap' and an ordinary 'Map'
+difference
+    : {{_ : Ord v}} → {{_ : Ord key}}
+    → InverseMap key v → Map key v → InverseMap key v
+difference whole part =
+    foldl' (λ m keyx → delete (fst keyx) (snd keyx) m) whole
+    $ Map.toAscList part
+
+{-# COMPILE AGDA2HS difference #-}

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
@@ -152,6 +152,11 @@ module _ {k a : Set} {{_ : Ord k}} where
   singleton : k → a → Map k a
   singleton = λ k x → insert k x empty
 
+  insertWith : (a → a → a) → k → a → Map k a → Map k a
+  insertWith f k new m = case lookup k m of λ where
+    Nothing → insert k new m
+    (Just old) → insert k (f new old) m
+
   withoutKeys : Map k a → Set.ℙ k → Map k a
   withoutKeys m s = filterWithKey (λ k _ → not (Set.member k s)) m
 

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -81,6 +81,7 @@ library
     Cardano.Write.Tx.Balance
   other-modules:
     Haskell.Data.ByteString
+    Haskell.Data.InverseMap
     Haskell.Data.Map
     Haskell.Data.Maybe
     Haskell.Data.Set

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
@@ -3,7 +3,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO)
 import Cardano.Wallet.Deposit.Read (Slot, SlotNo, TxIn)
-import Data.Set (Set)
+import Haskell.Data.InverseMap (InverseMap)
 import Haskell.Data.Map (Map)
 
 data Pruned = PrunedUpTo SlotNo
@@ -14,8 +14,9 @@ deriving instance Eq Pruned
 deriving instance Show Pruned
 
 data UTxOHistory = UTxOHistory{history :: UTxO,
-                               creationSlots :: Map Slot (Set TxIn),
+                               creationSlots :: InverseMap TxIn Slot,
                                creationTxIns :: Map TxIn Slot,
-                               spentSlots :: Map SlotNo (Set TxIn), spentTxIns :: Map TxIn SlotNo,
-                               tip :: Slot, finality :: Pruned, boot :: UTxO}
+                               spentSlots :: InverseMap TxIn SlotNo,
+                               spentTxIns :: Map TxIn SlotNo, tip :: Slot, finality :: Pruned,
+                               boot :: UTxO}
 

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/InverseMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/InverseMap.hs
@@ -1,0 +1,50 @@
+module Haskell.Data.InverseMap where
+
+import Data.Set (Set)
+import Haskell.Data.Map (Map)
+import qualified Haskell.Data.Map as Map (empty, fromListWith, insertWith, toAscList, update)
+import qualified Haskell.Data.Set as Set (delete, null, singleton, union)
+
+foldl' :: Foldable t => (b -> a -> b) -> b -> t a -> b
+foldl' = foldl
+
+type InverseMap key v = Map v (Set key)
+
+empty :: (Ord key, Ord v) => InverseMap key v
+empty = Map.empty
+
+inverseMapFromMap ::
+                    (Ord key, Ord v) => Map key v -> InverseMap key v
+inverseMapFromMap m
+  = Map.fromListWith Set.union $
+      do (key, v) <- Map.toAscList m
+         pure (v, Set.singleton key)
+
+insert ::
+         (Ord key, Ord v) =>
+         key -> v -> InverseMap key v -> InverseMap key v
+insert key v = Map.insertWith Set.union v (Set.singleton key)
+
+insertManyKeys ::
+                 (Ord key, Ord v) =>
+                 Set key -> v -> InverseMap key v -> InverseMap key v
+insertManyKeys keys v
+  = if Set.null keys then id else Map.insertWith Set.union v keys
+
+deleteFromSet :: Ord v => v -> Set v -> Maybe (Set v)
+deleteFromSet x vs
+  = if Set.null (Set.delete x vs) then Nothing else
+      Just (Set.delete x vs)
+
+delete ::
+         (Ord v, Ord key) =>
+         key -> v -> InverseMap key v -> InverseMap key v
+delete key x = Map.update (deleteFromSet key) x
+
+difference ::
+             (Ord v, Ord key) =>
+             InverseMap key v -> Map key v -> InverseMap key v
+difference whole part
+  = foldl' (\ m keyx -> delete (fst keyx) (snd keyx) m) whole $
+      Map.toAscList part
+


### PR DESCRIPTION
This pull request adds a type synonym `InverseMap` and uses it in the implementation of `UTxOHistory`.

In this way, we can simplify the helper functions used in the implementation of `UTxOHistory.Core`. It turns out that they can be subsumed by the function

* `InverseMap.insertManyKeys`
* `InverseMap.difference`