### PR TITLE
Fix name shadowing in `Cardano.Wallet.Deposit.Read.Value`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read/Value.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read/Value.agda
@@ -130,7 +130,7 @@ monus a b = record
   }
   where
     minus : Quantity → Quantity → Quantity
-    minus a b = a - b
+    minus x y = x - y
 
 {-# COMPILE AGDA2HS monus #-}
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read/Value.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read/Value.hs
@@ -89,4 +89,4 @@ monus a b =
         (Map.unionWith minus (assets a) (assets b))
   where
     minus :: Quantity -> Quantity -> Quantity
-    minus a b = a - b
+    minus x y = x - y


### PR DESCRIPTION
This pull request fixes a warning about name-shadowing in `Cardano.Wallet.Deposit.Read.Value`.