### PR TITLE
Fix small issues with `cardano-wallet-read`

### DIFF
--- a/lib/cardano-wallet-read/cardano-wallet-read.cabal
+++ b/lib/cardano-wallet-read/cardano-wallet-read.cabal
@@ -86,7 +86,6 @@ library
     Cardano.Wallet.Read.Block.Gen.Shelley
     Cardano.Wallet.Read.Chain
     Cardano.Wallet.Read.Eras
-    Cardano.Wallet.Read.Eras.EraValue
     Cardano.Wallet.Read.Hash
     Cardano.Wallet.Read.Tx
     Cardano.Wallet.Read.Tx.CBOR
@@ -100,7 +99,9 @@ library
     Cardano.Wallet.Read.Tx.Gen.Mary
     Cardano.Wallet.Read.Tx.Gen.Shelley
     Cardano.Wallet.Read.Tx.Gen.TxParameters
+    Cardano.Wallet.Read.Value
   other-modules:
+    Cardano.Wallet.Read.Eras.EraValue
     Cardano.Wallet.Read.Tx.CollateralInputs
     Cardano.Wallet.Read.Tx.Inputs
     Cardano.Wallet.Read.Tx.ScriptValidity
@@ -108,7 +109,7 @@ library
     Cardano.Wallet.Read.Tx.TxId
     Cardano.Wallet.Read.Tx.TxIn
     Cardano.Wallet.Read.Tx.TxOut
-    Cardano.Wallet.Read.Value
+
 
   build-depends:
     , base >= 4.14.3.0 && < 4.20

--- a/lib/cardano-wallet-read/cardano-wallet-read.cabal
+++ b/lib/cardano-wallet-read/cardano-wallet-read.cabal
@@ -100,6 +100,8 @@ library
     Cardano.Wallet.Read.Tx.Gen.Mary
     Cardano.Wallet.Read.Tx.Gen.Shelley
     Cardano.Wallet.Read.Tx.Gen.TxParameters
+  other-modules:
+    Cardano.Wallet.Read.Tx.CollateralInputs
     Cardano.Wallet.Read.Tx.Inputs
     Cardano.Wallet.Read.Tx.ScriptValidity
     Cardano.Wallet.Read.Tx.Tx

--- a/lib/cardano-wallet-read/haskell/Cardano/Read/Ledger/Block/BlockNo.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Read/Ledger/Block/BlockNo.hs
@@ -54,7 +54,7 @@ getEraBlockNo = case theEra @era of
     k = BlockNo . fromIntegral . O.unBlockNo
 
 newtype BlockNo = BlockNo {unBlockNo :: Natural}
-    deriving (Eq, Ord, Show, Generic, Enum)
+    deriving (Eq, Ord, Show, Generic, Enum, Num)
 
 instance NoThunks BlockNo
 

--- a/lib/cardano-wallet-read/haskell/Cardano/Read/Ledger/Block/SlotNo.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Read/Ledger/Block/SlotNo.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -53,7 +54,7 @@ getEraSlotNo = case theEra @era of
     k = SlotNo . fromIntegral . O.unSlotNo
 
 newtype SlotNo = SlotNo {unSlotNo :: Natural}
-    deriving (Eq, Ord, Show, Generic)
+    deriving (Eq, Ord, Show, Generic, Enum, Num)
 
 instance NoThunks SlotNo
 

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 {- |
 Copyright: © 2022 IOHK, 2024 Cardano Foundation
 License: Apache-2.0
@@ -6,24 +7,50 @@ The 'Tx' type represents transactions as they are read from the mainnet ledger.
 It is compatible with the era-specific index types from @cardano-ledger@.
 -}
 module Cardano.Wallet.Read.Tx
-    ( Tx (..)
-    , TxT
+    (
+    -- * Tx
+      TxT
+    , Tx (..)
+    , getInputs
+    , getCollateralInputs
+    , IsValid (IsValid)
+    , getScriptValidity
 
+    -- * TxIn
     , TxId
     , getTxId
+    , txIdFromHash
+    , hashFromTxId
+
+    , TxIx
+    , pattern TxIx
 
     , TxIn
-    , getInputs
+    , pattern TxIn
 
+    -- * TxOut
     , TxOut
     , getCompactAddr
     , getValue
     , mkBasicTxOut
     , utxoFromEraTx
+    , upgradeTxOutToBabbageOrLater
+    , toBabbageOutput
+    , toConwayOutput
+    , deserializeTxOut
+    , serializeTxOut
+    , mkEraTxOut
     ) where
 
+import Cardano.Wallet.Read.Tx.CollateralInputs
+    ( getCollateralInputs
+    )
 import Cardano.Wallet.Read.Tx.Inputs
     ( getInputs
+    )
+import Cardano.Wallet.Read.Tx.ScriptValidity
+    ( IsValid (IsValid)
+    , getScriptValidity
     )
 import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
@@ -32,14 +59,25 @@ import Cardano.Read.Ledger.Tx.Tx
 import Cardano.Wallet.Read.Tx.TxId
     ( TxId
     , getTxId
+    , hashFromTxId
+    , txIdFromHash
     )
 import Cardano.Wallet.Read.Tx.TxIn
     ( TxIn
+    , TxIx
+    , pattern TxIn
+    , pattern TxIx
     )
 import Cardano.Wallet.Read.Tx.TxOut
     ( TxOut
+    , deserializeTxOut
     , getCompactAddr
     , getValue
     , mkBasicTxOut
+    , mkEraTxOut
+    , serializeTxOut
+    , toBabbageOutput
+    , toConwayOutput
+    , upgradeTxOutToBabbageOrLater
     , utxoFromEraTx
     )

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/CollateralInputs.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/CollateralInputs.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2020-2024 IOHK
+-- License: Apache-2.0
+--
+
+module Cardano.Wallet.Read.Tx.CollateralInputs
+    ( getCollateralInputs
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Read.Eras
+    ( Era (..)
+    , IsEra (..)
+    )
+import Cardano.Wallet.Read.Tx.Tx
+    ( Tx
+    )
+import Cardano.Wallet.Read.Tx.TxIn
+    ( TxIn
+    )
+import Data.Set
+    ( Set
+    )
+
+import qualified Cardano.Read.Ledger.Tx.CollateralInputs as L
+import qualified Data.Set as Set
+
+{-# INLINABLE getCollateralInputs #-}
+-- | Extract the collateral inputs from a transaction in any era.
+getCollateralInputs :: forall era . IsEra era => Tx era -> Set TxIn
+getCollateralInputs = case theEra :: Era era of
+    Byron -> const Set.empty
+    Shelley -> const Set.empty
+    Allegra -> const Set.empty
+    Mary -> const Set.empty
+    Alonzo -> unCollateralInputs . L.getEraCollateralInputs
+    Babbage -> unCollateralInputs . L.getEraCollateralInputs
+    Conway -> unCollateralInputs . L.getEraCollateralInputs
+
+unCollateralInputs :: L.CollateralInputs era -> L.CollateralInputsType era
+unCollateralInputs (L.CollateralInputs x) = x

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/TxId.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/TxId.hs
@@ -24,6 +24,9 @@ module Cardano.Wallet.Read.Tx.TxId
 
 import Prelude
 
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Hashes
     ( EraIndependentTxBody
     )
@@ -36,7 +39,6 @@ import Cardano.Wallet.Read.Tx.Tx
 import Cardano.Wallet.Read.Eras
     ( Era (..)
     , IsEra (..)
-    , Shelley
     )
 import Cardano.Wallet.Read.Hash
     ( Blake2b_256
@@ -58,7 +60,7 @@ import qualified Cardano.Read.Ledger.Tx.TxId as L
 -- coercion between @Set TxId@ and @Set L.TxIdType Shelley@.
 -- Unfortunately, 'Set' expects a nominal role.
 -- (See the design literature on 'Data.Coercible'.)
-type TxId = L.TxIdType Shelley
+type TxId = SH.TxIn.TxId StandardCrypto
 
 {-# COMPLETE TxId #-}
 pattern TxId :: Hash Blake2b_256 EraIndependentTxBody -> TxId

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/TxOut.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/TxOut.hs
@@ -209,8 +209,8 @@ deserializeTxOut bytes
 utxoFromEraTx :: forall era. IsEra era => Tx era -> Map.Map TxIn TxOut
 utxoFromEraTx tx =
     case Read.getScriptValidity tx of
-        Read.IsValid True -> utxoFromEraTxCollateralOutputs tx
-        Read.IsValid False -> utxoFromEraTxOutputs tx
+        Read.IsValid True -> utxoFromEraTxOutputs tx
+        Read.IsValid False -> utxoFromEraTxCollateralOutputs tx
 
 {-# INLINEABLE utxoFromEraTxOutputs #-}
 -- | UTxO corresponding to the ordinary outputs of a transaction.

--- a/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxIdSpec.hs
+++ b/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxIdSpec.hs
@@ -15,9 +15,7 @@ import Cardano.Wallet.Read.Hash
     )
 import Cardano.Wallet.Read.Tx
     ( Tx
-    )
-import Cardano.Wallet.Read.Tx.TxId
-    ( TxId
+    , TxId
     , getTxId
     , txIdFromHash
     )

--- a/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
+++ b/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
@@ -37,7 +37,7 @@ import Cardano.Wallet.Read.Eras
 import Cardano.Wallet.Read.Hash
     ( hashFromBytesAsHex
     )
-import Cardano.Wallet.Read.Tx.TxOut
+import Cardano.Wallet.Read.Tx
     ( TxOut
     , getValue
     , mkEraTxOut


### PR DESCRIPTION
This pull request fixes various small issues with the `cardano-wallet-read` package.

It also fixes a larger issue — the definition of `utxoFromEraTx` was wrong. 😳 It should be moved to the `.agda` files and accompanied with some proof that making a basic transaction with outputs and applying it to the `UTxO` has the same effect as adding the outputs directly.
