### PR TITLE
Update CHaP

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,11 +17,11 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 -- repeating the index-state for hackage to work around hackage.nix parsing limitation
-index-state: 2024-03-19T15:29:53Z
+index-state: 2024-08-08T00:00:00Z
 
 index-state:
-  , hackage.haskell.org 2024-03-19T15:29:53Z
-  , cardano-haskell-packages 2024-03-15T17:07:52Z
+  , hackage.haskell.org 2024-08-08T00:00:00Z
+  , cardano-haskell-packages 2024-06-29T00:00:00Z
 
 --------------------------------------------------------------------------------
 -- Projects in the present repository

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1712590917,
-        "narHash": "sha256-DgXSWHF5b/UtM+ACBWLPNtMNTSGQrmtl/ME7e7dheLo=",
+        "lastModified": 1724028980,
+        "narHash": "sha256-KQ34tQnOMznr3cwPXJAOHyek3Trps5gzNrPmSrEjev4=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "251738d00d5799850c6eb610c4ab7b175b66224a",
+        "rev": "def0ec7a8cc0f11bba4f29cb7f5643eac5daba23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This pull request updates the `CHaP` input of `flake.nix` so that we may depend on upstream packages, such as `cardano-ledger-api`.