### PR TITLE
Depend on mocked `Cardano.Wallet.Read.Address`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read.agda
@@ -3,6 +3,7 @@ module Cardano.Wallet.Deposit.Read where
 
 open import Haskell.Prelude
 
+open import Cardano.Wallet.Read.Address public
 open import Cardano.Wallet.Read.Eras public
 open import Cardano.Wallet.Read.Block public
 open import Cardano.Wallet.Read.Chain public
@@ -16,25 +17,14 @@ import Cardano.Wallet.Read.Value
     )
 #-}
 
-import Haskell.Data.ByteString as BS
 import Haskell.Data.Map as Map
 
 {-----------------------------------------------------------------------------
     Address
 ------------------------------------------------------------------------------}
 
-Addr = BS.ByteString
+Addr = CompactAddr
 Address = Addr
-
-instance
-  iEqAddress : Eq Address
-  iEqAddress = BS.iEqByteString
-
-  iOrdAddress : Ord Address
-  iOrdAddress = BS.iOrdByteString
-
-  iLawfulEqAddress : IsLawfulEq Address
-  iLawfulEqAddress = BS.iLawfulEqByteString
 
 {-# COMPILE AGDA2HS Addr #-}
 {-# COMPILE AGDA2HS Address #-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Address.agda
@@ -1,0 +1,102 @@
+{-# OPTIONS --erasure #-}
+
+-- Synchronized manually with the corresponding Haskell module.
+module Cardano.Wallet.Read.Address
+    {-
+    ; CompactAddr
+      ; toShortByteString
+      ; fromShortByteString
+      ; isBootstrapCompactAddr
+    -}
+    where
+
+open import Haskell.Prelude
+
+open import Haskell.Data.ByteString.Short using
+    ( ShortByteString
+    )
+open import Haskell.Data.Maybe using
+    ( isJust
+    ; prop-Just-injective
+    )
+
+{-----------------------------------------------------------------------------
+    Address
+------------------------------------------------------------------------------}
+postulate
+  CompactAddr : Set
+
+  instance
+    iEqCompactAddr : Eq CompactAddr
+    iLawfulEqCompactAddr : IsLawfulEq CompactAddr
+
+  iOrdCompactAddr₀ : Ord CompactAddr
+
+  toShortByteString : CompactAddr → ShortByteString
+  fromShortByteString : ShortByteString → Maybe CompactAddr
+
+  isBootstrapCompactAddr : CompactAddr → Bool
+
+instance
+  iOrdCompactAddr : Ord CompactAddr
+  iOrdCompactAddr = record iOrdCompactAddr₀ { super = iEqCompactAddr }
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+
+postulate
+
+  prop-from-∘-to
+    : ∀ (x : CompactAddr)
+    → fromShortByteString (toShortByteString x) ≡ Just x
+
+  prop-to-∘-from-Just
+    : ∀ (s : ShortByteString)
+        (x : CompactAddr)
+    → fromShortByteString s ≡ Just x
+    → toShortByteString x ≡ s
+
+prop-toShortByteString-injective
+  : ∀ (x y : CompactAddr)
+  → toShortByteString x ≡ toShortByteString y
+  → x ≡ y
+prop-toShortByteString-injective x y eq =
+    prop-Just-injective _ _ lem1
+  where
+    lem1 : _
+    lem1 =
+      begin
+        Just x
+      ≡⟨ sym (prop-from-∘-to x) ⟩
+        fromShortByteString (toShortByteString x)
+      ≡⟨ cong fromShortByteString eq ⟩
+        fromShortByteString (toShortByteString y)
+      ≡⟨ prop-from-∘-to y ⟩
+        Just y
+      ∎
+
+@0 prop-fromShortByteString-partially-injective
+  : ∀ (sx sy : ShortByteString)
+  → @0 (isJust (fromShortByteString sx) ≡ True)
+  → fromShortByteString sx ≡ fromShortByteString sy
+  → sx ≡ sy
+prop-fromShortByteString-partially-injective sx sy eqJust eq =
+  case fromShortByteString sx of λ
+    { Nothing {{eqNothingx}} →
+        case (trans (sym eqJust) (cong isJust eqNothingx)) of λ ()
+    ; (Just x) {{eqJustx}} →
+       case fromShortByteString sy of λ 
+       { Nothing {{eqNothingy}} →
+            case (trans (trans (sym eqJustx) eq) eqNothingy) of λ ()
+       ; (Just y) {{eqJusty}} →
+        begin
+          sx
+        ≡⟨ sym (prop-to-∘-from-Just sx y (trans eq eqJusty)) ⟩
+          toShortByteString y
+        ≡⟨ prop-to-∘-from-Just sy y eqJusty ⟩
+          sy
+        ∎
+       }
+    }
+ 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Tx.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Tx.agda
@@ -14,13 +14,15 @@ open import Haskell.Data.Set using
 open import Haskell.Data.Word using
     ( Word16
     )
+open import Cardano.Wallet.Read.Address using
+    ( CompactAddr
+    )
 open import Cardano.Wallet.Read.Eras using
     ( IsEra
     )
 open import Cardano.Wallet.Read.Value using
     ( Value
     )
-import Haskell.Data.ByteString as BS
 
 {-----------------------------------------------------------------------------
     TxId
@@ -73,7 +75,6 @@ postulate instance
 {-----------------------------------------------------------------------------
     TxOut
 ------------------------------------------------------------------------------}
-CompactAddr = BS.ByteString
 
 postulate
   TxOut : Set

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString.agda
@@ -41,12 +41,12 @@ singleton : Word8 → ByteString
 singleton x = pack (x ∷ [])
 
 instance
-  iSemigroupDeltaUTxO : Semigroup ByteString
-  iSemigroupDeltaUTxO = record { _<>_ = append }
+  iSemigroupByteString : Semigroup ByteString
+  iSemigroupByteString = record { _<>_ = append }
 
 instance
-  iMonoidDeltaUTxO : Monoid ByteString
-  iMonoidDeltaUTxO =
+  iMonoidByteString : Monoid ByteString
+  iMonoidByteString =
     record {DefaultMonoid (λ where .DefaultMonoid.mempty → empty)}
 
 {-----------------------------------------------------------------------------

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString/Short.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString/Short.agda
@@ -1,0 +1,167 @@
+{-# OPTIONS --erasure #-}
+
+module Haskell.Data.ByteString.Short
+    {-
+    ; ByteString
+    -}
+    where
+
+open import Haskell.Prelude hiding (lookup; null; map)
+
+open import Haskell.Data.Word using
+    ( Word8
+    )
+
+import Haskell.Data.ByteString as BS
+
+{-----------------------------------------------------------------------------
+    ByteString
+------------------------------------------------------------------------------}
+
+postulate
+  ShortByteString : Set
+
+postulate
+  pack   : List Word8 → ShortByteString
+  unpack : ShortByteString → List Word8
+
+  instance
+    iEqShortByteString  : Eq ShortByteString
+  
+  iOrdShortByteString₀ : Ord ShortByteString
+
+instance
+  iOrdShortByteString : Ord ShortByteString
+  iOrdShortByteString =
+      record iOrdShortByteString₀ { super = iEqShortByteString }
+
+empty : ShortByteString
+empty = pack []
+
+singleton : Word8 → ShortByteString
+singleton x = pack (x ∷ [])
+
+fromShort : ShortByteString → BS.ByteString
+fromShort = BS.pack ∘ unpack
+
+toShort : BS.ByteString → ShortByteString
+toShort = pack ∘ BS.unpack
+
+append : ShortByteString → ShortByteString → ShortByteString
+append x y = pack (unpack x ++ unpack y)
+
+instance
+  iSemigroupShortByteString : Semigroup ShortByteString
+  iSemigroupShortByteString = record { _<>_ = append }
+
+instance
+  iMonoidShortByteString : Monoid ShortByteString
+  iMonoidShortByteString =
+    record {DefaultMonoid (λ where .DefaultMonoid.mempty → empty)}
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+
+postulate
+  prop-pack-∘-unpack
+    : ∀ (x : ShortByteString)
+    → pack (unpack x) ≡ x
+
+  prop-unpack-∘-pack
+    : ∀ (x : List Word8)
+    → unpack (pack x) ≡ x
+  
+  instance
+    iLawfulEqShortByteString : IsLawfulEq ShortByteString
+
+{-----------------------------------------------------------------------------
+    Properties
+    Injectivity
+------------------------------------------------------------------------------}
+
+prop-pack-injective
+  : ∀ (x y : List Word8)
+  → pack x ≡ pack y
+  → x ≡ y
+prop-pack-injective x y eq =
+  begin
+    x
+  ≡⟨ sym (prop-unpack-∘-pack x) ⟩
+    unpack (pack x)
+  ≡⟨ cong unpack eq ⟩
+    unpack (pack y)
+  ≡⟨ prop-unpack-∘-pack y ⟩
+    y
+  ∎
+
+prop-unpack-injective
+  : ∀ (x y : ShortByteString)
+  → unpack x ≡ unpack y
+  → x ≡ y
+prop-unpack-injective x y eq =
+  begin
+    x
+  ≡⟨ sym (prop-pack-∘-unpack x) ⟩
+    pack (unpack x)
+  ≡⟨ cong pack eq ⟩
+    pack (unpack y)
+  ≡⟨ prop-pack-∘-unpack y ⟩
+    y
+  ∎
+
+prop-fromShort-injective
+  : ∀ (x y : ShortByteString)
+  → fromShort x ≡ fromShort y
+  → x ≡ y
+prop-fromShort-injective x y =
+  prop-unpack-injective _ _
+  ∘ BS.prop-pack-injective _ _
+
+prop-toShort-injective
+  : ∀ (x y : BS.ByteString)
+  → toShort x ≡ toShort y
+  → x ≡ y
+prop-toShort-injective x y =
+  BS.prop-unpack-injective _ _
+  ∘ prop-pack-injective _ _
+
+{-----------------------------------------------------------------------------
+    Properties
+    Semigroup morphisms
+------------------------------------------------------------------------------}
+
+prop-pack-morphism
+  : ∀ (x y : List Word8)
+  → pack x <> pack y ≡ pack (x ++ y)
+prop-pack-morphism x y =
+  begin
+    pack x <> pack y
+  ≡⟨⟩
+    pack (unpack (pack x) ++ unpack (pack y))
+  ≡⟨ cong (λ X → pack (X ++ unpack (pack y))) (prop-unpack-∘-pack x) ⟩
+    pack (x ++ unpack (pack y))
+  ≡⟨ cong (λ Y → pack (x ++ Y)) (prop-unpack-∘-pack y) ⟩
+    pack (x ++ y)
+  ∎
+
+prop-unpack-morphism
+  : ∀ (x y : ShortByteString)
+  → unpack (x <> y) ≡ unpack x ++ unpack y
+prop-unpack-morphism x y =
+  begin
+    unpack (x <> y)
+  ≡⟨ cong unpack refl ⟩
+    unpack (pack (unpack x ++ unpack y))
+  ≡⟨ prop-unpack-∘-pack _ ⟩
+    unpack x ++ unpack y
+  ∎
+
+prop-<>-cancel-left
+  : ∀ (x y z : ShortByteString)
+  → x <> y ≡ x <> z
+  → y ≡ z
+prop-<>-cancel-left x y z =
+  prop-unpack-injective _ _
+  ∘ ++-cancel-left (unpack x) (unpack y)
+  ∘ prop-pack-injective _ _

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maybe.agda
@@ -21,10 +21,15 @@ fromMaybe : ∀ {a : Set} → a → Maybe a → a
 fromMaybe _ (Just a) = a
 fromMaybe a Nothing = a
 
+fromJust : (x : Maybe a) → @0 {isJust x ≡ True} → a
+fromJust Nothing  = error "fromJust Nothing"
+fromJust (Just x) = x
+
 {-# COMPILE AGDA2HS isNothing #-}
 {-# COMPILE AGDA2HS isJust #-}
 {-# COMPILE AGDA2HS catMaybes #-}
 {-# COMPILE AGDA2HS fromMaybe #-}
+{-# COMPILE AGDA2HS fromJust #-}
 
 prop-Just-injective
   : ∀ {a : Set} (x y : a)

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maybe.agda
@@ -36,3 +36,10 @@ prop-Just-injective
   → Just x ≡ Just y
   → x ≡ y
 prop-Just-injective _ _ refl = refl
+
+prop-fromJust-injective
+  : ∀ {a} (x y : Maybe a)
+  → {@0 px : isJust x ≡ True} → {@0 py : isJust y ≡ True}
+  → fromJust x {px} ≡ fromJust y {py}
+  → x ≡ y
+prop-fromJust-injective (Just a) (Just b) refl = refl

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maybe.agda
@@ -25,3 +25,9 @@ fromMaybe a Nothing = a
 {-# COMPILE AGDA2HS isJust #-}
 {-# COMPILE AGDA2HS catMaybes #-}
 {-# COMPILE AGDA2HS fromMaybe #-}
+
+prop-Just-injective
+  : ∀ {a : Set} (x y : a)
+  → Just x ≡ Just y
+  → x ≡ y
+prop-Just-injective _ _ refl = refl

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -63,6 +63,7 @@ library
     , cardano-ledger-api >= 1.9.2.0 && < 1.10
     , cardano-ledger-core >= 1.13.1.0 && < 1.14
     , cardano-ledger-mary >= 1.6.1.0 && < 1.7
+    , transformers >= 0.6.1.0 && < 0.7
   exposed-modules:
     Cardano.Wallet.Address.BIP32
     Cardano.Wallet.Address.BIP32_Ed25519
@@ -82,6 +83,7 @@ library
     Cardano.Wallet.Deposit.Pure.TxHistory.Type
     Cardano.Wallet.Deposit.Pure.TxSummary
     Cardano.Wallet.Deposit.Read
+    Cardano.Wallet.Read.Address
     Cardano.Wallet.Read.Block
     Cardano.Wallet.Read.Chain
     Cardano.Wallet.Read.Eras

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -91,6 +91,7 @@ library
     Data.Maps.Timeline
   other-modules:
     Haskell.Data.ByteString
+    Haskell.Data.ByteString.Short
     Haskell.Data.List
     Haskell.Data.Map
     Haskell.Data.Maps.InverseMap

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
@@ -2,13 +2,19 @@ module Cardano.Wallet.Address.Encoding where
 
 import Cardano.Wallet.Address.BIP32_Ed25519 (XPub, rawSerialiseXPub)
 import Cardano.Wallet.Address.Hash (blake2b'224)
-import Cardano.Wallet.Deposit.Read (Addr)
+import Cardano.Wallet.Read.Address (CompactAddr, fromShortByteString)
 import Data.Word (Word8)
-import Haskell.Data.ByteString (singleton)
+import Haskell.Data.ByteString.Short (ShortByteString, singleton, toShort)
+import Haskell.Data.Maybe (fromJust)
 
 tagEnterprise :: Word8
 tagEnterprise = 97
 
-mkEnterpriseAddress :: XPub -> Addr
+mkEnterpriseAddressBytes :: XPub -> ShortByteString
+mkEnterpriseAddressBytes xpub =
+    singleton tagEnterprise
+        <> toShort (blake2b'224 (rawSerialiseXPub xpub))
+
+mkEnterpriseAddress :: XPub -> CompactAddr
 mkEnterpriseAddress xpub =
-    singleton tagEnterprise <> blake2b'224 (rawSerialiseXPub xpub)
+    fromJust (fromShortByteString (mkEnterpriseAddressBytes xpub))

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -7,9 +7,9 @@ import Cardano.Wallet.Address.BIP32
 import Cardano.Wallet.Address.BIP32_Ed25519 (XPub, deriveXPubSoft)
 import Cardano.Wallet.Address.Encoding (mkEnterpriseAddress)
 import Cardano.Wallet.Deposit.Read (Address)
+import qualified Cardano.Wallet.Read.Address (CompactAddr)
 import Cardano.Write.Tx.Balance (ChangeAddressGen)
 import Data.Word.Odd (Word31)
-import qualified Haskell.Data.ByteString as BS (ByteString)
 import qualified Haskell.Data.Map as Map (Map, empty, insert, lookup, toAscList)
 import Haskell.Data.Maybe (isJust)
 
@@ -97,7 +97,8 @@ createAddress c s0 = (addr, s1)
     xpub = stateXPub s0
     addr :: Address
     addr = deriveCustomerAddress xpub c
-    addresses1 :: Map.Map BS.ByteString Word31
+    addresses1
+        :: Map.Map Cardano.Wallet.Read.Address.CompactAddr Word31
     addresses1 = Map.insert addr c (addresses s0)
     s1 :: AddressState
     s1 = AddressStateC (stateXPub s0) addresses1 (change s0)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read.hs
@@ -2,6 +2,7 @@
 
 module Cardano.Wallet.Deposit.Read where
 
+import Cardano.Wallet.Read.Address (CompactAddr)
 import Cardano.Wallet.Read.Block (Block, SlotNo)
 import Cardano.Wallet.Read.Chain
     ( ChainPoint (BlockPoint, GenesisPoint)
@@ -9,14 +10,13 @@ import Cardano.Wallet.Read.Chain
     )
 import Cardano.Wallet.Read.Eras (IsEra)
 import Cardano.Wallet.Read.Tx (Tx, TxIn, TxOut)
-import qualified Haskell.Data.ByteString as BS (ByteString)
 
 -- Working around a limitation in agda2hs.
 import Cardano.Wallet.Read.Value
     ( Value
     )
 
-type Addr = BS.ByteString
+type Addr = CompactAddr
 
 type Address = Addr
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Read/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Read/Address.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- 'Addr' — Addresses on the Cardano Blockchain
+module Cardano.Wallet.Read.Address
+    ( -- * Compact Addr
+      CompactAddr
+    , toShortByteString
+    , fromShortByteString
+    , isBootstrapCompactAddr
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
+import Control.Monad.Trans.State.Strict
+    ( evalStateT
+    )
+
+import qualified Cardano.Ledger.Address as SH
+import qualified Data.ByteString.Short as SBS
+
+{-----------------------------------------------------------------------------
+    CompactAddr
+------------------------------------------------------------------------------}
+type CompactAddr = SH.CompactAddr StandardCrypto
+
+toShortByteString :: CompactAddr -> SBS.ShortByteString
+toShortByteString = SH.unCompactAddr
+
+fromShortByteString :: SBS.ShortByteString -> Maybe CompactAddr
+fromShortByteString sbs =
+    SH.compactAddr
+        <$> evalStateT (SH.decodeAddrStateLenientT True True sbs) 0
+
+-- | Efficient check whether this is a Bootstrap address
+-- (i.e. an address that was valid in the Byron era).
+isBootstrapCompactAddr :: CompactAddr -> Bool
+isBootstrapCompactAddr = SH.isBootstrapCompactAddr

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Read/Tx.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Read/Tx.hs
@@ -16,6 +16,9 @@ module Cardano.Wallet.Read.Tx
 
 import Prelude
 
+import Cardano.Wallet.Read.Address
+    ( CompactAddr
+    )
 import Cardano.Wallet.Read.Eras
     ( IsEra
     )
@@ -59,8 +62,6 @@ data TxIn = TxInC
 {-----------------------------------------------------------------------------
     TxOut
 ------------------------------------------------------------------------------}
-type CompactAddr = ByteString
-
 data TxOut = TxOutC
     { getCompactAddr :: CompactAddr
     , getValue :: Value

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/ByteString/Short.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/ByteString/Short.hs
@@ -1,0 +1,5 @@
+module Haskell.Data.ByteString.Short
+    ( module Data.ByteString.Short
+    ) where
+
+import Data.ByteString.Short

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maybe.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maybe.hs
@@ -16,3 +16,7 @@ catMaybes (Just x : xs) = x : catMaybes xs
 fromMaybe :: a -> Maybe a -> a
 fromMaybe _ (Just a) = a
 fromMaybe a Nothing = a
+
+fromJust :: Maybe a -> a
+fromJust Nothing = error "fromJust Nothing"
+fromJust (Just x) = x


### PR DESCRIPTION
This pull request changes `Cardano.Wallet.Deposit` to depend on the
Haskell module `Cardano.Wallet.Read.Address` from the
`cardano-wallet-read` package.

At the moment, this dependency is mocked, it will be replaced by the
real thing later.

This pull request also adds

* A module `Haskell.Data.ByteString.Short` for the `ShortByteString` type.
* To the module `Haskell.Data.Maybe`
    * The function `fromJust` with proof obligation
    * Additional properties relating to injectivity
