### PR TITLE
Add COMPLETE pragma to `IsValidC`

### DIFF
--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/ScriptValidity.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/ScriptValidity.hs
@@ -31,6 +31,7 @@ import Cardano.Wallet.Read.Tx.Tx
     ( Tx (..)
     )
 
+{-# COMPLETE IsValidC #-}
 pattern IsValidC :: Bool -> IsValid
 pattern IsValidC x = IsValid x
 


### PR DESCRIPTION
This pull request adds a COMPLETE pragram to the `IsValidC` pattern synonym in order to enable checking for incomplete pattern matches in dependent code.