### PR TITLE
Partially match the `Specification` with the implementation

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Implementation.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Implementation.agda
@@ -1,0 +1,111 @@
+-- | The purpose of this module is for the compiler to check that
+-- the specification has been implemented.
+--
+-- The following pragma indicates that some proofs are still work-in-progress.
+-- The specification has been implemented correctly when the following
+-- pragma can be successfully removed from this file.
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module Cardano.Wallet.Deposit.Implementation where
+
+open import Haskell.Prelude
+open import Haskell.Reasoning
+
+open import Cardano.Wallet.Deposit.Pure using
+    ( TxSummary
+    ; ValueTransfer
+    ; WalletState
+    )
+open import Cardano.Wallet.Deposit.Read using
+    ( Address
+    ; Slot
+    ; Tx
+    ; TxBody
+    ; TxId
+    ; TxOut
+    ; Value
+    )
+
+import Cardano.Wallet.Deposit.Pure as Wallet
+import Cardano.Wallet.Deposit.Read as Read
+import Haskell.Data.Map as Map
+
+import Specification
+
+module DepositWallet =
+    Specification.DepositWallet
+        WalletState
+        Address
+        Tx
+        TxBody
+        TxId
+        Slot
+        Value
+        ⊤
+
+{-----------------------------------------------------------------------------
+    Operations
+------------------------------------------------------------------------------}
+fromValueTransfer : ValueTransfer → DepositWallet.ValueTransfer
+fromValueTransfer x = record
+    { spent = spent
+    ; received = received
+    }
+  where
+    open ValueTransfer x
+
+fromTxSummary : TxSummary → DepositWallet.TxSummary
+fromTxSummary x =
+    (Read.slotFromChainPoint point , summarizedTx , fromValueTransfer transfer)
+  where
+    open TxSummary x
+
+operations : DepositWallet.Operations
+operations = record
+  { listCustomers = Wallet.listCustomers
+  ; createAddress = Wallet.createAddress
+  ; availableBalance = Wallet.availableBalance
+  ; applyTx = Wallet.applyTx
+  ; getCustomerHistory = λ customer →
+    map fromTxSummary ∘ Wallet.getCustomerHistory customer
+  ; createPayment = λ destinations tt s →
+    Wallet.createPayment destinations s
+  }
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+-- Helper function
+pairFromTxOut : Read.TxOut → (Read.Address × Read.Value)
+pairFromTxOut =
+    λ txout → (Read.TxOut.address txout , Read.TxOut.value txout)
+
+@0 properties : DepositWallet.Properties operations
+properties = record
+    { prop-create-known = Wallet.prop-create-known
+    ; deriveAddress = Wallet.deriveCustomerAddress ∘ Wallet.getXPub
+    ; prop-create-derive = Wallet.prop-create-derive
+
+    ; summarize = {!  !}
+    ; prop-getAddressHistory-summary = {!  !}
+    ; prop-tx-known-address = {!   !}
+
+    ; totalValue = Wallet.totalValue
+    ; maxFee = Wallet.maxFee
+    ; exceeds = λ v1 v2 → Wallet.largerOrEqual v1 v2 ≡ True
+    ; _<>_ = _<>_
+    ; prop-createPayment-success = {!   !}
+    ; outputs = map pairFromTxOut ∘ TxBody.outputs
+    ; prop-createPayment-pays = {!   !}
+    ; prop-createPayment-not-known =
+        λ _ s destinations tx eq1 address eq2 neq3 rel4 →
+            Wallet.prop-createPayment-not-known
+                s destinations tx eq1 address eq2 neq3
+                (subst (Specification._∈_ address) (lem1 (TxBody.outputs tx)) rel4)
+    }
+  where
+    lem1
+      : ∀ (xs : List TxOut)
+      → map fst (map pairFromTxOut xs)
+      ≡ map Read.address xs
+    lem1 xs = sym (map-∘ fst pairFromTxOut xs)

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure.agda
@@ -49,22 +49,28 @@ import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 open import Cardano.Wallet.Address.BIP32_Ed25519 using
     ( XPub
     )
+open import Cardano.Wallet.Deposit.Pure.Address public using
+    ( deriveCustomerAddress
+    )
 open import Cardano.Wallet.Deposit.Pure.Address using
     ( Customer
-    ; deriveCustomerAddress
     ; AddressState
     )
 open import Cardano.Wallet.Deposit.Pure.UTxO.UTxO using
     ( UTxO
     )
-open import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer using
+open import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer public using
     ( ValueTransfer
-      ; fromSpent
-      ; fromReceived
+    )
+open import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer using
+    ( fromSpent
+    ; fromReceived
+    )
+open import Cardano.Wallet.Deposit.Pure.TxSummary public using
+    ( TxSummary
     )
 open import Cardano.Wallet.Deposit.Pure.TxSummary using
-    ( TxSummary
-      ; mkTxSummary
+    ( mkTxSummary
     )
 open import Cardano.Wallet.Deposit.Read using
     ( Address
@@ -78,6 +84,9 @@ open import Cardano.Wallet.Deposit.Read using
     ; TxIn
     ; TxOut
     ; Value
+    )
+open import Cardano.Wallet.Deposit.Read.Value public using
+    ( largerOrEqual
     )
 open import Cardano.Write.Tx.Balance using
     ( ChangeAddressGen
@@ -326,7 +335,7 @@ totalValue = mconcat ∘ map snd
 prop-createPayment-success
     : ∀ (s : WalletState)
         (destinations : List (Address × Value))
-    → exceeds (availableBalance s) (totalValue destinations <> maxFee) ≡ True
+    → largerOrEqual (availableBalance s) (totalValue destinations <> maxFee) ≡ True
     → isJust (createPayment destinations s) ≡ True
 prop-createPayment-success = λ s destinations x → {!   !}
 -}

--- a/lib/customer-deposit-wallet-pure/agda/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Everything.agda
@@ -14,6 +14,9 @@ import Cardano.Wallet.Deposit.Pure.UTxO.Tx
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
 
+import Cardano.Wallet.Deposit.Implementation
+import Specification
+
 import Haskell.Data.List
 import Haskell.Data.Maps.InverseMap
 import Haskell.Data.Maps.PairMap


### PR DESCRIPTION
This pull request adds a module `Cardano.Wallet.Deposit.Implementation`. This module uses the implemented functions to defines two values `operations` and `properties` that have types which are imported from the specification document. If these values are completely defined and the compiler accepts them, this means we have an implementation which satisfies the specification.

Currently, the `properties` still contains some unsolved metavariables, i.e. incomplete proofs. However, the proof for `prop-createPayment-not-known` is complete.

### Comments

* This pull request is mainly an exercise in how to combine implementation and specification. The purpose of a specification is to be human-readable, while the focus of an implementation is to contain enough details to be machine-executable. This brings some challenges when importing modules / concepts — a human-readable specification may only import other human-readable specifications, not implementations. For example, consider this question: May a specification import `Data.Map`?