### PR TITLE
Implement `TxHistory`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -6,6 +6,7 @@ import Cardano.Wallet.Address.Hash
 
 import Cardano.Wallet.Deposit.Pure
 import Cardano.Wallet.Deposit.Pure.Timeline
+import Cardano.Wallet.Deposit.Pure.TxHistory
 import Cardano.Wallet.Deposit.Pure.TxSummary
 
 import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure.agda
@@ -217,7 +217,7 @@ prop-changeAddress-not-Customer s addr =
 
 summarizeTx : WalletState → Tx → Map.Map Address ValueTransfer
 summarizeTx s tx =
-    UTxO.computeValueTransfer (utxo s) du
+    UTxO.valueTransferFromDeltaUTxO (utxo s) du
   where
     du = fst (UTxO.applyTx (isOurs s) tx (utxo s))
 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory.agda
@@ -1,0 +1,3 @@
+module Cardano.Wallet.Deposit.Pure.TxHistory where
+
+open import Cardano.Wallet.Deposit.Pure.TxHistory.Type public

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory.agda
@@ -1,3 +1,4 @@
 module Cardano.Wallet.Deposit.Pure.TxHistory where
 
+open import Cardano.Wallet.Deposit.Pure.TxHistory.Core public
 open import Cardano.Wallet.Deposit.Pure.TxHistory.Type public

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Core.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Core.agda
@@ -1,0 +1,170 @@
+{-# OPTIONS --erasure #-}
+
+module Cardano.Wallet.Deposit.Pure.TxHistory.Core where
+
+open import Haskell.Prelude
+open import Haskell.Reasoning
+
+open import Cardano.Wallet.Deposit.Read using
+    ( Address
+    ; Slot
+    ; SlotNo
+    ; TxId
+    ; WithOrigin
+    )
+open import Cardano.Wallet.Deposit.Pure.TxHistory.Type using
+    ( TxHistory
+    )
+open import Cardano.Wallet.Deposit.Pure.UTxO.Tx using
+    ( ResolvedTx 
+    ; valueTransferFromResolvedTx
+    )
+open import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer using
+    ( ValueTransfer
+    )
+open import Haskell.Data.InverseMap using
+    ( InverseMap
+    )
+open import Haskell.Data.List using
+    ( foldl'
+    ; sortOn
+    )
+open import Haskell.Data.Map using
+    ( Map
+    )
+open import Haskell.Data.Set using
+    ( ℙ
+    )
+
+import Haskell.Data.InverseMap as InverseMap
+import Haskell.Data.Map as Map
+import Haskell.Data.Maps.PairMap as PairMap
+import Haskell.Data.Set as Set
+
+{-# FOREIGN AGDA2HS
+-- Working around a limitation in agda2hs.
+import Cardano.Wallet.Deposit.Pure.TxHistory.Type
+    ( TxHistory (..)
+    )
+import Data.Foldable
+    ( toList
+    )
+#-}
+
+{-----------------------------------------------------------------------------
+    Helpers
+------------------------------------------------------------------------------}
+
+-- | Insert a set of keys into a 'Map' that all have the same value.
+insertManyKeys
+    : ∀ {key v : Set} {{_ : Ord key}} {{_ : Ord v}}
+    → ℙ key → v → Map key v → Map key v
+insertManyKeys keys v m0 =
+    foldl' (\m key → Map.insert key v m) m0 keys
+
+{-# COMPILE AGDA2HS insertManyKeys #-}
+
+{-----------------------------------------------------------------------------
+    Introduction
+------------------------------------------------------------------------------}
+empty : TxHistory
+empty = record
+  { txSlotsByTxId = Map.empty
+  ; txSlotsBySlot = Map.empty
+  ; txTransfers = PairMap.empty
+  ; tip = WithOrigin.Origin
+  }
+
+{-# COMPILE AGDA2HS empty #-}
+
+{-----------------------------------------------------------------------------
+    Observation
+------------------------------------------------------------------------------}
+
+-- | Returns the tip slot.
+getTip : TxHistory → Slot
+getTip = TxHistory.tip
+
+-- | Get the transaction history for a single address.
+getAddressHistory
+  : Address → TxHistory → List (Slot × TxId)
+getAddressHistory address history =
+    sortOn fst (map (λ {(x , y) → (y , x)}) (Map.toAscList txs2))
+  where
+    open TxHistory history
+
+    txs1 : ℙ TxId
+    txs1 = Map.keysSet (PairMap.lookupB address txTransfers)
+
+    txs2 : Map TxId Slot
+    txs2 = Map.restrictKeys txSlotsByTxId txs1
+
+-- | Get the total 'ValueTransfer' in a given slot range.
+getValueTransfers
+  : (Slot × Slot) → TxHistory → Map Address ValueTransfer
+getValueTransfers (from , to) history =
+    foldl' (Map.unionWith (_<>_)) Map.empty txs2
+  where
+    open TxHistory history
+    onlyFuture = Map.dropWhileAntitone (_<= from) txSlotsBySlot
+
+    txs1 : ℙ TxId
+    txs1 = foldMap id (Map.takeWhileAntitone (_<= to) txSlotsBySlot)
+
+    txs2 : List (Map Address ValueTransfer)
+    txs2 = map (λ tx → PairMap.lookupA tx txTransfers) (toList txs1)
+
+{-# COMPILE AGDA2HS getTip #-}
+{-# COMPILE AGDA2HS getAddressHistory #-}
+{-# COMPILE AGDA2HS getValueTransfers #-}
+
+{-----------------------------------------------------------------------------
+    Operations
+------------------------------------------------------------------------------}
+
+rollForward : SlotNo → List (TxId × ResolvedTx) → TxHistory → TxHistory
+rollForward new txs history =
+    if WithOrigin.At new <= getTip history
+    then history
+    else record
+        { txSlotsBySlot = InverseMap.insertManyKeys txids slot txSlotsBySlot
+        ; txSlotsByTxId = insertManyKeys txids slot txSlotsByTxId
+        ; txTransfers = foldl' insertValueTransfer txTransfers txs
+        ; tip = WithOrigin.At new
+        }
+  where
+    open TxHistory history
+
+    slot = WithOrigin.At new
+    txids = Set.fromList (map fst txs)
+
+    insertValueTransfer
+      : PairMap.PairMap TxId Address ValueTransfer
+      → TxId × ResolvedTx
+      → PairMap.PairMap TxId Address ValueTransfer
+    insertValueTransfer m0 (txid , tx) =
+        foldl' (uncurry ∘ fun) m0 (Map.toAscList mv)
+      where
+        mv = valueTransferFromResolvedTx tx
+        fun = λ m addr v → PairMap.insert txid addr v m
+
+rollBackward : Slot → TxHistory → TxHistory
+rollBackward new history = 
+    if new > getTip history
+    then history
+    else record
+        { txSlotsBySlot = leftSlots
+        ; txSlotsByTxId = Map.withoutKeys txSlotsByTxId rolledTxIds
+        ; txTransfers = PairMap.withoutKeysA txTransfers rolledTxIds
+        ; tip = new
+        }
+  where 
+    open TxHistory history
+    spanSlots = Map.spanAntitone (_<= new) txSlotsBySlot
+    leftSlots = fst spanSlots
+    rolledSlots = snd spanSlots
+    rolledTxIds =
+        foldMap id rolledSlots
+
+{-# COMPILE AGDA2HS rollForward #-}
+{-# COMPILE AGDA2HS rollBackward #-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Type.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Type.agda
@@ -1,0 +1,54 @@
+{-# OPTIONS --erasure #-}
+
+module Cardano.Wallet.Deposit.Pure.TxHistory.Type where
+
+open import Haskell.Prelude
+
+open import Cardano.Wallet.Deposit.Read using
+    ( Address
+    ; Slot
+    ; TxId
+    )
+open import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer using
+    ( ValueTransfer
+    )
+open import Haskell.Data.InverseMap using
+    ( InverseMap
+    )
+open import Haskell.Data.Map using
+    ( Map
+    )
+open import Haskell.Data.Maps.PairMap using
+    ( PairMap
+    )
+
+import Haskell.Data.Maps.PairMap as PairMap
+
+{-----------------------------------------------------------------------------
+    Data type
+------------------------------------------------------------------------------}
+
+{-| Tx History.
+
+History of the transactions to and from the Deposit Wallet.
+Information includes:
+
+* Slot of each transaction
+* Value transfer for each transaction, indexed by address
+
+-}
+record TxHistory : Set where
+  field
+    txSlotsByTxId : Map TxId Slot
+    txSlotsBySlot : InverseMap TxId Slot
+        -- ^ Map from transactions to slots
+    
+    txTransfers : PairMap TxId Address ValueTransfer
+        -- ^ Map from (transaction × address) to ValueTransfer
+
+    tip : Slot
+        -- ^ Current tip slot.
+
+open TxHistory public
+
+{-# COMPILE AGDA2HS TxHistory #-}

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/List.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/List.agda
@@ -2,6 +2,10 @@ module Haskell.Data.List where
 
 open import Haskell.Prelude
 
+open import Haskell.Data.List.Prop using
+    ( isSorted
+    )
+
 {-# FOREIGN AGDA2HS
 {-# LANGUAGE UnicodeSyntax #-}
 import qualified Data.List
@@ -20,4 +24,22 @@ foldl' = foldl
 foldl'
   :: Foldable t => (b -> a -> b) -> b -> t a -> b
 foldl' = Data.List.foldl'
+#-}
+
+postulate
+  sortOn : {{_ : Ord b}} → (a → b) → List a → List a
+
+  prop-sortOn-isSorted
+    : {{_ : Ord b}}
+    → ∀ (xs : List a) (f : a → b)
+    → isSorted (map f (sortOn f xs)) ≡ True
+
+  prop-sortOn-equal
+    : {{_ : Eq a}} → {{_ : Ord b}}
+    → ∀ (x : a) (xs : List a) (f : a → b)
+    → elem x (sortOn f xs) ≡ elem x xs
+
+{-# FOREIGN AGDA2HS
+sortOn :: Ord b => (a → b) → [a] → [a]
+sortOn = Data.List.sortOn
 #-}

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/List/Prop.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/List/Prop.agda
@@ -7,3 +7,6 @@ open import Haskell.Prelude
 -- | Predicate version of list membership.
 _∈_ : ∀ {a : Set} {{_ : Eq a}} → a → List a → Set
 x ∈ xs = elem x xs ≡ True
+
+isSorted : ∀ {{_ : Ord a}} → List a → Bool
+isSorted xs = and (zipWith (_<=_) xs (drop 1 xs))

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
@@ -511,6 +511,7 @@ module _ {a b v : Set} {{_ : Ord a}} {{_ : Ord b}} where
     ∎
 
 {-# COMPILE AGDA2HS PairMap #-}
+{-# COMPILE AGDA2HS empty #-}
 {-# COMPILE AGDA2HS lookupA #-}
 {-# COMPILE AGDA2HS lookupB #-}
 {-# COMPILE AGDA2HS lookupAB #-}

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
@@ -14,6 +14,9 @@ open import Haskell.Data.Maybe using
 open import Haskell.Data.Map using
     ( Map
     )
+open import Haskell.Data.Set using
+    ( ℙ
+    )
 
 import Haskell.Data.Map as Map
 
@@ -489,6 +492,9 @@ module _ {a b v : Set} {{_ : Ord a}} {{_ : Ord b}} where
           Nothing
         ∎
 
+  withoutKeysA : PairMap a b v → ℙ a → PairMap a b v
+  withoutKeysA m0 xs = foldl' (λ m x → deleteA x m) m0 xs
+
   @0 prop-lookupA-lookupB
     : ∀ (x : a) (y : b) (m : PairMap a b v)
     → Map.lookup y (lookupA x m)
@@ -510,3 +516,4 @@ module _ {a b v : Set} {{_ : Ord a}} {{_ : Ord b}} where
 {-# COMPILE AGDA2HS lookupAB #-}
 {-# COMPILE AGDA2HS insert #-}
 {-# COMPILE AGDA2HS deleteA #-}
+{-# COMPILE AGDA2HS withoutKeysA #-}

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -75,6 +75,8 @@ library
     Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
     Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
     Cardano.Wallet.Deposit.Pure.Timeline
+    Cardano.Wallet.Deposit.Pure.TxHistory
+    Cardano.Wallet.Deposit.Pure.TxHistory.Type
     Cardano.Wallet.Deposit.Pure.TxSummary
     Cardano.Wallet.Deposit.Read
     Cardano.Wallet.Deposit.Read.Value

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -76,6 +76,7 @@ library
     Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
     Cardano.Wallet.Deposit.Pure.Timeline
     Cardano.Wallet.Deposit.Pure.TxHistory
+    Cardano.Wallet.Deposit.Pure.TxHistory.Core
     Cardano.Wallet.Deposit.Pure.TxHistory.Type
     Cardano.Wallet.Deposit.Pure.TxSummary
     Cardano.Wallet.Deposit.Read

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory.hs
@@ -1,0 +1,5 @@
+module Cardano.Wallet.Deposit.Pure.TxHistory
+    ( module Cardano.Wallet.Deposit.Pure.TxHistory.Type
+    ) where
+
+import Cardano.Wallet.Deposit.Pure.TxHistory.Type

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory.hs
@@ -1,5 +1,7 @@
 module Cardano.Wallet.Deposit.Pure.TxHistory
-    ( module Cardano.Wallet.Deposit.Pure.TxHistory.Type
+    ( module Cardano.Wallet.Deposit.Pure.TxHistory.Core
+    , module Cardano.Wallet.Deposit.Pure.TxHistory.Type
     ) where
 
+import Cardano.Wallet.Deposit.Pure.TxHistory.Core
 import Cardano.Wallet.Deposit.Pure.TxHistory.Type

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
@@ -1,0 +1,12 @@
+module Cardano.Wallet.Deposit.Pure.TxHistory.Type where
+
+import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer (ValueTransfer)
+import Cardano.Wallet.Deposit.Read (Address, Slot, TxId)
+import Haskell.Data.InverseMap (InverseMap)
+import Haskell.Data.Map (Map)
+import Haskell.Data.Maps.PairMap (PairMap)
+
+data TxHistory = TxHistory{txSlotsByTxId :: Map TxId Slot,
+                           txSlotsBySlot :: InverseMap TxId Slot,
+                           txTransfers :: PairMap TxId Address ValueTransfer, tip :: Slot}
+

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
@@ -65,9 +65,9 @@ groupByAddress :: UTxO -> Map.Map Read.Address Read.Value
 groupByAddress
   = Map.fromListWith (<>) . map pairFromTxOut . Map.elems
 
-computeValueTransfer ::
-                     UTxO -> DeltaUTxO -> Map.Map Read.Address ValueTransfer
-computeValueTransfer u0 du = Map.unionWith (<>) ins outs
+valueTransferFromDeltaUTxO ::
+                           UTxO -> DeltaUTxO -> Map.Map Read.Address ValueTransfer
+valueTransferFromDeltaUTxO u0 du = Map.unionWith (<>) ins outs
   where
     u1 :: UTxO
     u1 = UTxO.restrictedBy u0 (excluded du)
@@ -75,4 +75,13 @@ computeValueTransfer u0 du = Map.unionWith (<>) ins outs
     ins = Map.map fromSpent (groupByAddress u1)
     outs :: Map.Map Read.Address ValueTransfer
     outs = Map.map fromReceived (groupByAddress (received du))
+
+valueTransferFromResolvedTx ::
+                            ResolvedTx -> Map.Map Read.Address ValueTransfer
+valueTransferFromResolvedTx tx = valueTransferFromDeltaUTxO u0 du
+  where
+    u0 :: UTxO
+    u0 = resolvedInputs tx
+    du :: DeltaUTxO
+    du = fst (applyTx (\ _ -> True) (resolvedTx tx) u0)
 

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/List.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/List.hs
@@ -9,3 +9,6 @@ foldl'
   :: Foldable t => (b -> a -> b) -> b -> t a -> b
 foldl' = Data.List.foldl'
 
+sortOn :: Ord b => (a ->b) ->[a] ->[a]
+sortOn = Data.List.sortOn
+

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Haskell.Data.Maps.PairMap where
 
+import Data.Set (Set)
+import Haskell.Data.List (foldl')
 import Haskell.Data.Map (Map)
 import qualified Haskell.Data.Map as Map (delete, empty, insert, keys, lookup, null, update)
 import Haskell.Data.Maybe (fromMaybe)
@@ -61,4 +63,9 @@ deleteA ai m
   where
     bs :: [b]
     bs = Map.keys (implicitEmpty (Map.lookup ai (mab m)))
+
+withoutKeysA ::
+             forall a b v . (Ord a, Ord b) =>
+               PairMap a b v -> Set a -> PairMap a b v
+withoutKeysA m0 xs = foldl' (\ m x -> deleteA x m) m0 xs
 

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
@@ -37,6 +37,9 @@ delete2s xs b m0 = foldr (\ a -> delete2 a b) m0 xs
 data PairMap a b v = PairMap{mab :: Map a (Map b v),
                              mba :: Map b (Map a v)}
 
+empty :: forall a b v . (Ord a, Ord b) => PairMap a b v
+empty = PairMap Map.empty Map.empty
+
 lookupA ::
         forall a b v . (Ord a, Ord b) => a -> PairMap a b v -> Map b v
 lookupA a = implicitEmpty . Map.lookup a . \ r -> mab r


### PR DESCRIPTION
This pull request implements a type `TxHistory` which represents a history of transactions. This data type supports the following efficient queries:

* `getAddressHistory` — Return a list of transactions that involve a given address.
* `getValueTransfers` — Given a range of slots, return the total `ValueTransfer` by address.