### PR TITLE
Implement `PairMap` type

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -15,4 +15,5 @@ import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
 
 import Haskell.Data.List
+import Haskell.Data.Maps.PairMap
 import Haskell.Data.Word.Odd

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
@@ -3,6 +3,7 @@
 module Haskell.Data.Maps.PairMap where
 
 open import Haskell.Prelude
+open import Haskell.Reasoning
 
 open import Haskell.Data.List using
     ( foldl'
@@ -39,6 +40,38 @@ withEmpty f = explicitEmpty ∘ f ∘ implicitEmpty
 {-# COMPILE AGDA2HS explicitEmpty #-}
 {-# COMPILE AGDA2HS implicitEmpty #-}
 {-# COMPILE AGDA2HS withEmpty #-}
+
+@0 prop-explicitEmpty-bind
+  : ∀ {{_ : Ord a}} (x : a) (m : Map a b)
+  → explicitEmpty m >>= Map.lookup x
+    ≡ Map.lookup x m
+prop-explicitEmpty-bind x m = case Map.null m of λ
+  { True {{eq}} →
+    begin
+      (if Map.null m then Nothing else Just m) >>= Map.lookup x
+    ≡⟨ cong (λ o → (if o then Nothing else Just m) >>= Map.lookup x) eq ⟩
+      Nothing
+    ≡⟨ sym (Map.prop-lookup-empty x) ⟩
+      Map.lookup x Map.empty
+    ≡⟨ cong (λ o → Map.lookup x o) (sym (Map.prop-null-empty m eq)) ⟩
+      Map.lookup x m
+    ∎
+  ; False {{eq}} →
+    begin
+      (if Map.null m then Nothing else Just m) >>= Map.lookup x
+    ≡⟨ cong (λ o → (if o then Nothing else Just m) >>= Map.lookup x) eq ⟩
+      Just m >>= Map.lookup x
+    ≡⟨⟩
+      Map.lookup x m
+    ∎
+  }
+
+@0 prop-implicitEmpty-bind
+  : ∀ {{_ : Ord a}} (x : a) (m : Maybe (Map a b))
+  → m >>= Map.lookup x
+    ≡ Map.lookup x (implicitEmpty m)
+prop-implicitEmpty-bind x Nothing = sym (Map.prop-lookup-empty x)
+prop-implicitEmpty-bind x (Just m1) = refl
 
 {-----------------------------------------------------------------------------
     Map a (Map b v)

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
@@ -1,0 +1,119 @@
+-- | A map from pairs of keys to values,
+-- with efficient lookups for single keys.
+module Haskell.Data.Maps.PairMap where
+
+open import Haskell.Prelude
+
+open import Haskell.Data.List using
+    ( foldl'
+    )
+open import Haskell.Data.Maybe using
+    ( fromMaybe
+    )
+open import Haskell.Data.Map using
+    ( Map
+    )
+
+import Haskell.Data.Map as Map
+
+variable
+  v : Set
+
+{-----------------------------------------------------------------------------
+    Helper functions
+------------------------------------------------------------------------------}
+
+explicitEmpty : {{_ : Ord a}} → Map a v → Maybe (Map a v)
+explicitEmpty m = if Map.null m then Nothing else Just m
+
+implicitEmpty : {{_ : Ord a}} → Maybe (Map a v) → Map a v
+implicitEmpty Nothing = Map.empty
+implicitEmpty (Just x) = x 
+
+withEmpty
+  : {{_ : Ord a}}
+  → (Map a v → Map a v)
+  → Maybe (Map a v) → Maybe (Map a v)
+withEmpty f = explicitEmpty ∘ f ∘ implicitEmpty
+
+{-# COMPILE AGDA2HS explicitEmpty #-}
+{-# COMPILE AGDA2HS implicitEmpty #-}
+{-# COMPILE AGDA2HS withEmpty #-}
+
+{-----------------------------------------------------------------------------
+    Map a (Map b v)
+    Helper functions and properties
+------------------------------------------------------------------------------}
+
+lookup2
+  : {{_ : Ord a}} → {{_ : Ord b}} 
+  → a → b → Map a (Map b v) → Maybe v
+lookup2 a b m = Map.lookup a m >>= Map.lookup b
+
+insert2
+  : {{_ : Ord a}} → {{_ : Ord b}} 
+  → a → b → v → Map a (Map b v) → Map a (Map b v)
+insert2 ai bi v m =
+  Map.insert ai (Map.insert bi v (implicitEmpty (Map.lookup ai m))) m
+
+delete2
+  : {{_ : Ord a}} → {{_ : Ord b}} 
+  → a → b → Map a (Map b v) → Map a (Map b v)
+delete2 a b = Map.update (explicitEmpty ∘ Map.delete b) a
+
+delete2s
+  : {{_ : Ord a}} → {{_ : Ord b}} 
+  → List a → b → Map a (Map b v) → Map a (Map b v)
+delete2s xs b m0 = foldr (λ a m → delete2 a b m) m0 xs
+-- fixme: use foldl'
+
+{-# COMPILE AGDA2HS lookup2 #-}
+{-# COMPILE AGDA2HS insert2 #-}
+{-# COMPILE AGDA2HS delete2 #-}
+{-# COMPILE AGDA2HS delete2s #-}
+
+{-----------------------------------------------------------------------------
+    PairMap
+------------------------------------------------------------------------------}
+
+record PairMap (a b v : Set) {{orda : Ord a}} {{ordb : Ord b}} : Set where
+  field
+    mab : Map a (Map b v)
+    mba : Map b (Map a v)
+
+open PairMap public
+
+module _ {a b v : Set} {{_ : Ord a}} {{_ : Ord b}} where
+  empty : PairMap a b v
+  empty = record { mab = Map.empty ; mba = Map.empty }
+
+  lookupA : a → PairMap a b v → Map b v
+  lookupA a = fromMaybe Map.empty ∘ Map.lookup a ∘ mab
+
+  lookupB : b → PairMap a b v → Map a v
+  lookupB b = fromMaybe Map.empty ∘ Map.lookup b ∘ mba
+
+  lookupAB : a → b → PairMap a b v → Maybe v
+  lookupAB a b m = Map.lookup a (mab m) >>= Map.lookup b
+
+  insert : a → b → v → PairMap a b v → PairMap a b v
+  insert ai bi v m = record
+    { mab = insert2 ai bi v (mab m)
+    ; mba = insert2 bi ai v (mba m)
+    }
+
+  deleteA : a → PairMap a b v → PairMap a b v
+  deleteA ai m = record
+      { mab = Map.delete ai (mab m)
+      ; mba = delete2s bs ai (mba m)
+      }
+    where
+      bs : List b
+      bs = Map.keys (implicitEmpty (Map.lookup ai (mab m)))
+
+{-# COMPILE AGDA2HS PairMap #-}
+{-# COMPILE AGDA2HS lookupA #-}
+{-# COMPILE AGDA2HS lookupB #-}
+{-# COMPILE AGDA2HS lookupAB #-}
+{-# COMPILE AGDA2HS insert #-}
+{-# COMPILE AGDA2HS deleteA #-}

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
@@ -59,3 +59,45 @@ prop-¬-not
 --
 prop-¬-not {False} contra = refl
 prop-¬-not {True} contra = case contra refl of λ ()
+
+{-----------------------------------------------------------------------------
+    Properties of if_then_else
+------------------------------------------------------------------------------}
+prop-if-apply
+  : ∀ (b : Bool) (t e : a) (f : a → c)
+  → f (if b then t else e) ≡ (if b then f t else f e)
+prop-if-apply True = λ t e f → refl
+prop-if-apply False = λ t e f → refl
+
+prop-if-redundant
+  : ∀ (b : Bool) (t : a)
+  → (if b then t else t) ≡ t
+prop-if-redundant False _ = refl
+prop-if-redundant True _ = refl
+
+prop-if-nested
+  : ∀ {a : Set} (x y : Bool) (t e : a)
+  → (if x then (if y then t else e) else e)
+    ≡ (if (x && y) then t else e)
+prop-if-nested True  True = λ o e → refl
+prop-if-nested True  False = λ o e → refl
+prop-if-nested False True = λ o e → refl
+prop-if-nested False False = λ o e → refl
+
+@0 prop-if-eq-subst
+  : ∀ {{_ : Eq a}} (x y : a) (t : a → b) (e : b)
+      (subst : (x == y) ≡ True → t x ≡ t y)
+  → (if x == y then t x else e)
+    ≡ (if x == y then t y else e)
+prop-if-eq-subst x y t e subst =
+  case x == y of λ
+    { True {{eq}} → cong (λ o → if x == y then o else e) (subst eq)
+    ; False {{eq}} →
+      begin
+        (if x == y then t x else e)
+      ≡⟨ cong (λ o → if o then t x else e) eq ⟩
+        e
+      ≡⟨ sym (cong (λ o → if o then t y else e) eq) ⟩
+        (if x == y then t y else e)
+      ∎
+    }

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -84,6 +84,7 @@ library
     Haskell.Data.InverseMap
     Haskell.Data.List
     Haskell.Data.Map
+    Haskell.Data.Maps.PairMap
     Haskell.Data.Maybe
     Haskell.Data.Set
     Haskell.Data.Word

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Haskell.Data.Maps.PairMap where
+
+import Haskell.Data.Map (Map)
+import qualified Haskell.Data.Map as Map (delete, empty, insert, keys, lookup, null, update)
+import Haskell.Data.Maybe (fromMaybe)
+
+explicitEmpty :: Ord a => Map a v -> Maybe (Map a v)
+explicitEmpty m = if Map.null m then Nothing else Just m
+
+implicitEmpty :: Ord a => Maybe (Map a v) -> Map a v
+implicitEmpty Nothing = Map.empty
+implicitEmpty (Just x) = x
+
+withEmpty ::
+            Ord a => (Map a v -> Map a v) -> Maybe (Map a v) -> Maybe (Map a v)
+withEmpty f = explicitEmpty . f . implicitEmpty
+
+lookup2 :: (Ord a, Ord b) => a -> b -> Map a (Map b v) -> Maybe v
+lookup2 a b m = Map.lookup a m >>= Map.lookup b
+
+insert2 ::
+          (Ord a, Ord b) => a -> b -> v -> Map a (Map b v) -> Map a (Map b v)
+insert2 ai bi v m
+  = Map.insert ai (Map.insert bi v (implicitEmpty (Map.lookup ai m)))
+      m
+
+delete2 ::
+          (Ord a, Ord b) => a -> b -> Map a (Map b v) -> Map a (Map b v)
+delete2 a b = Map.update (explicitEmpty . Map.delete b) a
+
+delete2s ::
+           (Ord a, Ord b) => [a] -> b -> Map a (Map b v) -> Map a (Map b v)
+delete2s xs b m0 = foldr (\ a -> delete2 a b) m0 xs
+
+data PairMap a b v = PairMap{mab :: Map a (Map b v),
+                             mba :: Map b (Map a v)}
+
+lookupA ::
+        forall a b v . (Ord a, Ord b) => a -> PairMap a b v -> Map b v
+lookupA a = fromMaybe Map.empty . Map.lookup a . \ r -> mab r
+
+lookupB ::
+        forall a b v . (Ord a, Ord b) => b -> PairMap a b v -> Map a v
+lookupB b = fromMaybe Map.empty . Map.lookup b . \ r -> mba r
+
+lookupAB ::
+         forall a b v . (Ord a, Ord b) => a -> b -> PairMap a b v -> Maybe v
+lookupAB a b m = Map.lookup a (mab m) >>= Map.lookup b
+
+insert ::
+       forall a b v . (Ord a, Ord b) =>
+         a -> b -> v -> PairMap a b v -> PairMap a b v
+insert ai bi v m
+  = PairMap (insert2 ai bi v (mab m)) (insert2 bi ai v (mba m))
+
+deleteA ::
+        forall a b v . (Ord a, Ord b) =>
+          a -> PairMap a b v -> PairMap a b v
+deleteA ai m
+  = PairMap (Map.delete ai (mab m)) (delete2s bs ai (mba m))
+  where
+    bs :: [b]
+    bs = Map.keys (implicitEmpty (Map.lookup ai (mab m)))
+

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
@@ -9,8 +9,7 @@ explicitEmpty :: Ord a => Map a v -> Maybe (Map a v)
 explicitEmpty m = if Map.null m then Nothing else Just m
 
 implicitEmpty :: Ord a => Maybe (Map a v) -> Map a v
-implicitEmpty Nothing = Map.empty
-implicitEmpty (Just x) = x
+implicitEmpty = fromMaybe Map.empty
 
 withEmpty ::
             Ord a => (Map a v -> Map a v) -> Maybe (Map a v) -> Maybe (Map a v)
@@ -38,11 +37,11 @@ data PairMap a b v = PairMap{mab :: Map a (Map b v),
 
 lookupA ::
         forall a b v . (Ord a, Ord b) => a -> PairMap a b v -> Map b v
-lookupA a = fromMaybe Map.empty . Map.lookup a . \ r -> mab r
+lookupA a = implicitEmpty . Map.lookup a . \ r -> mab r
 
 lookupB ::
         forall a b v . (Ord a, Ord b) => b -> PairMap a b v -> Map a v
-lookupB b = fromMaybe Map.empty . Map.lookup b . \ r -> mba r
+lookupB b = implicitEmpty . Map.lookup b . \ r -> mba r
 
 lookupAB ::
          forall a b v . (Ord a, Ord b) => a -> b -> PairMap a b v -> Maybe v


### PR DESCRIPTION
This pull request implements a type `PairMap` which is essentially a map

```agda
PairMap a b v = Map (a × b) v
```

However, this type provides efficient lookup functions

```agda
lookupA : a → PairMap a b v → Map b v
lookupB : b → PairMap a b v → Map a v
```

In database terminology, this type stores rows of the form `a × b × v` and maintains an index on both the first column `a` and the second column `b`.

The datatype is implemented by storing two nested maps `Map a (Map b v)` and `Map b (Map a v)`. The `invariant-equal` expresses that these maps contain the same elements, and we formally prove that this invariant holds.