### PR TITLE
Automatically use `fourmolu` on generated Haskell code

### DIFF
--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,24 @@
+comma-style: leading
+function-arrows: leading
+import-export-style: leading
+fixities:
+  - infixl 9 . 
+  - infixl 5 ++ 
+  - infixr 4 <$ 
+  - infixr 1 >>, >>= 
+  - infixr 1 =<< 
+  - infixl 0 $, $! 
+  - infixl 4 <*>, <*, *>, <**> 
+  - infixl 6 <> 
+  - infixl 7 <+> 
+  - infixl 3 <|> 
+  - infixr 5 :|
+haddock-style: single-line
+in-style: left-align
+indent-wheres: false
+indentation: 4
+let-style: auto
+newlines-between-decls: 1
+record-brace-space: false
+column-limit: 80
+single-constraint-parens: auto

--- a/lib/customer-deposit-wallet-pure/generate-haskell.sh
+++ b/lib/customer-deposit-wallet-pure/generate-haskell.sh
@@ -5,7 +5,8 @@ agda2hs \
     --no-default-libraries \
     --config agda2hs-rewrites.yaml \
     -o ./haskell/ \
-    ./agda/${ROOT}
+    ./agda/${ROOT} \
+    && fourmolu -i ./haskell/
 
 # agda \
 #     --no-default-libraries \

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
@@ -1,19 +1,21 @@
 {-# LANGUAGE StandaloneDeriving #-}
+
 module Cardano.Wallet.Address.BIP32 where
 
 import Data.Word.Odd (Word31)
 
-data DerivationType = Soft
-                    | Hardened
+data DerivationType
+    = Soft
+    | Hardened
 
 deriving instance Eq DerivationType
 
 deriving instance Ord DerivationType
 
-data BIP32Path = Root
-               | Segment BIP32Path DerivationType Word31
+data BIP32Path
+    = Root
+    | Segment BIP32Path DerivationType Word31
 
 deriving instance Eq BIP32Path
 
 deriving instance Ord BIP32Path
-

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
@@ -2,21 +2,20 @@
 
 module Cardano.Wallet.Address.BIP32_Ed25519 where
 
-
-import Data.ByteString
-  ( ByteString
-  )
-import Data.Maybe
-  ( fromJust
-  )
-import Data.Word
-  ( Word32
-  )
-import Data.Word.Odd
-  ( Word31
-  )
 import qualified Cardano.Crypto.Wallet as CC
+import Data.ByteString
+    ( ByteString
+    )
 import qualified Data.ByteString as BS
+import Data.Maybe
+    ( fromJust
+    )
+import Data.Word
+    ( Word32
+    )
+import Data.Word.Odd
+    ( Word31
+    )
 
 -- FIXME: We define type synonyms here so that
 -- they can be exported. Ideally, we would re-export from
@@ -25,50 +24,50 @@ type XPub = CC.XPub
 type XPrv = CC.XPrv
 type XSignature = CC.XSignature
 
-toXPub :: XPrv ->XPub
+toXPub :: XPrv -> XPub
 toXPub = CC.toXPub
 
-sign :: XPrv ->ByteString ->XSignature
+sign :: XPrv -> ByteString -> XSignature
 sign = CC.sign BS.empty
 
-verify :: XPub ->ByteString ->XSignature ->Bool
+verify :: XPub -> ByteString -> XSignature -> Bool
 verify = CC.verify
 
-rawSerialiseXPub :: XPub ->ByteString
+rawSerialiseXPub :: XPub -> ByteString
 rawSerialiseXPub = CC.unXPub
 
-rawSerialiseXPrv :: XPrv ->ByteString
+rawSerialiseXPrv :: XPrv -> ByteString
 rawSerialiseXPrv = CC.unXPrv
 
-rawSerialiseXSignature :: XSignature ->ByteString
+rawSerialiseXSignature :: XSignature -> ByteString
 rawSerialiseXSignature = CC.unXSignature
 
-word32fromWord31 :: Word31 ->Word32
+word32fromWord31 :: Word31 -> Word32
 word32fromWord31 = fromInteger . toInteger
 
-deriveXPubSoft :: XPub ->Word31 ->XPub
+deriveXPubSoft :: XPub -> Word31 -> XPub
 deriveXPubSoft xpub ix =
-  fromJust
-    (CC.deriveXPub
-      CC.DerivationScheme2
-      xpub
-      (word32fromWord31 ix)
-    )
-  -- deriveXPub always returns Just on Word31
+    fromJust
+        ( CC.deriveXPub
+            CC.DerivationScheme2
+            xpub
+            (word32fromWord31 ix)
+        )
 
-deriveXPrvSoft :: XPrv ->Word31 ->XPrv
+-- deriveXPub always returns Just on Word31
+
+deriveXPrvSoft :: XPrv -> Word31 -> XPrv
 deriveXPrvSoft xprv ix =
-  CC.deriveXPrv
-    CC.DerivationScheme2
-    BS.empty
-    xprv
-    (word32fromWord31 ix)
+    CC.deriveXPrv
+        CC.DerivationScheme2
+        BS.empty
+        xprv
+        (word32fromWord31 ix)
 
-deriveXPrvHard :: XPrv ->Word31 ->XPrv
+deriveXPrvHard :: XPrv -> Word31 -> XPrv
 deriveXPrvHard xprv ix =
-  CC.deriveXPrv
-    CC.DerivationScheme2
-    BS.empty
-    xprv
-    (0x80000000 + word32fromWord31 ix)
-
+    CC.deriveXPrv
+        CC.DerivationScheme2
+        BS.empty
+        xprv
+        (0x80000000 + word32fromWord31 ix)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
@@ -10,6 +10,5 @@ tagEnterprise :: Word8
 tagEnterprise = 97
 
 mkEnterpriseAddress :: XPub -> Addr
-mkEnterpriseAddress xpub
-  = singleton tagEnterprise <> blake2b'224 (rawSerialiseXPub xpub)
-
+mkEnterpriseAddress xpub =
+    singleton tagEnterprise <> blake2b'224 (rawSerialiseXPub xpub)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Hash.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Hash.hs
@@ -2,22 +2,20 @@
 
 module Cardano.Wallet.Address.Hash where
 
-
 import Cardano.Crypto.Hash
-  ( Blake2b_224
-  , Blake2b_256
-  , HashAlgorithm (digest)
-  )
+    ( Blake2b_224
+    , Blake2b_256
+    , HashAlgorithm (digest)
+    )
 import Data.ByteString
-  ( ByteString
-  )
+    ( ByteString
+    )
 import Data.Proxy
-  ( Proxy (..)
-  )
+    ( Proxy (..)
+    )
 
-blake2b'224 :: ByteString ->ByteString
+blake2b'224 :: ByteString -> ByteString
 blake2b'224 = digest (Proxy :: Proxy Blake2b_224)
 
-blake2b'256 :: ByteString ->ByteString
+blake2b'256 :: ByteString -> ByteString
 blake2b'256 = digest (Proxy :: Proxy Blake2b_256)
-

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure.hs
@@ -1,35 +1,50 @@
 module Cardano.Wallet.Deposit.Pure where
 
 import Cardano.Wallet.Address.BIP32_Ed25519 (XPub)
-import Cardano.Wallet.Deposit.Read (Address, Block(transactions), ChainPoint, Tx, TxBody, TxOut(TxOutC), chainPointFromBlock)
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    , Block (transactions)
+    , ChainPoint
+    , Tx
+    , TxBody
+    , TxOut (TxOutC)
+    , chainPointFromBlock
+    )
 import Cardano.Wallet.Deposit.Read.Value (Value)
-import Cardano.Write.Tx.Balance (ChangeAddressGen, PartialTx(PartialTxC), balanceTransaction)
+import Cardano.Write.Tx.Balance
+    ( ChangeAddressGen
+    , PartialTx (PartialTxC)
+    , balanceTransaction
+    )
 import qualified Haskell.Data.Map as Map (Map, lookup)
 
 -- Working around a limitation in agda2hs.
 import Cardano.Wallet.Deposit.Pure.Address
-    ( Customer
-    , AddressState
+    ( AddressState
+    , Customer
     )
-import Cardano.Wallet.Deposit.Pure.UTxO.UTxO
-    ( UTxO
-    )
+import qualified Cardano.Wallet.Deposit.Pure.Address as Addr
 import Cardano.Wallet.Deposit.Pure.TxSummary
     ( TxSummary
     )
-import qualified Cardano.Wallet.Deposit.Pure.Address as Addr
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.Tx as UTxO
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO
+    ( UTxO
+    )
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 
-data WalletState = WalletState{addresses :: AddressState,
-                               utxo :: UTxO, txSummaries :: Map.Map Customer [TxSummary],
-                               localTip :: ChainPoint}
+data WalletState = WalletState
+    { addresses :: AddressState
+    , utxo :: UTxO
+    , txSummaries :: Map.Map Customer [TxSummary]
+    , localTip :: ChainPoint
+    }
 
 getXPub :: WalletState -> XPub
-getXPub = Addr.getXPub . \ r -> addresses r
+getXPub = Addr.getXPub . \r -> addresses r
 
 listCustomers :: WalletState -> [(Customer, Address)]
-listCustomers = Addr.listCustomers . \ r -> addresses r
+listCustomers = Addr.listCustomers . \r -> addresses r
 
 createAddress :: Customer -> WalletState -> (Address, WalletState)
 createAddress c s0 = (addr, s1)
@@ -47,43 +62,46 @@ isOurs :: WalletState -> Address -> Bool
 isOurs s = Addr.isOurs (addresses s)
 
 knownCustomerAddress :: Address -> WalletState -> Bool
-knownCustomerAddress address
-  = elem address . map (\ r -> snd r) . listCustomers
+knownCustomerAddress address =
+    elem address . map (\r -> snd r) . listCustomers
 
 newChangeAddress :: WalletState -> ChangeAddressGen ()
-newChangeAddress = Addr.newChangeAddress . \ r -> addresses r
+newChangeAddress = Addr.newChangeAddress . \r -> addresses r
 
 getCustomerHistory :: WalletState -> Customer -> [TxSummary]
 getCustomerHistory s c = concat (Map.lookup c (txSummaries s))
 
 availableBalance :: WalletState -> Value
-availableBalance = UTxO.balance . \ r -> utxo r
+availableBalance = UTxO.balance . \r -> utxo r
 
 applyTx :: Tx -> WalletState -> WalletState
 applyTx tx s0 = s1
   where
     s1 :: WalletState
-    s1
-      = WalletState (addresses s0)
-          (snd (UTxO.applyTx (isOurs s0) tx (utxo s0)))
-          (txSummaries s0)
-          (localTip s0)
+    s1 =
+        WalletState
+            (addresses s0)
+            (snd (UTxO.applyTx (isOurs s0) tx (utxo s0)))
+            (txSummaries s0)
+            (localTip s0)
 
 rollForwardOne :: Block -> WalletState -> WalletState
-rollForwardOne block s0
-  = WalletState (addresses s1) (utxo s1) (txSummaries s1)
-      (chainPointFromBlock block)
+rollForwardOne block s0 =
+    WalletState
+        (addresses s1)
+        (utxo s1)
+        (txSummaries s1)
+        (chainPointFromBlock block)
   where
     s1 :: WalletState
-    s1 = foldl (\ s tx -> applyTx tx s) s0 (transactions block)
+    s1 = foldl (\s tx -> applyTx tx s) s0 (transactions block)
 
 txOutFromPair :: (Address, Value) -> TxOut
 txOutFromPair (x, y) = TxOutC x y
 
 createPayment :: [(Address, Value)] -> WalletState -> Maybe TxBody
-createPayment destinations s
-  = balanceTransaction (utxo s) (newChangeAddress s) () partialTx
+createPayment destinations s =
+    balanceTransaction (utxo s) (newChangeAddress s) () partialTx
   where
     partialTx :: PartialTx
     partialTx = PartialTxC (map txOutFromPair destinations)
-

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -1,6 +1,9 @@
 module Cardano.Wallet.Deposit.Pure.Address where
 
-import Cardano.Wallet.Address.BIP32 (BIP32Path(Root, Segment), DerivationType(Hardened, Soft))
+import Cardano.Wallet.Address.BIP32
+    ( BIP32Path (Root, Segment)
+    , DerivationType (Hardened, Soft)
+    )
 import Cardano.Wallet.Address.BIP32_Ed25519 (XPub, deriveXPubSoft)
 import Cardano.Wallet.Address.Encoding (mkEnterpriseAddress)
 import Cardano.Wallet.Deposit.Read (Address)
@@ -12,61 +15,66 @@ import Haskell.Data.Maybe (isJust)
 
 type Customer = Word31
 
-data DerivationPath = DerivationCustomer Customer
-                    | DerivationChange
+data DerivationPath
+    = DerivationCustomer Customer
+    | DerivationChange
 
 toBIP32Path :: DerivationPath -> BIP32Path
 toBIP32Path = addSuffix prefix
   where
     prefix :: BIP32Path
-    prefix
-      = Segment (Segment (Segment Root Hardened 1857) Hardened 1815)
-          Hardened
-          0
+    prefix =
+        Segment
+            (Segment (Segment Root Hardened 1857) Hardened 1815)
+            Hardened
+            0
     addSuffix :: BIP32Path -> DerivationPath -> BIP32Path
     addSuffix path DerivationChange = Segment path Soft 1
-    addSuffix path (DerivationCustomer c)
-      = Segment (Segment path Soft 0) Soft c
+    addSuffix path (DerivationCustomer c) =
+        Segment (Segment path Soft 0) Soft c
 
 xpubFromDerivationPath :: XPub -> DerivationPath -> XPub
-xpubFromDerivationPath xpub DerivationChange
-  = deriveXPubSoft xpub 1
-xpubFromDerivationPath xpub (DerivationCustomer c)
-  = deriveXPubSoft (deriveXPubSoft xpub 0) c
+xpubFromDerivationPath xpub DerivationChange =
+    deriveXPubSoft xpub 1
+xpubFromDerivationPath xpub (DerivationCustomer c) =
+    deriveXPubSoft (deriveXPubSoft xpub 0) c
 
 deriveAddress :: XPub -> DerivationPath -> Address
-deriveAddress xpub
-  = mkEnterpriseAddress . xpubFromDerivationPath xpub
+deriveAddress xpub =
+    mkEnterpriseAddress . xpubFromDerivationPath xpub
 
 deriveCustomerAddress :: XPub -> Customer -> Address
-deriveCustomerAddress xpub c
-  = deriveAddress xpub (DerivationCustomer c)
+deriveCustomerAddress xpub c =
+    deriveAddress xpub (DerivationCustomer c)
 
-data AddressState = AddressStateC{stateXPub :: XPub,
-                                  addresses :: Map.Map Address Customer, change :: Address}
+data AddressState = AddressStateC
+    { stateXPub :: XPub
+    , addresses :: Map.Map Address Customer
+    , change :: Address
+    }
 
 isCustomerAddress :: AddressState -> Address -> Bool
-isCustomerAddress s
-  = \ addr -> isJust $ Map.lookup addr (addresses s)
+isCustomerAddress s =
+    \addr -> isJust $ Map.lookup addr (addresses s)
 
 isChangeAddress :: AddressState -> Address -> Bool
-isChangeAddress = \ s -> (change s ==)
+isChangeAddress = \s -> (change s ==)
 
 isOurs :: AddressState -> Address -> Bool
-isOurs
-  = \ s addr -> isChangeAddress s addr || isCustomerAddress s addr
+isOurs =
+    \s addr -> isChangeAddress s addr || isCustomerAddress s addr
 
-getDerivationPath'cases ::
-                        AddressState -> Address -> Maybe Customer -> Maybe DerivationPath
-getDerivationPath'cases s addr (Just c)
-  = Just (DerivationCustomer c)
-getDerivationPath'cases s addr Nothing
-  = if isChangeAddress s addr then Just DerivationChange else Nothing
+getDerivationPath'cases
+    :: AddressState -> Address -> Maybe Customer -> Maybe DerivationPath
+getDerivationPath'cases s addr (Just c) =
+    Just (DerivationCustomer c)
+getDerivationPath'cases s addr Nothing =
+    if isChangeAddress s addr then Just DerivationChange else Nothing
 
-getDerivationPath ::
-                  AddressState -> Address -> Maybe DerivationPath
-getDerivationPath s addr
-  = getDerivationPath'cases s addr (Map.lookup addr (addresses s))
+getDerivationPath
+    :: AddressState -> Address -> Maybe DerivationPath
+getDerivationPath s addr =
+    getDerivationPath'cases s addr (Map.lookup addr (addresses s))
 
 getBIP32Path :: AddressState -> Address -> Maybe BIP32Path
 getBIP32Path s = fmap toBIP32Path . getDerivationPath s
@@ -75,14 +83,14 @@ swap :: (a, b) -> (b, a)
 swap (x, y) = (y, x)
 
 listCustomers :: AddressState -> [(Customer, Address)]
-listCustomers = map swap . Map.toAscList . \ r -> addresses r
+listCustomers = map swap . Map.toAscList . \r -> addresses r
 
 knownCustomerAddress :: Address -> AddressState -> Bool
-knownCustomerAddress address
-  = elem address . map (\ r -> snd r) . listCustomers
+knownCustomerAddress address =
+    elem address . map (\r -> snd r) . listCustomers
 
-createAddress ::
-              Customer -> AddressState -> (Address, AddressState)
+createAddress
+    :: Customer -> AddressState -> (Address, AddressState)
 createAddress c s0 = (addr, s1)
   where
     xpub :: XPub
@@ -95,16 +103,18 @@ createAddress c s0 = (addr, s1)
     s1 = AddressStateC (stateXPub s0) addresses1 (change s0)
 
 getXPub :: AddressState -> XPub
-getXPub = \ r -> stateXPub r
+getXPub = \r -> stateXPub r
 
 emptyFromXPub :: XPub -> AddressState
-emptyFromXPub xpub
-  = AddressStateC xpub Map.empty
-      (deriveAddress xpub DerivationChange)
+emptyFromXPub xpub =
+    AddressStateC
+        xpub
+        Map.empty
+        (deriveAddress xpub DerivationChange)
 
 fromXPubAndCount :: XPub -> Word31 -> AddressState
-fromXPubAndCount xpub knownCustomerCount
-  = foldl (\ s c -> snd (createAddress c s)) s0 customers
+fromXPubAndCount xpub knownCustomerCount =
+    foldl (\s c -> snd (createAddress c s)) s0 customers
   where
     s0 :: AddressState
     s0 = emptyFromXPub xpub
@@ -112,5 +122,4 @@ fromXPubAndCount xpub knownCustomerCount
     customers = [0 .. knownCustomerCount]
 
 newChangeAddress :: AddressState -> ChangeAddressGen ()
-newChangeAddress s = \ _ -> (change s, ())
-
+newChangeAddress s = \_ -> (change s, ())

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Core.hs
@@ -1,17 +1,49 @@
 {-# LANGUAGE LambdaCase #-}
+
 module Cardano.Wallet.Deposit.Pure.TxHistory.Core where
 
-import Cardano.Wallet.Deposit.Pure.TxHistory.Type (TxHistory(tip, txIds, txTransfers))
-import Cardano.Wallet.Deposit.Pure.UTxO.Tx (ResolvedTx, valueTransferFromResolvedTx)
+import Cardano.Wallet.Deposit.Pure.TxHistory.Type
+    ( TxHistory (tip, txIds, txTransfers)
+    )
+import Cardano.Wallet.Deposit.Pure.UTxO.Tx
+    ( ResolvedTx
+    , valueTransferFromResolvedTx
+    )
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer (ValueTransfer)
-import Cardano.Wallet.Deposit.Read (Address, Slot, SlotNo, TxId, WithOrigin(At, Origin))
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    , Slot
+    , SlotNo
+    , TxId
+    , WithOrigin (At, Origin)
+    )
 import Data.Set (Set)
 import qualified Haskell.Data.ByteString (ByteString)
 import Haskell.Data.List (foldl', sortOn)
 import Haskell.Data.Map (Map)
-import qualified Haskell.Data.Map as Map (empty, keysSet, restrictKeys, toAscList, unionWith)
-import qualified Haskell.Data.Maps.PairMap as PairMap (PairMap, empty, insert, lookupA, lookupB, withoutKeysA)
-import qualified Haskell.Data.Maps.Timeline as Timeline (Timeline, deleteAfter, empty, getMapTime, insertMany, restrictRange)
+import qualified Haskell.Data.Map as Map
+    ( empty
+    , keysSet
+    , restrictKeys
+    , toAscList
+    , unionWith
+    )
+import qualified Haskell.Data.Maps.PairMap as PairMap
+    ( PairMap
+    , empty
+    , insert
+    , lookupA
+    , lookupB
+    , withoutKeysA
+    )
+import qualified Haskell.Data.Maps.Timeline as Timeline
+    ( Timeline
+    , deleteAfter
+    , empty
+    , getMapTime
+    , insertMany
+    , restrictRange
+    )
 import qualified Haskell.Data.Set as Set (fromList)
 import Numeric.Natural (Natural)
 
@@ -27,78 +59,92 @@ empty :: TxHistory
 empty = TxHistory Timeline.empty PairMap.empty Origin
 
 getTip :: TxHistory -> Slot
-getTip = \ r -> tip r
+getTip = \r -> tip r
 
 getAddressHistory :: Address -> TxHistory -> [(Slot, TxId)]
-getAddressHistory address history
-  = sortOn (\ r -> fst r)
-      (map
-         (\case
-              (x, y) -> (y, x))
-         (Map.toAscList txs2))
+getAddressHistory address history =
+    sortOn
+        (\r -> fst r)
+        ( map
+            ( \case
+                (x, y) -> (y, x)
+            )
+            (Map.toAscList txs2)
+        )
   where
     txs1 :: Set TxId
     txs1 = Map.keysSet (PairMap.lookupB address (txTransfers history))
     txs2 :: Map TxId Slot
     txs2 = Map.restrictKeys (Timeline.getMapTime (txIds history)) txs1
 
-getValueTransfers ::
-                  (Slot, Slot) -> TxHistory -> Map Address ValueTransfer
-getValueTransfers range history
-  = foldl' (Map.unionWith (<>)) Map.empty txs2
+getValueTransfers
+    :: (Slot, Slot) -> TxHistory -> Map Address ValueTransfer
+getValueTransfers range history =
+    foldl' (Map.unionWith (<>)) Map.empty txs2
   where
     txs1 :: Set TxId
-    txs1
-      = Map.keysSet
-          (Timeline.getMapTime
-             (Timeline.restrictRange range (txIds history)))
+    txs1 =
+        Map.keysSet
+            ( Timeline.getMapTime
+                (Timeline.restrictRange range (txIds history))
+            )
     txs2 :: [Map Address ValueTransfer]
-    txs2
-      = map (\ tx -> PairMap.lookupA tx (txTransfers history))
-          (toList txs1)
+    txs2 =
+        map
+            (\tx -> PairMap.lookupA tx (txTransfers history))
+            (toList txs1)
 
-rollForward ::
-            SlotNo -> [(TxId, ResolvedTx)] -> TxHistory -> TxHistory
-rollForward new txs history
-  = if At new <= getTip history then history else
-      TxHistory (Timeline.insertMany slot txids (txIds history))
-        (foldl' insertValueTransfer (txTransfers history) txs)
-        (At new)
+rollForward
+    :: SlotNo -> [(TxId, ResolvedTx)] -> TxHistory -> TxHistory
+rollForward new txs history =
+    if At new <= getTip history
+        then history
+        else
+            TxHistory
+                (Timeline.insertMany slot txids (txIds history))
+                (foldl' insertValueTransfer (txTransfers history) txs)
+                (At new)
   where
     slot :: WithOrigin Natural
     slot = At new
     txids :: Set TxId
-    txids = Set.fromList (map (\ r -> fst r) txs)
-    insertValueTransfer ::
-                        PairMap.PairMap TxId Address ValueTransfer ->
-                          (TxId, ResolvedTx) -> PairMap.PairMap TxId Address ValueTransfer
-    insertValueTransfer m0 (txid, tx)
-      = foldl' (uncurry . fun) m0 (Map.toAscList mv)
+    txids = Set.fromList (map (\r -> fst r) txs)
+    insertValueTransfer
+        :: PairMap.PairMap TxId Address ValueTransfer
+        -> (TxId, ResolvedTx)
+        -> PairMap.PairMap TxId Address ValueTransfer
+    insertValueTransfer m0 (txid, tx) =
+        foldl' (uncurry . fun) m0 (Map.toAscList mv)
       where
         mv :: Map Address ValueTransfer
         mv = valueTransferFromResolvedTx tx
-        fun ::
-            PairMap.PairMap Haskell.Data.ByteString.ByteString Address
-              ValueTransfer
-              ->
-              Address ->
-                ValueTransfer ->
-                  PairMap.PairMap Haskell.Data.ByteString.ByteString Address
-                    ValueTransfer
-        fun = \ m addr v -> PairMap.insert txid addr v m
+        fun
+            :: PairMap.PairMap
+                Haskell.Data.ByteString.ByteString
+                Address
+                ValueTransfer
+            -> Address
+            -> ValueTransfer
+            -> PairMap.PairMap
+                Haskell.Data.ByteString.ByteString
+                Address
+                ValueTransfer
+        fun = \m addr v -> PairMap.insert txid addr v m
 
 rollBackward :: Slot -> TxHistory -> TxHistory
-rollBackward new history
-  = if new > getTip history then history else
-      TxHistory keptTimeline
-        (PairMap.withoutKeysA (txTransfers history) deletedTxIds)
-        new
+rollBackward new history =
+    if new > getTip history
+        then history
+        else
+            TxHistory
+                keptTimeline
+                (PairMap.withoutKeysA (txTransfers history) deletedTxIds)
+                new
   where
-    deleteAfterTxIds ::
-                     (Set TxId, Timeline.Timeline (WithOrigin SlotNo) TxId)
+    deleteAfterTxIds
+        :: (Set TxId, Timeline.Timeline (WithOrigin SlotNo) TxId)
     deleteAfterTxIds = Timeline.deleteAfter new (txIds history)
     deletedTxIds :: Set TxId
     deletedTxIds = fst deleteAfterTxIds
     keptTimeline :: Timeline.Timeline (WithOrigin SlotNo) TxId
     keptTimeline = snd deleteAfterTxIds
-

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
@@ -5,6 +5,8 @@ import Cardano.Wallet.Deposit.Read (Address, Slot, TxId)
 import Haskell.Data.Maps.PairMap (PairMap)
 import Haskell.Data.Maps.Timeline (Timeline)
 
-data TxHistory = TxHistory{txIds :: Timeline Slot TxId,
-                           txTransfers :: PairMap TxId Address ValueTransfer, tip :: Slot}
-
+data TxHistory = TxHistory
+    { txIds :: Timeline Slot TxId
+    , txTransfers :: PairMap TxId Address ValueTransfer
+    , tip :: Slot
+    }

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
@@ -1,12 +1,14 @@
 module Cardano.Wallet.Deposit.Pure.TxSummary where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer (ValueTransfer)
-import Cardano.Wallet.Deposit.Read (ChainPoint(GenesisPoint), Tx(txid), TxId)
+import Cardano.Wallet.Deposit.Read (ChainPoint (GenesisPoint), Tx (txid), TxId)
 
-data TxSummary = TxSummary{summarizedTx :: TxId,
-                           point :: ChainPoint, transfer :: ValueTransfer}
+data TxSummary = TxSummary
+    { summarizedTx :: TxId
+    , point :: ChainPoint
+    , transfer :: ValueTransfer
+    }
 
 mkTxSummary :: Tx -> ValueTransfer -> TxSummary
-mkTxSummary
-  = \ tx transfer' -> TxSummary (txid tx) GenesisPoint transfer'
-
+mkTxSummary =
+    \tx transfer' -> TxSummary (txid tx) GenesisPoint transfer'

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -1,13 +1,19 @@
 module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO)
-import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO (empty, excluding, excludingS, null, union)
+import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
+    ( empty
+    , excluding
+    , excludingS
+    , null
+    , union
+    )
 import Cardano.Wallet.Deposit.Read (TxIn)
 import Data.Set (Set)
 import qualified Haskell.Data.Map as Map (empty, keysSet)
 import qualified Haskell.Data.Set as Set (difference, empty, null, union)
 
-data DeltaUTxO = DeltaUTxO{excluded :: Set TxIn, received :: UTxO}
+data DeltaUTxO = DeltaUTxO {excluded :: Set TxIn, received :: UTxO}
 
 null :: DeltaUTxO -> Bool
 null du = Set.null (excluded du) && UTxO.null (received du)
@@ -16,8 +22,8 @@ empty :: DeltaUTxO
 empty = DeltaUTxO Set.empty Map.empty
 
 apply :: DeltaUTxO -> UTxO -> UTxO
-apply du utxo
-  = UTxO.union (UTxO.excluding utxo (excluded du)) (received du)
+apply du utxo =
+    UTxO.union (UTxO.excluding utxo (excluded du)) (received du)
 
 excludingD :: UTxO -> Set TxIn -> (DeltaUTxO, UTxO)
 excludingD utxo txins = (du, UTxO.excluding utxo txins)
@@ -32,9 +38,10 @@ receiveD old new = (du, UTxO.union old new)
     du = DeltaUTxO Set.empty new
 
 appendDeltaUTxO :: DeltaUTxO -> DeltaUTxO -> DeltaUTxO
-appendDeltaUTxO da db
-  = DeltaUTxO (Set.union (excluded da) excluded'db)
-      (UTxO.union received'da (received db))
+appendDeltaUTxO da db =
+    DeltaUTxO
+        (Set.union (excluded da) excluded'db)
+        (UTxO.union received'da (received db))
   where
     received'da :: UTxO
     received'da = UTxO.excluding (received da) (excluded db)
@@ -46,4 +53,3 @@ instance Semigroup DeltaUTxO where
 
 instance Monoid DeltaUTxO where
     mempty = empty
-

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
@@ -1,22 +1,49 @@
 module Cardano.Wallet.Deposit.Pure.UTxO.Tx where
 
-import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO (DeltaUTxO(excluded, received))
-import qualified Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO (excludingD, null, receiveD)
+import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
+    ( DeltaUTxO (excluded, received)
+    )
+import qualified Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
+    ( excludingD
+    , null
+    , receiveD
+    )
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO)
-import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO (filterByAddress, null, restrictedBy)
-import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer (ValueTransfer, fromReceived, fromSpent)
-import Cardano.Wallet.Deposit.Read (Tx(txbody, txid), TxBody(inputs, outputs))
-import qualified Cardano.Wallet.Deposit.Read as Read (Addr, Address, TxIn, TxOut(address, value))
+import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
+    ( filterByAddress
+    , null
+    , restrictedBy
+    )
+import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
+    ( ValueTransfer
+    , fromReceived
+    , fromSpent
+    )
+import Cardano.Wallet.Deposit.Read (Tx (txbody, txid), TxBody (inputs, outputs))
+import qualified Cardano.Wallet.Deposit.Read as Read
+    ( Addr
+    , Address
+    , TxIn
+    , TxOut (address, value)
+    )
 import qualified Cardano.Wallet.Deposit.Read.Value as Read (Value)
 import Data.Set (Set)
 import qualified Haskell.Data.ByteString (ByteString)
-import qualified Haskell.Data.Map as Map (Map, elems, fromList, fromListWith, map, unionWith)
+import qualified Haskell.Data.Map as Map
+    ( Map
+    , elems
+    , fromList
+    , fromListWith
+    , map
+    , unionWith
+    )
 import qualified Haskell.Data.Set as Set (fromList)
 
 spendTxD :: Tx -> UTxO -> (DeltaUTxO, UTxO)
-spendTxD tx u
-  = Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.excludingD u
-      inputsToExclude
+spendTxD tx u =
+    Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.excludingD
+        u
+        inputsToExclude
   where
     inputsToExclude :: Set Read.TxIn
     inputsToExclude = Set.fromList (inputs (txbody tx))
@@ -27,46 +54,52 @@ utxoFromTxOutputs tx = Map.fromList $ zip txins txouts
     n :: Int
     n = length (outputs (txbody tx))
     txins :: [(Haskell.Data.ByteString.ByteString, Int)]
-    txins = map (\ j -> (txid tx, j)) $ [0 .. n - 1]
+    txins = map (\j -> (txid tx, j)) $ [0 .. n - 1]
     txouts :: [Read.TxOut]
     txouts = outputs (txbody tx)
 
 type IsOurs addr = addr -> Bool
 
 applyTx :: IsOurs Read.Addr -> Tx -> UTxO -> (DeltaUTxO, UTxO)
-applyTx isOurs tx u0
-  = if
-      UTxO.null (UTxO.filterByAddress isOurs (utxoFromTxOutputs tx)) &&
-        Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.null
-          (fst (spendTxD tx u0))
-      then (mempty, u0) else
-      (fst
-         (Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.receiveD
-            (snd (spendTxD tx u0))
-            (UTxO.filterByAddress isOurs (utxoFromTxOutputs tx)))
-         <> fst (spendTxD tx u0),
-       snd
-         (Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.receiveD
-            (snd (spendTxD tx u0))
-            (UTxO.filterByAddress isOurs (utxoFromTxOutputs tx))))
+applyTx isOurs tx u0 =
+    if UTxO.null (UTxO.filterByAddress isOurs (utxoFromTxOutputs tx))
+        && Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.null
+            (fst (spendTxD tx u0))
+        then (mempty, u0)
+        else
+            ( fst
+                ( Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.receiveD
+                    (snd (spendTxD tx u0))
+                    (UTxO.filterByAddress isOurs (utxoFromTxOutputs tx))
+                )
+                <> fst (spendTxD tx u0)
+            , snd
+                ( Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.receiveD
+                    (snd (spendTxD tx u0))
+                    (UTxO.filterByAddress isOurs (utxoFromTxOutputs tx))
+                )
+            )
 
-data ResolvedTx = ResolvedTx{resolvedTx :: Tx,
-                             resolvedInputs :: UTxO}
+data ResolvedTx = ResolvedTx
+    { resolvedTx :: Tx
+    , resolvedInputs :: UTxO
+    }
 
 resolveInputs :: UTxO -> Tx -> ResolvedTx
-resolveInputs utxo tx
-  = ResolvedTx tx
-      (UTxO.restrictedBy utxo (Set.fromList (inputs (txbody tx))))
+resolveInputs utxo tx =
+    ResolvedTx
+        tx
+        (UTxO.restrictedBy utxo (Set.fromList (inputs (txbody tx))))
 
 pairFromTxOut :: Read.TxOut -> (Read.Address, Read.Value)
-pairFromTxOut = \ txout -> (Read.address txout, Read.value txout)
+pairFromTxOut = \txout -> (Read.address txout, Read.value txout)
 
 groupByAddress :: UTxO -> Map.Map Read.Address Read.Value
-groupByAddress
-  = Map.fromListWith (<>) . map pairFromTxOut . Map.elems
+groupByAddress =
+    Map.fromListWith (<>) . map pairFromTxOut . Map.elems
 
-valueTransferFromDeltaUTxO ::
-                           UTxO -> DeltaUTxO -> Map.Map Read.Address ValueTransfer
+valueTransferFromDeltaUTxO
+    :: UTxO -> DeltaUTxO -> Map.Map Read.Address ValueTransfer
 valueTransferFromDeltaUTxO u0 du = Map.unionWith (<>) ins outs
   where
     u1 :: UTxO
@@ -76,12 +109,11 @@ valueTransferFromDeltaUTxO u0 du = Map.unionWith (<>) ins outs
     outs :: Map.Map Read.Address ValueTransfer
     outs = Map.map fromReceived (groupByAddress (received du))
 
-valueTransferFromResolvedTx ::
-                            ResolvedTx -> Map.Map Read.Address ValueTransfer
+valueTransferFromResolvedTx
+    :: ResolvedTx -> Map.Map Read.Address ValueTransfer
 valueTransferFromResolvedTx tx = valueTransferFromDeltaUTxO u0 du
   where
     u0 :: UTxO
     u0 = resolvedInputs tx
     du :: DeltaUTxO
-    du = fst (applyTx (\ _ -> True) (resolvedTx tx) u0)
-
+    du = fst (applyTx (\_ -> True) (resolvedTx tx) u0)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -1,9 +1,19 @@
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxO where
 
-import Cardano.Wallet.Deposit.Read (Address, TxIn, TxOut(address, value))
+import Cardano.Wallet.Deposit.Read (Address, TxIn, TxOut (address, value))
 import Cardano.Wallet.Deposit.Read.Value (Value)
 import Data.Set (Set)
-import qualified Haskell.Data.Map as Map (Map, empty, filter, keysSet, member, null, restrictKeys, unionWith, withoutKeys)
+import qualified Haskell.Data.Map as Map
+    ( Map
+    , empty
+    , filter
+    , keysSet
+    , member
+    , null
+    , restrictKeys
+    , unionWith
+    , withoutKeys
+    )
 import qualified Haskell.Data.Set as Set (filter)
 
 type UTxO = Map.Map TxIn TxOut
@@ -18,10 +28,10 @@ dom :: UTxO -> Set TxIn
 dom = Map.keysSet
 
 balance :: UTxO -> Value
-balance = foldMap (\ r -> value r)
+balance = foldMap (\r -> value r)
 
 union :: UTxO -> UTxO -> UTxO
-union = Map.unionWith (\ x y -> x)
+union = Map.unionWith (\x y -> x)
 
 excluding :: UTxO -> Set TxIn -> UTxO
 excluding = Map.withoutKeys
@@ -30,9 +40,8 @@ restrictedBy :: UTxO -> Set TxIn -> UTxO
 restrictedBy = Map.restrictKeys
 
 excludingS :: Set TxIn -> UTxO -> Set TxIn
-excludingS s utxo
-  = Set.filter (not . \ txin -> Map.member txin utxo) s
+excludingS s utxo =
+    Set.filter (not . \txin -> Map.member txin utxo) s
 
 filterByAddress :: (Address -> Bool) -> UTxO -> UTxO
-filterByAddress p = Map.filter (p . \ r -> address r)
-
+filterByAddress p = Map.filter (p . \r -> address r)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
@@ -1,15 +1,29 @@
 {-# LANGUAGE LambdaCase #-}
+
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core where
 
-import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO (DeltaUTxO(excluded, received))
+import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
+    ( DeltaUTxO (excluded, received)
+    )
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO, dom, excluding)
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO (union)
-import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type (Pruned(NotPruned, PrunedUpTo), UTxOHistory(boot, created, finality, history, spent, tip))
-import Cardano.Wallet.Deposit.Read (Slot, SlotNo, TxIn, WithOrigin(At, Origin))
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
+    ( Pruned (NotPruned, PrunedUpTo)
+    , UTxOHistory (boot, created, finality, history, spent, tip)
+    )
+import Cardano.Wallet.Deposit.Read (Slot, SlotNo, TxIn, WithOrigin (At, Origin))
 import Data.Set (Set)
 import Haskell.Data.Map (Map)
 import qualified Haskell.Data.Map as Map (keysSet)
-import qualified Haskell.Data.Maps.Timeline as Timeline (deleteAfter, difference, dropWhileAntitone, empty, getMapTime, insertMany, takeWhileAntitone)
+import qualified Haskell.Data.Maps.Timeline as Timeline
+    ( deleteAfter
+    , difference
+    , dropWhileAntitone
+    , empty
+    , getMapTime
+    , insertMany
+    , takeWhileAntitone
+    )
 import Haskell.Data.Maybe (fromMaybe)
 import qualified Haskell.Data.Set as Set (difference, intersection)
 
@@ -23,104 +37,133 @@ guard True = Just ()
 guard False = Nothing
 
 empty :: UTxO -> UTxOHistory
-empty utxo
-  = UTxOHistory utxo
-      (Timeline.insertMany Origin (dom utxo) Timeline.empty)
-      Timeline.empty
-      Origin
-      NotPruned
-      utxo
+empty utxo =
+    UTxOHistory
+        utxo
+        (Timeline.insertMany Origin (dom utxo) Timeline.empty)
+        Timeline.empty
+        Origin
+        NotPruned
+        utxo
 
 getUTxO :: UTxOHistory -> UTxO
-getUTxO us
-  = excluding (history us)
-      (Map.keysSet (Timeline.getMapTime (spent us)))
+getUTxO us =
+    excluding
+        (history us)
+        (Map.keysSet (Timeline.getMapTime (spent us)))
 
 getTip :: UTxOHistory -> Slot
-getTip = \ r -> tip r
+getTip = \r -> tip r
 
 getFinality :: UTxOHistory -> Pruned
-getFinality = \ r -> finality r
+getFinality = \r -> finality r
 
 getSpent :: UTxOHistory -> Map TxIn SlotNo
-getSpent = Timeline.getMapTime . \ r -> spent r
+getSpent = Timeline.getMapTime . \r -> spent r
 
 constrainingAppendBlock :: a -> UTxOHistory -> SlotNo -> a -> a
-constrainingAppendBlock noop us newTip f
-  = if At newTip <= tip us then noop else f
+constrainingAppendBlock noop us newTip f =
+    if At newTip <= tip us then noop else f
 
-constrainingRollback ::
-                     a -> UTxOHistory -> Slot -> (Maybe Slot -> a) -> a
-constrainingRollback noop us newTip f
-  = if newTip >= tip us then noop else
-      f (case finality us of
-             NotPruned -> Just newTip
-             PrunedUpTo finality' -> if newTip >= At finality' then Just newTip
-                                       else Nothing)
+constrainingRollback
+    :: a -> UTxOHistory -> Slot -> (Maybe Slot -> a) -> a
+constrainingRollback noop us newTip f =
+    if newTip >= tip us
+        then noop
+        else
+            f
+                ( case finality us of
+                    NotPruned -> Just newTip
+                    PrunedUpTo finality' ->
+                        if newTip >= At finality'
+                            then Just newTip
+                            else Nothing
+                )
 
-constrainingPrune ::
-                  a -> UTxOHistory -> SlotNo -> (SlotNo -> a) -> a
-constrainingPrune noop us newFinality f
-  = fromMaybe noop $
-      do case finality us of
-             NotPruned -> pure ()
-             PrunedUpTo finality' -> guard $ newFinality > finality'
-         case tip us of
-             Origin -> Nothing
-             At tip' -> pure $ f $ min newFinality tip'
+constrainingPrune
+    :: a -> UTxOHistory -> SlotNo -> (SlotNo -> a) -> a
+constrainingPrune noop us newFinality f =
+    fromMaybe noop
+        $ do
+            case finality us of
+                NotPruned -> pure ()
+                PrunedUpTo finality' -> guard $ newFinality > finality'
+            case tip us of
+                Origin -> Nothing
+                At tip' -> pure $ f $ min newFinality tip'
 
-data DeltaUTxOHistory = AppendBlock SlotNo DeltaUTxO
-                      | Rollback Slot
-                      | Prune SlotNo
+data DeltaUTxOHistory
+    = AppendBlock SlotNo DeltaUTxO
+    | Rollback Slot
+    | Prune SlotNo
 
 appendBlock :: SlotNo -> DeltaUTxO -> UTxOHistory -> UTxOHistory
-appendBlock newTip delta noop
-  = constrainingAppendBlock noop noop newTip
-      (UTxOHistory (UTxO.union (history noop) (received delta))
-         (Timeline.insertMany (At newTip) receivedTxIns (created noop))
-         (Timeline.insertMany newTip excludedTxIns (spent noop))
-         (At newTip)
-         (finality noop)
-         (boot noop))
+appendBlock newTip delta noop =
+    constrainingAppendBlock
+        noop
+        noop
+        newTip
+        ( UTxOHistory
+            (UTxO.union (history noop) (received delta))
+            (Timeline.insertMany (At newTip) receivedTxIns (created noop))
+            (Timeline.insertMany newTip excludedTxIns (spent noop))
+            (At newTip)
+            (finality noop)
+            (boot noop)
+        )
   where
     receivedTxIns :: Set TxIn
-    receivedTxIns
-      = Set.difference (dom (received delta)) (dom (history noop))
+    receivedTxIns =
+        Set.difference (dom (received delta)) (dom (history noop))
     excludedTxIns :: Set TxIn
-    excludedTxIns
-      = Set.difference
-          (Set.intersection (excluded delta) (dom (history noop)))
-          (Map.keysSet (Timeline.getMapTime (spent noop)))
+    excludedTxIns =
+        Set.difference
+            (Set.intersection (excluded delta) (dom (history noop)))
+            (Map.keysSet (Timeline.getMapTime (spent noop)))
 
 rollback :: Slot -> UTxOHistory -> UTxOHistory
-rollback newTip noop
-  = constrainingRollback noop noop newTip
-      (\case
-           Just newTip' -> UTxOHistory
-                             (excluding (history noop)
-                                (fst (Timeline.deleteAfter newTip' (created noop))))
-                             (snd (Timeline.deleteAfter newTip' (created noop)))
-                             (case newTip' of
-                                  Origin -> Timeline.empty
-                                  At slot'' -> snd
-                                                 (Timeline.takeWhileAntitone (<= slot'')
-                                                    (spent noop)))
-                             newTip'
-                             (finality noop)
-                             (boot noop)
-           Nothing -> empty (boot noop))
+rollback newTip noop =
+    constrainingRollback
+        noop
+        noop
+        newTip
+        ( \case
+            Just newTip' ->
+                UTxOHistory
+                    ( excluding
+                        (history noop)
+                        (fst (Timeline.deleteAfter newTip' (created noop)))
+                    )
+                    (snd (Timeline.deleteAfter newTip' (created noop)))
+                    ( case newTip' of
+                        Origin -> Timeline.empty
+                        At slot'' ->
+                            snd
+                                ( Timeline.takeWhileAntitone
+                                    (<= slot'')
+                                    (spent noop)
+                                )
+                    )
+                    newTip'
+                    (finality noop)
+                    (boot noop)
+            Nothing -> empty (boot noop)
+        )
 
 prune :: SlotNo -> UTxOHistory -> UTxOHistory
-prune newFinality noop
-  = constrainingPrune noop noop newFinality $
-      \ newFinality' ->
-        UTxOHistory
-          (excluding (history noop)
-             (fst (Timeline.dropWhileAntitone (<= newFinality') (spent noop))))
-          (Timeline.difference (created noop)
-             (fst (Timeline.dropWhileAntitone (<= newFinality') (spent noop))))
-          (snd (Timeline.dropWhileAntitone (<= newFinality') (spent noop)))
-          (tip noop)
-          (PrunedUpTo newFinality')
-          (boot noop)
-
+prune newFinality noop =
+    constrainingPrune noop noop newFinality
+        $ \newFinality' ->
+            UTxOHistory
+                ( excluding
+                    (history noop)
+                    (fst (Timeline.dropWhileAntitone (<= newFinality') (spent noop)))
+                )
+                ( Timeline.difference
+                    (created noop)
+                    (fst (Timeline.dropWhileAntitone (<= newFinality') (spent noop)))
+                )
+                (snd (Timeline.dropWhileAntitone (<= newFinality') (spent noop)))
+                (tip noop)
+                (PrunedUpTo newFinality')
+                (boot noop)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
@@ -1,18 +1,24 @@
 {-# LANGUAGE StandaloneDeriving #-}
+
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO)
 import Cardano.Wallet.Deposit.Read (Slot, SlotNo, TxIn)
 import Haskell.Data.Maps.Timeline (Timeline)
 
-data Pruned = PrunedUpTo SlotNo
-            | NotPruned
+data Pruned
+    = PrunedUpTo SlotNo
+    | NotPruned
 
 deriving instance Eq Pruned
 
 deriving instance Show Pruned
 
-data UTxOHistory = UTxOHistory{history :: UTxO,
-                               created :: Timeline Slot TxIn, spent :: Timeline SlotNo TxIn,
-                               tip :: Slot, finality :: Pruned, boot :: UTxO}
-
+data UTxOHistory = UTxOHistory
+    { history :: UTxO
+    , created :: Timeline Slot TxIn
+    , spent :: Timeline SlotNo TxIn
+    , tip :: Slot
+    , finality :: Pruned
+    , boot :: UTxO
+    }

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
@@ -2,20 +2,21 @@ module Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer where
 
 import Cardano.Wallet.Deposit.Read.Value (Value)
 
-data ValueTransfer = ValueTransfer{spent :: Value,
-                                   received :: Value}
+data ValueTransfer = ValueTransfer
+    { spent :: Value
+    , received :: Value
+    }
 
 fromSpent :: Value -> ValueTransfer
-fromSpent = \ value -> ValueTransfer value mempty
+fromSpent = \value -> ValueTransfer value mempty
 
 fromReceived :: Value -> ValueTransfer
-fromReceived = \ value -> ValueTransfer mempty value
+fromReceived = \value -> ValueTransfer mempty value
 
 instance Semigroup ValueTransfer where
-    (<>)
-      = \ v1 v2 ->
-          ValueTransfer (spent v1 <> spent v2) (received v1 <> received v2)
+    (<>) =
+        \v1 v2 ->
+            ValueTransfer (spent v1 <> spent v2) (received v1 <> received v2)
 
 instance Monoid ValueTransfer where
     mempty = ValueTransfer mempty mempty
-

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE StandaloneDeriving #-}
+
 module Cardano.Wallet.Deposit.Read where
 
 import qualified Haskell.Data.ByteString as BS (ByteString)
@@ -19,16 +20,17 @@ type Ix = Int
 
 type TxIn = (TxId, Ix)
 
-data TxOut = TxOutC{address :: Address, value :: Value}
+data TxOut = TxOutC {address :: Address, value :: Value}
 
-data TxBody = TxBodyC{inputs :: [TxIn], outputs :: [TxOut]}
+data TxBody = TxBodyC {inputs :: [TxIn], outputs :: [TxOut]}
 
-data Tx = TxC{txid :: TxId, txbody :: TxBody}
+data Tx = TxC {txid :: TxId, txbody :: TxBody}
 
 type SlotNo = Natural
 
-data WithOrigin a = Origin
-                  | At a
+data WithOrigin a
+    = Origin
+    | At a
 
 deriving instance (Eq a) => Eq (WithOrigin a)
 
@@ -42,16 +44,22 @@ type HashHeader = ()
 
 type HashBBody = ()
 
-data BHBody = BHBody{prev :: Maybe HashHeader, blockno :: BlockNo,
-                     slot :: SlotNo, bhash :: HashBBody}
+data BHBody = BHBody
+    { prev :: Maybe HashHeader
+    , blockno :: BlockNo
+    , slot :: SlotNo
+    , bhash :: HashBBody
+    }
 
 dummyBHBody :: BHBody
 dummyBHBody = BHBody Nothing 128 42 ()
 
 type Sig = ()
 
-data BHeader = BHeader{blockHeaderBody :: BHBody,
-                       blockHeaderSignature :: Sig}
+data BHeader = BHeader
+    { blockHeaderBody :: BHBody
+    , blockHeaderSignature :: Sig
+    }
 
 bhHash :: BHeader -> HashHeader
 bhHash _ = ()
@@ -59,14 +67,15 @@ bhHash _ = ()
 dummyBHeader :: BHeader
 dummyBHeader = BHeader dummyBHBody ()
 
-data Block = Block{blockHeader :: BHeader, transactions :: [Tx]}
+data Block = Block {blockHeader :: BHeader, transactions :: [Tx]}
 
-data ChainPoint = GenesisPoint
-                | BlockPoint SlotNo HashHeader
+data ChainPoint
+    = GenesisPoint
+    | BlockPoint SlotNo HashHeader
 
 chainPointFromBlock :: Block -> ChainPoint
-chainPointFromBlock block
-  = BlockPoint (slot (blockHeaderBody bh)) (bhHash bh)
+chainPointFromBlock block =
+    BlockPoint (slot (blockHeaderBody bh)) (bhHash bh)
   where
     bh :: BHeader
     bh = blockHeader block
@@ -74,4 +83,3 @@ chainPointFromBlock block
 slotFromChainPoint :: ChainPoint -> Slot
 slotFromChainPoint GenesisPoint = Origin
 slotFromChainPoint (BlockPoint slotNo _) = At slotNo
-

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read/Value.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read/Value.hs
@@ -1,16 +1,26 @@
-{-# LANGUAGE StandaloneDeriving, LambdaCase #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
 module Cardano.Wallet.Deposit.Read.Value where
 
 import qualified Haskell.Data.ByteString as BS (ByteString)
-import qualified Haskell.Data.Map as Map (Map, empty, filterWithKey, fromList, lookup, null, unionWith)
+import qualified Haskell.Data.Map as Map
+    ( Map
+    , empty
+    , filterWithKey
+    , fromList
+    , lookup
+    , null
+    , unionWith
+    )
 import Haskell.Data.Maybe (fromMaybe)
 import Numeric.Natural (Natural)
 
 type Coin = Natural
 
 monusCoin :: Coin -> Coin -> Coin
-monusCoin a b
-  = case a < b of
+monusCoin a b =
+    case a < b of
         False -> a - b
         True -> 0
 
@@ -22,26 +32,33 @@ type PolicyID = ScriptHash
 
 type Quantity = Integer
 
-data AssetID = AdaID
-             | Asset PolicyID AssetName
+data AssetID
+    = AdaID
+    | Asset PolicyID AssetName
 
 deriving instance Eq AssetID
 
 deriving instance Ord AssetID
 
-data Value = Value{ada :: Coin,
-                   assets :: Map.Map (PolicyID, AssetName) Quantity}
+data Value = Value
+    { ada :: Coin
+    , assets :: Map.Map (PolicyID, AssetName) Quantity
+    }
 
 deriving instance Eq Value
 
 valueFromList :: Coin -> [(PolicyID, AssetName, Quantity)] -> Value
-valueFromList coin xs
-  = Value coin
-      (Map.fromList
-         (map
-            (\case
-                 (p, n, q) -> ((p, n), q))
-            xs))
+valueFromList coin xs =
+    Value
+        coin
+        ( Map.fromList
+            ( map
+                ( \case
+                    (p, n, q) -> ((p, n), q)
+                )
+                xs
+            )
+        )
 
 injectCoin :: Coin -> Value
 injectCoin coin = Value coin Map.empty
@@ -50,26 +67,26 @@ getCoin :: Value -> Coin
 getCoin v = ada v
 
 largerOrEqual :: Value -> Value -> Bool
-largerOrEqual a b
-  = ada a >= ada b &&
-      Map.null (Map.filterWithKey isSmallerThanB (assets a))
+largerOrEqual a b =
+    ada a >= ada b
+        && Map.null (Map.filterWithKey isSmallerThanB (assets a))
   where
     isSmallerThanB :: (PolicyID, AssetName) -> Quantity -> Bool
-    isSmallerThanB key qa
-      = qa < fromMaybe 0 (Map.lookup key (assets b))
+    isSmallerThanB key qa =
+        qa < fromMaybe 0 (Map.lookup key (assets b))
 
 instance Semigroup Value where
-    a <> b
-      = Value (ada a + ada b) (Map.unionWith (+) (assets a) (assets b))
+    a <> b =
+        Value (ada a + ada b) (Map.unionWith (+) (assets a) (assets b))
 
 instance Monoid Value where
     mempty = Value 0 Map.empty
 
 monus :: Value -> Value -> Value
-monus a b
-  = Value (monusCoin (ada a) (ada b))
-      (Map.unionWith minus (assets a) (assets b))
+monus a b =
+    Value
+        (monusCoin (ada a) (ada b))
+        (Map.unionWith minus (assets a) (assets b))
   where
     minus :: Quantity -> Quantity -> Quantity
     minus a b = a - b
-

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Write/Tx/Balance.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Write/Tx/Balance.hs
@@ -2,14 +2,19 @@ module Cardano.Write.Tx.Balance where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO)
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO (balance)
-import Cardano.Wallet.Deposit.Read (Address, TxBody(TxBodyC), TxIn, TxOut(TxOutC, value))
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    , TxBody (TxBodyC)
+    , TxIn
+    , TxOut (TxOutC, value)
+    )
 import Cardano.Wallet.Deposit.Read.Value (Value, largerOrEqual, monus)
 import qualified Haskell.Data.Map as Map (toAscList)
 
-data PartialTx = PartialTxC{outputs :: [TxOut]}
+data PartialTx = PartialTxC {outputs :: [TxOut]}
 
 totalOut :: PartialTx -> Value
-totalOut = mconcat . map (\ r -> value r) . \ r -> outputs r
+totalOut = mconcat . map (\r -> value r) . \r -> outputs r
 
 type ChangeAddressGen c = c -> (Address, c)
 
@@ -18,21 +23,25 @@ secondCons y (x, ys) = (x, y : ys)
 
 coinSelectionGreedy :: Value -> [(TxIn, TxOut)] -> (Value, [TxIn])
 coinSelectionGreedy v [] = (mempty, [])
-coinSelectionGreedy v ((txin, txout) : xs)
-  = if largerOrEqual v (value txout) then
-      secondCons txin $ coinSelectionGreedy (monus v (value txout)) xs
-      else (monus (value txout) v, [])
+coinSelectionGreedy v ((txin, txout) : xs) =
+    if largerOrEqual v (value txout)
+        then secondCons txin $ coinSelectionGreedy (monus v (value txout)) xs
+        else (monus (value txout) v, [])
 
-balanceTransaction ::
-                   UTxO -> ChangeAddressGen c -> c -> PartialTx -> Maybe TxBody
-balanceTransaction utxo newAddress c0 partialTx
-  = if largerOrEqual target (UTxO.balance utxo) then Nothing else
-      Just $
-        TxBodyC (snd (coinSelectionGreedy target (Map.toAscList utxo)))
-          (TxOutC (fst (newAddress c0))
-             (fst (coinSelectionGreedy target (Map.toAscList utxo)))
-             : outputs partialTx)
+balanceTransaction
+    :: UTxO -> ChangeAddressGen c -> c -> PartialTx -> Maybe TxBody
+balanceTransaction utxo newAddress c0 partialTx =
+    if largerOrEqual target (UTxO.balance utxo)
+        then Nothing
+        else
+            Just
+                $ TxBodyC
+                    (snd (coinSelectionGreedy target (Map.toAscList utxo)))
+                    ( TxOutC
+                        (fst (newAddress c0))
+                        (fst (coinSelectionGreedy target (Map.toAscList utxo)))
+                        : outputs partialTx
+                    )
   where
     target :: Value
     target = totalOut partialTx
-

--- a/lib/customer-deposit-wallet-pure/haskell/Everything.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Everything.hs
@@ -1,2 +1,1 @@
 module Everything where
-

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/List.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/List.hs
@@ -2,13 +2,11 @@
 
 module Haskell.Data.List where
 
-
 import qualified Data.List
 
 foldl'
-  :: Foldable t => (b -> a -> b) -> b -> t a -> b
+    :: Foldable t => (b -> a -> b) -> b -> t a -> b
 foldl' = Data.List.foldl'
 
-sortOn :: Ord b => (a ->b) ->[a] ->[a]
+sortOn :: Ord b => (a -> b) -> [a] -> [a]
 sortOn = Data.List.sortOn
-

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/InverseMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/InverseMap.hs
@@ -3,7 +3,13 @@ module Haskell.Data.Maps.InverseMap where
 import Data.Set (Set)
 import Haskell.Data.List (foldl')
 import Haskell.Data.Map (Map)
-import qualified Haskell.Data.Map as Map (empty, fromListWith, insertWith, toAscList, update)
+import qualified Haskell.Data.Map as Map
+    ( empty
+    , fromListWith
+    , insertWith
+    , toAscList
+    , update
+    )
 import qualified Haskell.Data.Set as Set (delete, null, singleton, union)
 
 type InverseMap key v = Map v (Set key)
@@ -11,38 +17,50 @@ type InverseMap key v = Map v (Set key)
 empty :: (Ord key, Ord v) => InverseMap key v
 empty = Map.empty
 
-inverseMapFromMap ::
-                    (Ord key, Ord v) => Map key v -> InverseMap key v
-inverseMapFromMap m
-  = Map.fromListWith Set.union $
-      do (key, v) <- Map.toAscList m
-         pure (v, Set.singleton key)
+inverseMapFromMap
+    :: (Ord key, Ord v) => Map key v -> InverseMap key v
+inverseMapFromMap m =
+    Map.fromListWith Set.union
+        $ do
+            (key, v) <- Map.toAscList m
+            pure (v, Set.singleton key)
 
-insert ::
-         (Ord key, Ord v) =>
-         key -> v -> InverseMap key v -> InverseMap key v
+insert
+    :: (Ord key, Ord v)
+    => key
+    -> v
+    -> InverseMap key v
+    -> InverseMap key v
 insert key v = Map.insertWith Set.union v (Set.singleton key)
 
-insertManyKeys ::
-                 (Ord key, Ord v) =>
-                 Set key -> v -> InverseMap key v -> InverseMap key v
-insertManyKeys keys v
-  = if Set.null keys then id else Map.insertWith Set.union v keys
+insertManyKeys
+    :: (Ord key, Ord v)
+    => Set key
+    -> v
+    -> InverseMap key v
+    -> InverseMap key v
+insertManyKeys keys v =
+    if Set.null keys then id else Map.insertWith Set.union v keys
 
 deleteFromSet :: Ord v => v -> Set v -> Maybe (Set v)
-deleteFromSet x vs
-  = if Set.null (Set.delete x vs) then Nothing else
-      Just (Set.delete x vs)
+deleteFromSet x vs =
+    if Set.null (Set.delete x vs)
+        then Nothing
+        else Just (Set.delete x vs)
 
-delete ::
-         (Ord v, Ord key) =>
-         key -> v -> InverseMap key v -> InverseMap key v
+delete
+    :: (Ord v, Ord key)
+    => key
+    -> v
+    -> InverseMap key v
+    -> InverseMap key v
 delete key x = Map.update (deleteFromSet key) x
 
-difference ::
-             (Ord v, Ord key) =>
-             InverseMap key v -> Map key v -> InverseMap key v
-difference whole part
-  = foldl' (\ m keyx -> delete (fst keyx) (snd keyx) m) whole $
-      Map.toAscList part
-
+difference
+    :: (Ord v, Ord key)
+    => InverseMap key v
+    -> Map key v
+    -> InverseMap key v
+difference whole part =
+    foldl' (\m keyx -> delete (fst keyx) (snd keyx) m) whole
+        $ Map.toAscList part

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
@@ -1,10 +1,19 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+
 module Haskell.Data.Maps.PairMap where
 
 import Data.Set (Set)
 import Haskell.Data.List (foldl')
 import Haskell.Data.Map (Map)
-import qualified Haskell.Data.Map as Map (delete, empty, insert, keys, lookup, null, update)
+import qualified Haskell.Data.Map as Map
+    ( delete
+    , empty
+    , insert
+    , keys
+    , lookup
+    , null
+    , update
+    )
 import Haskell.Data.Maybe (fromMaybe)
 
 explicitEmpty :: Ord a => Map a v -> Maybe (Map a v)
@@ -13,62 +22,76 @@ explicitEmpty m = if Map.null m then Nothing else Just m
 implicitEmpty :: Ord a => Maybe (Map a v) -> Map a v
 implicitEmpty = fromMaybe Map.empty
 
-withEmpty ::
-            Ord a => (Map a v -> Map a v) -> Maybe (Map a v) -> Maybe (Map a v)
+withEmpty
+    :: Ord a => (Map a v -> Map a v) -> Maybe (Map a v) -> Maybe (Map a v)
 withEmpty f = explicitEmpty . f . implicitEmpty
 
 lookup2 :: (Ord a, Ord b) => a -> b -> Map a (Map b v) -> Maybe v
 lookup2 a b m = Map.lookup a m >>= Map.lookup b
 
-insert2 ::
-          (Ord a, Ord b) => a -> b -> v -> Map a (Map b v) -> Map a (Map b v)
-insert2 ai bi v m
-  = Map.insert ai (Map.insert bi v (implicitEmpty (Map.lookup ai m)))
-      m
+insert2
+    :: (Ord a, Ord b) => a -> b -> v -> Map a (Map b v) -> Map a (Map b v)
+insert2 ai bi v m =
+    Map.insert
+        ai
+        (Map.insert bi v (implicitEmpty (Map.lookup ai m)))
+        m
 
-delete2 ::
-          (Ord a, Ord b) => a -> b -> Map a (Map b v) -> Map a (Map b v)
+delete2
+    :: (Ord a, Ord b) => a -> b -> Map a (Map b v) -> Map a (Map b v)
 delete2 a b = Map.update (explicitEmpty . Map.delete b) a
 
-delete2s ::
-           (Ord a, Ord b) => [a] -> b -> Map a (Map b v) -> Map a (Map b v)
-delete2s xs b m0 = foldr (\ a -> delete2 a b) m0 xs
+delete2s
+    :: (Ord a, Ord b) => [a] -> b -> Map a (Map b v) -> Map a (Map b v)
+delete2s xs b m0 = foldr (\a -> delete2 a b) m0 xs
 
-data PairMap a b v = PairMap{mab :: Map a (Map b v),
-                             mba :: Map b (Map a v)}
+data PairMap a b v = PairMap
+    { mab :: Map a (Map b v)
+    , mba :: Map b (Map a v)
+    }
 
-empty :: forall a b v . (Ord a, Ord b) => PairMap a b v
+empty :: forall a b v. (Ord a, Ord b) => PairMap a b v
 empty = PairMap Map.empty Map.empty
 
-lookupA ::
-        forall a b v . (Ord a, Ord b) => a -> PairMap a b v -> Map b v
-lookupA a = implicitEmpty . Map.lookup a . \ r -> mab r
+lookupA
+    :: forall a b v. (Ord a, Ord b) => a -> PairMap a b v -> Map b v
+lookupA a = implicitEmpty . Map.lookup a . \r -> mab r
 
-lookupB ::
-        forall a b v . (Ord a, Ord b) => b -> PairMap a b v -> Map a v
-lookupB b = implicitEmpty . Map.lookup b . \ r -> mba r
+lookupB
+    :: forall a b v. (Ord a, Ord b) => b -> PairMap a b v -> Map a v
+lookupB b = implicitEmpty . Map.lookup b . \r -> mba r
 
-lookupAB ::
-         forall a b v . (Ord a, Ord b) => a -> b -> PairMap a b v -> Maybe v
+lookupAB
+    :: forall a b v. (Ord a, Ord b) => a -> b -> PairMap a b v -> Maybe v
 lookupAB a b m = Map.lookup a (mab m) >>= Map.lookup b
 
-insert ::
-       forall a b v . (Ord a, Ord b) =>
-         a -> b -> v -> PairMap a b v -> PairMap a b v
-insert ai bi v m
-  = PairMap (insert2 ai bi v (mab m)) (insert2 bi ai v (mba m))
+insert
+    :: forall a b v
+     . (Ord a, Ord b)
+    => a
+    -> b
+    -> v
+    -> PairMap a b v
+    -> PairMap a b v
+insert ai bi v m =
+    PairMap (insert2 ai bi v (mab m)) (insert2 bi ai v (mba m))
 
-deleteA ::
-        forall a b v . (Ord a, Ord b) =>
-          a -> PairMap a b v -> PairMap a b v
-deleteA ai m
-  = PairMap (Map.delete ai (mab m)) (delete2s bs ai (mba m))
+deleteA
+    :: forall a b v
+     . (Ord a, Ord b)
+    => a
+    -> PairMap a b v
+    -> PairMap a b v
+deleteA ai m =
+    PairMap (Map.delete ai (mab m)) (delete2s bs ai (mba m))
   where
     bs :: [b]
     bs = Map.keys (implicitEmpty (Map.lookup ai (mab m)))
 
-withoutKeysA ::
-             forall a b v . (Ord a, Ord b) =>
-               PairMap a b v -> Set a -> PairMap a b v
-withoutKeysA m0 xs = foldl' (\ m x -> deleteA x m) m0 xs
-
+withoutKeysA
+    :: forall a b v
+     . (Ord a, Ord b)
+    => PairMap a b v
+    -> Set a
+    -> PairMap a b v
+withoutKeysA m0 xs = foldl' (\m x -> deleteA x m) m0 xs

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
@@ -1,97 +1,139 @@
 {-# LANGUAGE LambdaCase #-}
+
 module Haskell.Data.Maps.Timeline where
 
 import Data.Set (Set)
 import Haskell.Data.List (foldl')
 import Haskell.Data.Map (Map)
-import qualified Haskell.Data.Map as Map (empty, insert, lookup, restrictKeys, spanAntitone, toAscList, withoutKeys)
-import qualified Haskell.Data.Maps.InverseMap as InverseMap (InverseMap, difference, insertManyKeys)
+import qualified Haskell.Data.Map as Map
+    ( empty
+    , insert
+    , lookup
+    , restrictKeys
+    , spanAntitone
+    , toAscList
+    , withoutKeys
+    )
+import qualified Haskell.Data.Maps.InverseMap as InverseMap
+    ( InverseMap
+    , difference
+    , insertManyKeys
+    )
 import Haskell.Data.Maybe (fromMaybe)
 import qualified Haskell.Data.Set as Set (empty, toAscList)
 
-insertManyKeys ::
-                 (Ord key, Ord v) => Set key -> v -> Map key v -> Map key v
-insertManyKeys keys v m0
-  = foldl' (\ m key -> Map.insert key v m) m0 keys
+insertManyKeys
+    :: (Ord key, Ord v) => Set key -> v -> Map key v -> Map key v
+insertManyKeys keys v m0 =
+    foldl' (\m key -> Map.insert key v m) m0 keys
 
-data Timeline time a = Timeline{events :: Map a time,
-                                eventsByTime :: InverseMap.InverseMap a time}
+data Timeline time a = Timeline
+    { events :: Map a time
+    , eventsByTime :: InverseMap.InverseMap a time
+    }
 
 empty :: (Ord time, Ord a) => Timeline time a
 empty = Timeline Map.empty Map.empty
 
-lookupByTime ::
-               (Ord time, Ord a) => time -> Timeline time a -> Set a
-lookupByTime t
-  = fromMaybe Set.empty . Map.lookup t . \ r -> eventsByTime r
+lookupByTime
+    :: (Ord time, Ord a) => time -> Timeline time a -> Set a
+lookupByTime t =
+    fromMaybe Set.empty . Map.lookup t . \r -> eventsByTime r
 
-lookupByItem ::
-               (Ord time, Ord a) => a -> Timeline time a -> Maybe time
-lookupByItem x = Map.lookup x . \ r -> events r
+lookupByItem
+    :: (Ord time, Ord a) => a -> Timeline time a -> Maybe time
+lookupByItem x = Map.lookup x . \r -> events r
 
 getMapTime :: (Ord time, Ord a) => Timeline time a -> Map a time
-getMapTime = \ r -> events r
+getMapTime = \r -> events r
 
 toAscList :: (Ord time, Ord a) => Timeline time a -> [(time, a)]
-toAscList
-  = concat .
-      map
-        (\case
-             (t, xs) -> map (\ x -> (t, x)) (Set.toAscList xs))
-        . Map.toAscList . \ r -> eventsByTime r
+toAscList =
+    concat
+        . map
+            ( \case
+                (t, xs) -> map (\x -> (t, x)) (Set.toAscList xs)
+            )
+        . Map.toAscList
+        . \r -> eventsByTime r
 
-insertMany ::
-             (Ord time, Ord a) =>
-             time -> Set a -> Timeline time a -> Timeline time a
-insertMany t xs timeline
-  = Timeline (insertManyKeys xs t (events timeline))
-      (InverseMap.insertManyKeys xs t (eventsByTime timeline))
+insertMany
+    :: (Ord time, Ord a)
+    => time
+    -> Set a
+    -> Timeline time a
+    -> Timeline time a
+insertMany t xs timeline =
+    Timeline
+        (insertManyKeys xs t (events timeline))
+        (InverseMap.insertManyKeys xs t (eventsByTime timeline))
 
-difference ::
-             (Ord time, Ord a) => Timeline time a -> Set a -> Timeline time a
-difference timeline xs
-  = Timeline (Map.withoutKeys (events timeline) xs)
-      (InverseMap.difference (eventsByTime timeline)
-         (Map.restrictKeys (events timeline) xs))
+difference
+    :: (Ord time, Ord a) => Timeline time a -> Set a -> Timeline time a
+difference timeline xs =
+    Timeline
+        (Map.withoutKeys (events timeline) xs)
+        ( InverseMap.difference
+            (eventsByTime timeline)
+            (Map.restrictKeys (events timeline) xs)
+        )
 
-takeWhileAntitone ::
-                    (Ord time, Ord a) =>
-                    (time -> Bool) -> Timeline time a -> (Set a, Timeline time a)
-takeWhileAntitone predicate timeline
-  = (foldMap id
-       (snd (Map.spanAntitone predicate (eventsByTime timeline))),
-     Timeline
-       (Map.withoutKeys (events timeline)
-          (foldMap id
-             (snd (Map.spanAntitone predicate (eventsByTime timeline)))))
-       (fst (Map.spanAntitone predicate (eventsByTime timeline))))
+takeWhileAntitone
+    :: (Ord time, Ord a)
+    => (time -> Bool)
+    -> Timeline time a
+    -> (Set a, Timeline time a)
+takeWhileAntitone predicate timeline =
+    ( foldMap
+        id
+        (snd (Map.spanAntitone predicate (eventsByTime timeline)))
+    , Timeline
+        ( Map.withoutKeys
+            (events timeline)
+            ( foldMap
+                id
+                (snd (Map.spanAntitone predicate (eventsByTime timeline)))
+            )
+        )
+        (fst (Map.spanAntitone predicate (eventsByTime timeline)))
+    )
 
-dropWhileAntitone ::
-                    (Ord time, Ord a) =>
-                    (time -> Bool) -> Timeline time a -> (Set a, Timeline time a)
-dropWhileAntitone predicate timeline
-  = (foldMap id
-       (fst (Map.spanAntitone predicate (eventsByTime timeline))),
-     Timeline
-       (Map.withoutKeys (events timeline)
-          (foldMap id
-             (fst (Map.spanAntitone predicate (eventsByTime timeline)))))
-       (snd (Map.spanAntitone predicate (eventsByTime timeline))))
+dropWhileAntitone
+    :: (Ord time, Ord a)
+    => (time -> Bool)
+    -> Timeline time a
+    -> (Set a, Timeline time a)
+dropWhileAntitone predicate timeline =
+    ( foldMap
+        id
+        (fst (Map.spanAntitone predicate (eventsByTime timeline)))
+    , Timeline
+        ( Map.withoutKeys
+            (events timeline)
+            ( foldMap
+                id
+                (fst (Map.spanAntitone predicate (eventsByTime timeline)))
+            )
+        )
+        (snd (Map.spanAntitone predicate (eventsByTime timeline)))
+    )
 
-deleteAfter ::
-              (Ord time, Ord a) =>
-              time -> Timeline time a -> (Set a, Timeline time a)
+deleteAfter
+    :: (Ord time, Ord a)
+    => time
+    -> Timeline time a
+    -> (Set a, Timeline time a)
 deleteAfter t = takeWhileAntitone (<= t)
 
-restrictRange ::
-                (Ord time, Ord a) =>
-                (time, time) -> Timeline time a -> Timeline time a
-restrictRange (from, to)
-  = \case
+restrictRange
+    :: (Ord time, Ord a)
+    => (time, time)
+    -> Timeline time a
+    -> Timeline time a
+restrictRange (from, to) =
+    \case
         (_, s) -> s
-      .
-      dropWhileAntitone (<= from) .
-        \case
+        . dropWhileAntitone (<= from)
+        . \case
             (_, s) -> s
-          . takeWhileAntitone (<= to)
-
+        . takeWhileAntitone (<= to)

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maybe.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maybe.hs
@@ -16,4 +16,3 @@ catMaybes (Just x : xs) = x : catMaybes xs
 fromMaybe :: a -> Maybe a -> a
 fromMaybe _ (Just a) = a
 fromMaybe a Nothing = a
-


### PR DESCRIPTION
This pull request adds a `fourmolu` pass on the Haskell code that was generated by `agda2hs` in order to improve readability. (I find some of the indentation choices of the `haskell-src-exts` pretty printer questionable.)