### PR TITLE
[ADP-3344] Add type `RollbackWindow`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/RollbackWindow.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/RollbackWindow.agda
@@ -1,0 +1,318 @@
+{-# OPTIONS --erasure #-}
+
+module Cardano.Wallet.Deposit.Pure.RollbackWindow where
+
+open import Haskell.Prelude hiding
+    ( null
+    )
+open import Haskell.Reasoning
+
+open import Haskell.Data.Maybe using
+    ( fromMaybe
+    ; prop-Just-injective
+    )
+open import Haskell.Data.Set using
+    ( ℙ
+    )
+
+import Haskell.Data.Map as Map
+import Haskell.Data.Set as Set
+
+{-----------------------------------------------------------------------------
+    Helpers
+------------------------------------------------------------------------------}
+if'
+  : (b : Bool)
+  → (thn : @0 (b ≡ True) → a)
+  → (els : @0 (b ≡ False) → a)
+  → a
+if' True thn els = thn refl
+if' False thn els = els refl 
+
+{-# COMPILE AGDA2HS if' #-}
+
+prop-if'-False
+  : ∀ (b : Bool)
+  → (cond : b ≡ False)
+  → {thn : @0 (b ≡ True) → a}
+  → {els : @0 (b ≡ False) → a}
+  → if' b thn els ≡ els cond
+prop-if'-False .False refl = refl
+
+prop-if'-True
+  : ∀ (b : Bool)
+  → (cond : b ≡ True)
+  → {thn : @0 (b ≡ True) → a}
+  → {els : @0 (b ≡ False) → a}
+  → if' b thn els ≡ thn cond
+prop-if'-True .True refl = refl
+
+-- Substitution that also amends an equality proof.
+substWithEq
+  : ∀ {A B : Set} {x : A} (f : (a1 : A) → @0 (x ≡ a1) → B)
+  → {y : A} → (eq : x ≡ y) → (f x refl ≡ f y eq)
+substWithEq f refl = refl
+
+{-----------------------------------------------------------------------------
+    RollbackWindow
+------------------------------------------------------------------------------}
+-- | A 'RollbackWindow' is a time interval.
+-- This time interval is used to keep track of data / transactions
+-- that are not final and may still be rolled back.
+-- The 'tip' is the higher end of the interval,
+-- representing the latest state of the data.
+-- The 'finality' is the lower end of the interval,
+-- until which rollbacks are supported.
+record RollbackWindow (time : Set) {{_ : Ord time}} : Set where
+  constructor RollbackWindowC
+  field
+    finality : time
+    tip : time
+    @0 invariant : (finality <= tip) ≡ True
+
+open RollbackWindow public
+
+-- | Test whether a given time is within a 'RollbackWindow'.
+member
+    : ∀ {time} {{_ : Ord time}}
+    → time → RollbackWindow time → Bool
+member time w = (finality w <= time) && (time <= tip w)
+
+-- | Interval containing a single point
+singleton
+    : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+    → time → RollbackWindow time
+singleton time = record
+    { tip = time
+    ; finality = time
+    ; invariant = reflexivity time
+    }
+
+-- | Move forward the tip of the 'RollbackWindow'.
+-- Return 'Nothing' if the new tip would not actually be moving forward.
+rollForward
+    : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+    → time → RollbackWindow time → Maybe (RollbackWindow time)
+rollForward newTip w =
+    if tip w < newTip
+       then (λ {{cond}} → Just (record
+          { finality = finality w
+          ; tip = newTip
+          ; invariant =
+            transitivity
+              (finality w) (tip w) newTip
+              (prop-⋀-&& (invariant w `and` (lt2lte (tip w) newTip cond)))
+          }))
+       else Nothing
+
+-- | Potential results of a 'rollBackwards'.
+data MaybeRollback (a : Set) : Set where
+    Past : MaybeRollback a
+    Present : a → MaybeRollback a
+    Future : MaybeRollback a
+
+-- | Roll back the tip of the 'RollbackWindow' to a point within the window.
+-- Return different error conditions if the target is outside the window.
+rollBackward
+    : ∀ {time} {{_ : Ord time}}
+    → time → RollbackWindow time → MaybeRollback (RollbackWindow time)
+rollBackward newTip w =
+  if tip w < newTip
+    then Future
+    else if finality w <= newTip
+      then (λ {{cond}} → Present (record
+        { tip = newTip
+        ; finality = finality w
+        ; invariant = cond
+        }))
+      else Past
+
+-- | Move forward the finality of the 'RollbackWindow'.
+-- Return 'Nothing' if the finality is not moving forward, or too far.
+prune
+    : ∀ {time} {{_ : Ord time}}
+    → time → RollbackWindow time → Maybe (RollbackWindow time)
+prune newFinality w =
+  if member newFinality w
+    then (λ {{cond}} → Just (record
+      { tip = tip w
+      ; finality = newFinality
+      ; invariant = projr (prop-&&-⋀ cond)
+      }))
+    else Nothing
+
+-- The anonymous module is need to get `forall time` in the Haskell code.
+module _ {time : Set} {{_ : Ord time}} where
+-- | Intersection of two 'RollbackWindow'.
+  intersect
+    : ∀ {{@0 _ : IsLawfulOrd time}}
+    → RollbackWindow time → RollbackWindow time → Maybe (RollbackWindow time)
+  intersect w1 w2 =
+    if' (fin3 <= tip3)
+      (λ eq → Just (record
+          { tip = tip3
+          ; finality = fin3
+          ; invariant = eq
+          })
+      )
+      (λ eq → Nothing)
+    where
+      fin3 = max (finality w1) (finality w2)
+      tip3 = min (tip w1) (tip w2)
+
+{-# COMPILE AGDA2HS RollbackWindow #-}
+{-# COMPILE AGDA2HS member #-}
+{-# COMPILE AGDA2HS singleton #-}
+{-# COMPILE AGDA2HS rollForward #-}
+{-# COMPILE AGDA2HS MaybeRollback #-}
+{-# COMPILE AGDA2HS rollBackward #-}
+{-# COMPILE AGDA2HS prune #-}
+{-# COMPILE AGDA2HS intersect #-}
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+--
+@0 prop-tip-member
+  : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+      (w : RollbackWindow time)
+  → member (tip w) w ≡ True
+--
+prop-tip-member w =
+  begin
+    member (tip w) w
+  ≡⟨⟩
+    (finality w <= tip w) && (tip w <= tip w)
+  ≡⟨ cong (λ o → (finality w <= tip w) && o) (reflexivity (tip w)) ⟩
+    (finality w <= tip w) && True
+  ≡⟨ prop-x-&&-True _ ⟩
+    (finality w <= tip w)
+  ≡⟨ invariant w ⟩
+    True
+  ∎
+
+--
+@0 prop-finality-member
+  : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+      (w : RollbackWindow time)
+  → member (finality w) w ≡ True
+--
+prop-finality-member w =
+  begin
+    member (finality w) w
+  ≡⟨⟩
+    (finality w <= finality w) && (finality w <= tip w)
+  ≡⟨ cong (λ o → o && (finality w <= tip w) ) (reflexivity (finality w)) ⟩
+    True && (finality w <= tip w)
+  ≡⟨ invariant w ⟩
+    True
+  ∎
+
+{-
+Remark: 
+Somehow, we want to make an argument based on the result of a function.
+"If it returns Just, then some precondition has to hold".
+I think that this is a regularly occuring pattern which we need to
+handle better than this, where we undo the structure of the function.
+Somehow, taking the contrapositive is very classical reasoning.
+-}
+
+--
+@0 lemma-between-max-min
+  : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+  → (t1 t2 t3 t4 t : time)
+  → ((max t1 t2 <= t) && (t <= min t3 t4))
+    ≡ ((t1 <= t && t <= t3) && (t2 <= t && t <= t4))
+--
+lemma-between-max-min t1 t2 t3 t4 t =
+    begin
+      max t1 t2 <= t && t <= min t3 t4
+    ≡⟨ cong (λ o → o && t <= min t3 t4) (prop-max-universal t1 t2 t) ⟩
+      (t1 <= t && t2 <= t) && (t <= min t3 t4)
+    ≡⟨ cong (λ o → (t1 <= t && t2 <= t) && o) (prop-min-universal t t3 t4) ⟩
+      (t1 <= t && t2 <= t) && (t <= t3 && t <= t4)
+    ≡⟨ shuffle (t1 <= t) (t2 <= t) (t <= t3) (t <= t4) ⟩
+      ((t1 <= t && t <= t3) && (t2 <= t && t <= t4))
+    ∎
+  where
+    shuffle
+      : ∀ (b1 b2 b3 b4 : Bool)
+      → ((b1 && b2) && (b3 && b4))
+        ≡ ((b1 && b3) && (b2 && b4))
+    shuffle False b2 b3 b4 = refl
+    shuffle True False False b4 = refl
+    shuffle True False True b4 = refl
+    shuffle True True b3 b4 = refl
+
+--
+@0 prop-member-intersect
+  : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+      (w1 w2 w3 : RollbackWindow time)
+      (t : time)
+  → intersect w1 w2 ≡ Just w3
+  → member t w3 ≡ (member t w1 && member t w2)
+--
+prop-member-intersect w1 w2 w3 t eq0 =
+    begin
+      member t w3
+    ≡⟨⟩
+      (finality w3 <= t) && (t <= tip w3)
+    ≡⟨ cong (λ o → (o <= t) && _) eqFin ⟩
+      (fin3 <= t) && (t <= tip w3)
+    ≡⟨ cong (λ o → (fin3 <= t) && (t <= o)) eqTip ⟩
+      (fin3 <= t) && (t <= tip3)
+    ≡⟨ lemma-between-max-min (finality w1) (finality w2) (tip w1) (tip w2) t ⟩
+      (member t w1 && member t w2)
+    ∎
+  where
+    fin3 = max (finality w1) (finality w2)
+    tip3 = min (tip w1) (tip w2)
+
+    @0 cases
+      : (b : Bool) → (@0 cond : (fin3 <= tip3) ≡ b) → (fin3 <= tip3) ≡ True
+    cases True cond = cond
+    cases False cond = case trans (sym eqNothing) eq0 of λ ()
+      where
+        eqNothing =
+          begin
+            intersect w1 w2
+          ≡⟨⟩
+            if' (fin3 <= tip3) _ (λ eq → Nothing)
+          ≡⟨ prop-if'-False (fin3 <= tip3) cond ⟩
+            Nothing
+          ∎
+
+    contra
+      : (fin3 <= tip3) ≡ True
+    contra = case (fin3 <= tip3) of λ
+      { True {{cond}} → cases True cond
+      ; False {{cond}} → cases False cond
+      }
+
+    eqJust =
+      begin
+        Just w3
+      ≡⟨ sym eq0 ⟩
+        intersect w1 w2
+      ≡⟨⟩
+        if' (fin3 <= tip3)
+          (λ eq → Just (record
+            { tip = tip3
+            ; finality = fin3
+            ; invariant = eq
+            })
+          )
+          (λ eq → Nothing)
+      ≡⟨ prop-if'-True (fin3 <= tip3) contra ⟩
+        Just (record
+          { tip = tip3
+          ; finality = fin3
+          ; invariant = contra
+          })
+      ∎
+        
+    eqFin : finality w3 ≡ fin3
+    eqFin = cong finality (prop-Just-injective _ _ eqJust)
+
+    eqTip : tip w3 ≡ tip3
+    eqTip = cong tip (prop-Just-injective _ _ eqJust)

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.agda
@@ -8,6 +8,9 @@ open import Cardano.Wallet.Deposit.Read using
     ; SlotNo
     ; TxIn
     )
+open import Cardano.Wallet.Deposit.Pure.RollbackWindow using
+    ( RollbackWindow
+    )
 open import Cardano.Wallet.Deposit.Pure.UTxO.UTxO using
     ( UTxO
     )
@@ -20,32 +23,6 @@ open import Haskell.Data.Maps.Timeline using
 open import Haskell.Data.Set using
     ( ℙ
     )
-
-{-----------------------------------------------------------------------------
-    Pruned
-------------------------------------------------------------------------------}
-
--- | The finality of the UTxO history.
-data Pruned : Set where
-    PrunedUpTo : SlotNo → Pruned
-    NotPruned  : Pruned
-
-instance
-  iEqPruned : Eq Pruned
-  iEqPruned ._==_ NotPruned NotPruned = True
-  iEqPruned ._==_ (PrunedUpTo x) (PrunedUpTo y) = x == y
-  iEqPruned ._==_ _ _ = False
-
-  iShowPruned : Show Pruned
-  iShowPruned = record {Show₂ (record {show = showPruned})}
-    where
-      showPruned : Pruned → String
-      showPruned (PrunedUpTo x) = "PrunedUpTo _"
-      showPruned NotPruned = "NotPruned"
-
-{-# COMPILE AGDA2HS Pruned #-}
-{-# COMPILE AGDA2HS iEqPruned derive #-}
-{-# COMPILE AGDA2HS iShowPruned derive #-}
 
 {-----------------------------------------------------------------------------
     UTxOHistory
@@ -64,10 +41,8 @@ record UTxOHistory : Set where
         -- ^ Creation slots of the TxIn, spent and unspent.
     spent : Timeline SlotNo TxIn
         -- ^ Spending slot number of the TxIn, spent.
-    tip : Slot
-        -- ^ Current tip slot.
-    finality : Pruned
-        -- ^ Finality slot.
+    window : RollbackWindow Slot
+        -- ^ Current rollback window.
     boot : UTxO
         -- ^ UTxO created at genesis.
 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Read.agda
@@ -64,6 +64,10 @@ instance
     (At _) Origin → GT
     (At x) (At y) → compare x y
 
+postulate instance
+  iIsLawfulOrdWithOrigin
+    : {{_ : Ord a}} → {{IsLawfulOrd a}} → IsLawfulOrd (WithOrigin a)
+
 {-# COMPILE AGDA2HS WithOrigin #-}
 {-# COMPILE AGDA2HS iEqWithOrigin derive #-}
 {-# COMPILE AGDA2HS iOrdWithOrigin derive #-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Block.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Block.agda
@@ -43,6 +43,9 @@ instance
   iOrdSlotNo : Ord SlotNo
   iOrdSlotNo = ordFromCompare (λ x y → compare (unSlotNo x) (unSlotNo y))
 
+postulate instance
+  iIsLawfulOrdSlotNo : IsLawfulOrd SlotNo
+
 {-----------------------------------------------------------------------------
     HeaderHash
 ------------------------------------------------------------------------------}

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning.agda
@@ -11,3 +11,4 @@ for an extended description of how to use these modules.
 
 open import Haskell.Reasoning.Core public
 open import Haskell.Reasoning.Bool public
+open import Haskell.Reasoning.Ord public

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
@@ -8,7 +8,6 @@ open import Haskell.Reasoning.Core
 {-----------------------------------------------------------------------------
     Relate (≡ True) to logical connectives
 ------------------------------------------------------------------------------}
-
 -- Logical conjunction
 prop-&&-⋀
   : ∀ {x y : Bool}
@@ -59,6 +58,21 @@ prop-¬-not
 --
 prop-¬-not {False} contra = refl
 prop-¬-not {True} contra = case contra refl of λ ()
+
+{-----------------------------------------------------------------------------
+    Logical connectives and constants
+------------------------------------------------------------------------------}
+prop-x-&&-True
+  : ∀ (x : Bool)
+  → (x && True) ≡ x
+prop-x-&&-True True = refl
+prop-x-&&-True False = refl
+
+prop-x-&&-False
+  : ∀ (x : Bool)
+  → (x && False) ≡ False
+prop-x-&&-False True = refl
+prop-x-&&-False False = refl
 
 {-----------------------------------------------------------------------------
     Properties of if_then_else

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Ord.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Ord.agda
@@ -1,0 +1,173 @@
+{-# OPTIONS --erasure #-}
+
+module Haskell.Reasoning.Ord where
+
+open import Haskell.Prelude
+open import Haskell.Reasoning.Bool
+open import Haskell.Reasoning.Core
+
+{-----------------------------------------------------------------------------
+    Properties of min
+------------------------------------------------------------------------------}
+data Cases-min (x1 x2 : a) {{_ : Ord a}} {{_ : IsLawfulOrd a}} : Set where
+    Case-min-x1 : ((x1 <= x2) ≡ True) → (min x1 x2 ≡ x1) → Cases-min x1 x2
+    Case-min-x2 : ((x2 <= x1) ≡ True) → (min x1 x2 ≡ x2) → Cases-min x1 x2
+
+--
+decide-Cases-min
+  : ∀ (x1 x2 : a) {{_ : Ord a}} {{_ : IsLawfulOrd a}}
+  → Cases-min x1 x2
+--
+decide-Cases-min x1 x2 = cases (x1 <= x2) refl
+  where
+    cases : (b : Bool) → (x1 <= x2) ≡ b → Cases-min x1 x2
+    cases True leq = Case-min-x1 leq lem2
+      where
+        lem2 =
+          begin
+            min x1 x2
+          ≡⟨ equality _ _ (min2if x1 x2) ⟩
+            (if (x1 <= x2) then x1 else x2)
+          ≡⟨ cong (λ o → if o then x1 else x2) leq ⟩
+            x1
+          ∎
+
+    cases False leq = Case-min-x2 (trans (lte2gte x2 x1) (gt2gte x1 x2 lem1)) lem2
+      where
+        lem1 : (x1 > x2) ≡ True
+        lem1 =
+         begin
+            (x1 > x2)
+          ≡⟨ sym (not-not (x1 > x2)) ⟩
+            not (not (x1 > x2))
+          ≡⟨ cong not (sym (lte2ngt x1 x2)) ⟩
+            not (x1 <= x2)
+          ≡⟨ cong not leq ⟩
+            True
+          ∎
+
+        lem2 =
+          begin
+            min x1 x2
+          ≡⟨ equality _ _ (min2if x1 x2) ⟩
+            (if (x1 <= x2) then x1 else x2)
+          ≡⟨ cong (λ o → if o then x1 else x2) leq ⟩
+            x2
+          ∎
+
+-- min is lesser or equal to the first argument
+prop-min-<-x1
+  : ∀ (x1 x2 : a) {{_ : Ord a}} {{_ : IsLawfulOrd a}}
+  → (min x1 x2 <= x1) ≡ True
+--
+prop-min-<-x1 x1 x2 = case decide-Cases-min x1 x2 of λ
+  { (Case-min-x1 leq eq) →
+    begin
+      min x1 x2 <= x1
+    ≡⟨ cong (λ o → o <= _) eq ⟩
+      x1 <= x1
+    ≡⟨ reflexivity x1 ⟩
+      True
+    ∎
+  ; (Case-min-x2 leq eq) →
+    begin
+      min x1 x2 <= x1
+    ≡⟨ cong (λ o → o <= _) eq ⟩
+      x2 <= x1
+    ≡⟨ leq ⟩
+      True
+    ∎
+  }
+
+-- min is lesser or equal to the second argument
+prop-min-<-x2
+  : ∀ (x1 x2 : a) {{_ : Ord a}} {{_ : IsLawfulOrd a}}
+  → (min x1 x2 <= x2) ≡ True
+--
+prop-min-<-x2 x1 x2 = case decide-Cases-min x1 x2 of λ
+  { (Case-min-x1 leq eq) →
+    begin
+      min x1 x2 <= x2
+    ≡⟨ cong (λ o → o <= _) eq ⟩
+      x1 <= x2
+    ≡⟨ leq ⟩
+      True
+    ∎
+  ; (Case-min-x2 leq eq) →
+    begin
+      min x1 x2 <= x2
+    ≡⟨ cong (λ o → o <= _) eq ⟩
+      x2 <= x2
+    ≡⟨ reflexivity x2 ⟩
+      True
+    ∎
+  }
+
+--
+lemma-<=-expand
+  : ∀ (x y z : a) {{_ : Ord a}} {{_ : IsLawfulOrd a}}
+  → (y <= z) ≡ True
+  → (x <= y) ≡ (x <= y && x <= z)
+lemma-<=-expand x y z eq1 = cases (x <= y) refl
+  where
+    cases : (b : Bool) → (x <= y) ≡ b → (x <= y) ≡ (x <= y && x <= z)
+    cases True eq2 =
+      begin
+        (x <= y)
+      ≡⟨ sym (prop-x-&&-True (x <= y)) ⟩
+        (x <= y && True)
+      ≡⟨ cong (λ o → (x <= y) && o) (sym lem1) ⟩
+        (x <= y && x <= z)
+      ∎
+      where
+        lem1 : (x <= z) ≡ True
+        lem1 = transitivity x y z (prop-⋀-&& (eq2 `and` eq1))
+
+    cases False eq2 =
+      begin
+        (x <= y)
+      ≡⟨ eq2 ⟩
+        False
+      ≡⟨⟩
+        False && (x <= z)
+      ≡⟨ cong (λ o → o && (x <= z)) (sym eq2) ⟩
+       (x <= y && x <= z)
+      ∎
+
+--
+prop-min-universal
+  : ∀ (x y1 y2 : a) {{_ : Ord a}} {{_ : IsLawfulOrd a}}
+  → (x <= min y1 y2) ≡ (x <= y1 && x <= y2)
+--
+prop-min-universal x y1 y2 =  case decide-Cases-min y1 y2 of λ
+  { (Case-min-x1 leq eq) →
+    begin
+      x <= min y1 y2
+    ≡⟨ cong (λ o → x <= o) eq ⟩
+      x <= y1
+    ≡⟨ lemma-<=-expand x y1 y2 leq ⟩
+      (x <= y1 && x <= y2)
+    ∎
+  ; (Case-min-x2 leq eq) →
+    begin
+      x <= min y1 y2
+    ≡⟨ cong (λ o → x <= o) eq ⟩
+      x <= y2
+    ≡⟨ lemma-<=-expand x y2 y1 leq ⟩
+      (x <= y2 && x <= y1)
+    ≡⟨ &&-sym (x <= y2) (x <= y1) ⟩
+      (x <= y1 && x <= y2)
+    ∎
+  } 
+
+{-----------------------------------------------------------------------------
+    Properties of max
+------------------------------------------------------------------------------}
+
+--
+postulate
+ prop-max-universal
+  : ∀ (x1 x2 y : a) {{_ : Ord a}} {{_ : IsLawfulOrd a}}
+  → (max x1 x2 <= y) ≡ (x1 <= y && x2 <= y)
+--
+

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -68,6 +68,7 @@ library
     Cardano.Wallet.Address.Hash
     Cardano.Wallet.Deposit.Pure
     Cardano.Wallet.Deposit.Pure.Address
+    Cardano.Wallet.Deposit.Pure.RollbackWindow
     Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     Cardano.Wallet.Deposit.Pure.UTxO.Tx
     Cardano.Wallet.Deposit.Pure.UTxO.UTxO

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.Deposit.Pure.RollbackWindow where
+
+if' :: Bool -> a -> a -> a
+if' True thn els = thn
+if' False thn els = els
+
+data RollbackWindow time = RollbackWindowC
+    { finality :: time
+    , tip :: time
+    }
+
+member :: Ord time => time -> RollbackWindow time -> Bool
+member time w = finality w <= time && time <= tip w
+
+singleton :: Ord time => time -> RollbackWindow time
+singleton time = RollbackWindowC time time
+
+rollForward
+    :: Ord time
+    => time
+    -> RollbackWindow time
+    -> Maybe (RollbackWindow time)
+rollForward newTip w =
+    if tip w < newTip
+        then Just (RollbackWindowC (finality w) newTip)
+        else Nothing
+
+data MaybeRollback a
+    = Past
+    | Present a
+    | Future
+
+rollBackward
+    :: Ord time
+    => time
+    -> RollbackWindow time
+    -> MaybeRollback (RollbackWindow time)
+rollBackward newTip w =
+    if tip w < newTip
+        then Future
+        else
+            if finality w <= newTip
+                then Present (RollbackWindowC (finality w) newTip)
+                else Past
+
+prune
+    :: Ord time
+    => time
+    -> RollbackWindow time
+    -> Maybe (RollbackWindow time)
+prune newFinality w =
+    if member newFinality w
+        then Just (RollbackWindowC newFinality (tip w))
+        else Nothing
+
+intersect
+    :: forall time
+     . Ord time
+    => RollbackWindow time
+    -> RollbackWindow time
+    -> Maybe (RollbackWindow time)
+intersect w1 w2 =
+    if' (fin3 <= tip3) (Just (RollbackWindowC fin3 tip3)) Nothing
+  where
+    fin3 :: time
+    fin3 = max (finality w1) (finality w2)
+    tip3 :: time
+    tip3 = min (tip w1) (tip w2)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
@@ -1,26 +1,16 @@
-{-# LANGUAGE StandaloneDeriving #-}
-
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type where
 
+import Cardano.Wallet.Deposit.Pure.RollbackWindow (RollbackWindow)
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO)
 import Cardano.Wallet.Deposit.Read (Slot)
 import Cardano.Wallet.Read.Block (SlotNo)
 import Cardano.Wallet.Read.Tx (TxIn)
 import Haskell.Data.Maps.Timeline (Timeline)
 
-data Pruned
-    = PrunedUpTo SlotNo
-    | NotPruned
-
-deriving instance Eq Pruned
-
-deriving instance Show Pruned
-
 data UTxOHistory = UTxOHistory
     { history :: UTxO
     , created :: Timeline Slot TxIn
     , spent :: Timeline SlotNo TxIn
-    , tip :: Slot
-    , finality :: Pruned
+    , window :: RollbackWindow Slot
     , boot :: UTxO
     }


### PR DESCRIPTION
This pull request adds a type `RollbackWindow`, which represents a time interval between `finality` and `tip`.

The idea is that a `rollForward` can be used to move the `tip` forward, while `rollBackward` can be used to roll the `tip` backwards — but only up to `finality`. The `finality` indicates the point until which rollbacks are possible — older data has been discarded by using `prune`.

The boundaries of the interval are inclusive, as the properties `prop-finality-member` and `prop-tip-member` demonstrate.

This pull request also changes the `UTxOHistory` type to make use of the `RollbackWindow` type. Importantly, the helper functions `constrainingAppendBlock`, `constrainingRollback`, and `constrainingPrune` that distinguish different cases are replaced by their corresponding `case` expressions.

ADP-3344