### PR TITLE
Expose `Data.Maps.Timeline`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
@@ -84,6 +84,15 @@ toAscList =
     ∘ Map.toAscList
     ∘ eventsByTime
 
+-- | Insert a single item.
+insert
+    : {{_ : Ord time}} {{_ : Ord a}}
+    → time → a → Timeline time a → Timeline time a
+insert t x timeline = record
+    { events = Map.insert x t (events timeline)
+    ; eventsByTime = InverseMap.insert x t (eventsByTime timeline)
+    }
+
 -- | Insert a set of items that all have the same timestamp.
 insertMany
     : {{_ : Ord time}} {{_ : Ord a}}
@@ -166,6 +175,7 @@ restrictRange (from , to) =
 {-# COMPILE AGDA2HS lookupByItem #-}
 {-# COMPILE AGDA2HS getMapTime #-}
 {-# COMPILE AGDA2HS toAscList #-}
+{-# COMPILE AGDA2HS insert #-}
 {-# COMPILE AGDA2HS insertMany #-}
 {-# COMPILE AGDA2HS difference #-}
 {-# COMPILE AGDA2HS takeWhileAntitone #-}

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -81,6 +81,7 @@ library
     Cardano.Wallet.Deposit.Read
     Cardano.Wallet.Deposit.Read.Value
     Cardano.Write.Tx.Balance
+    Data.Maps.Timeline
   other-modules:
     Haskell.Data.ByteString
     Haskell.Data.List

--- a/lib/customer-deposit-wallet-pure/haskell/Data/Maps/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Data/Maps/Timeline.hs
@@ -1,0 +1,5 @@
+module Data.Maps.Timeline
+    ( module Haskell.Data.Maps.Timeline
+    ) where
+
+import Haskell.Data.Maps.Timeline

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
@@ -17,6 +17,7 @@ import qualified Haskell.Data.Map as Map
 import qualified Haskell.Data.Maps.InverseMap as InverseMap
     ( InverseMap
     , difference
+    , insert
     , insertManyKeys
     )
 import Haskell.Data.Maybe (fromMaybe)
@@ -56,6 +57,17 @@ toAscList =
             )
         . Map.toAscList
         . \r -> eventsByTime r
+
+insert
+    :: (Ord time, Ord a)
+    => time
+    -> a
+    -> Timeline time a
+    -> Timeline time a
+insert t x timeline =
+    Timeline
+        (Map.insert x t (events timeline))
+        (InverseMap.insert x t (eventsByTime timeline))
 
 insertMany
     :: (Ord time, Ord a)


### PR DESCRIPTION
This pull request exposes the module `Data.Maps.Timeline` in the package for outside use.

We also export a function `Data.Maps.Timeline.insert` that inserts a single item only.
