### PR TITLE
Separate Haskell build step and add `-frelease` flag

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,14 +21,29 @@ steps:
     env:
       TMPDIR: "/tmp"
 
-  - label: "Build .agda .hs"
+  - group: "Build artifacts"
     depends_on: linux-nix
-    command: |
-      ${nix} --command bash -c 'just ci-build'
-    agents:
-      system: ${linux}
-    env:
-      TMPDIR: "/tmp"
+    steps:
+
+    - label: "Build .agda"
+      key: build-agda
+      depends_on: []
+      command: |
+        ${nix} --command bash -c 'just ci-build-agda'
+      agents:
+        system: ${linux}
+      env:
+        TMPDIR: "/tmp"
+
+    - label: "Build .hs"
+      key: build-hs
+      depends_on: []
+      command: |
+        ${nix} --command bash -c 'just ci-build-hs'
+      agents:
+        system: ${linux}
+      env:
+        TMPDIR: "/tmp"
 
   - label: "Check unit tests"
     depends_on: linux-nix

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ ci-build-agda:
     just haskell && git diff --exit-code
 
 ci-build-hs:
-    cabal update && cabal build -v0 -j all
+    cabal update && cabal build -v0 -j all -frelease
 
 ci-check:
     # We do not rebuild the .hs files,

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ haskell:
     cd lib/customer-deposit-wallet-pure/ && ./generate-haskell.sh
 
 build:
-    cabal build -v0 -O -j all
+    cabal build -O -j all
 
 build0:
     cabal build -v0 -O0 -j all
@@ -16,8 +16,11 @@ build0:
 test:
     cabal test -v0 -O0 -j all
 
-ci-build:
-    just haskell && git diff --exit-code && just build0
+ci-build-agda:
+    just haskell && git diff --exit-code
+
+ci-build-hs:
+    cabal update && cabal build -v0 -j all
 
 ci-check:
     # We do not rebuild the .hs files,


### PR DESCRIPTION
This pull request changes CI such that

* The transpilation of `.agda` files is a separate step from the compilation of `.hs` files.
* The `.hs` files are compiled with the `-frelease` flag.

### Comments

* As the codebase is small and should compile quickly, there is no need to introduce `block` steps in the Buildkite pipeline — there is no secondary CI.