### PR TITLE
Move `InverseMap` to `Haskell.Data.Maps.InverseMap`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Everything.agda
@@ -15,6 +15,7 @@ import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
 
 import Haskell.Data.List
+import Haskell.Data.Maps.InverseMap
 import Haskell.Data.Maps.PairMap
 import Haskell.Data.Maps.Timeline
 import Haskell.Data.Word.Odd

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/InverseMap.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/InverseMap.agda
@@ -1,5 +1,5 @@
 -- | A type representing the inverse of a 'Map'
-module Haskell.Data.InverseMap where
+module Haskell.Data.Maps.InverseMap where
 
 open import Haskell.Prelude
 

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
@@ -17,7 +17,7 @@ open import Haskell.Data.Set using
     ( ℙ
     )
 
-import Haskell.Data.InverseMap as InverseMap
+import Haskell.Data.Maps.InverseMap as InverseMap
 import Haskell.Data.Map as Map
 import Haskell.Data.Set as Set
 

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -83,9 +83,9 @@ library
     Cardano.Write.Tx.Balance
   other-modules:
     Haskell.Data.ByteString
-    Haskell.Data.InverseMap
     Haskell.Data.List
     Haskell.Data.Map
+    Haskell.Data.Maps.InverseMap
     Haskell.Data.Maps.PairMap
     Haskell.Data.Maps.Timeline
     Haskell.Data.Maybe

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/InverseMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/InverseMap.hs
@@ -1,4 +1,4 @@
-module Haskell.Data.InverseMap where
+module Haskell.Data.Maps.InverseMap where
 
 import Data.Set (Set)
 import Haskell.Data.List (foldl')

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
@@ -2,10 +2,10 @@
 module Haskell.Data.Maps.Timeline where
 
 import Data.Set (Set)
-import qualified Haskell.Data.InverseMap as InverseMap (InverseMap, difference, insertManyKeys)
 import Haskell.Data.List (foldl')
 import Haskell.Data.Map (Map)
 import qualified Haskell.Data.Map as Map (empty, insert, lookup, restrictKeys, spanAntitone, toAscList, withoutKeys)
+import qualified Haskell.Data.Maps.InverseMap as InverseMap (InverseMap, difference, insertManyKeys)
 import Haskell.Data.Maybe (fromMaybe)
 import qualified Haskell.Data.Set as Set (empty, toAscList)
 


### PR DESCRIPTION
This pull request moves `InverseMap` to the colorful collection of map data types in `Haskell.Data.Maps.*`.