### PR TITLE
Fix `DeltaUTxO.append`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -50,7 +50,7 @@ empty = record
 
 apply : DeltaUTxO → UTxO → UTxO
 apply du utxo =
-   UTxO.union (UTxO.excluding utxo (excluded du)) (received du)
+   UTxO.union (received du) (UTxO.excluding utxo (excluded du))
 
 excludingD : UTxO → Set.ℙ TxIn → (DeltaUTxO × UTxO)
 excludingD utxo txins =
@@ -115,3 +115,17 @@ prop-null-empty du eq =
 
     lem2 : Map.null (received du) ≡ True
     lem2 = projr (prop-&&-⋀ eq)
+
+--
+@0 prop-apply-empty
+  : ∀ (utxo : UTxO)
+  → apply empty utxo ≡ utxo
+--
+prop-apply-empty utxo =
+  begin
+    apply empty utxo
+  ≡⟨ UTxO.prop-union-empty-left ⟩
+    UTxO.excluding utxo (excluded empty)
+  ≡⟨ UTxO.prop-excluding-empty utxo ⟩
+    utxo
+  ∎

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -70,23 +70,15 @@ receiveD old new =
       ; received = new
       }
 
-appendDeltaUTxO : DeltaUTxO → DeltaUTxO → DeltaUTxO
-appendDeltaUTxO da db = record
-    { excluded = Set.union (excluded da) (excluded'db)
-    ; received = UTxO.union (received'da) (received db)
+-- | Apply `x` *after* `y`.
+append : DeltaUTxO → DeltaUTxO → DeltaUTxO
+append x y = record
+    { excluded = Set.union (excluded'x) (excluded y)
+    ; received = UTxO.union (received x) (received'y)
     }
   where
-    received'da = UTxO.excluding (received da) (excluded db)
-    excluded'db = UTxO.excludingS (excluded db) (received da)
-
-instance
-  iSemigroupDeltaUTxO : Semigroup DeltaUTxO
-  iSemigroupDeltaUTxO = record { _<>_ = appendDeltaUTxO }
-
-instance
-  iMonoidDeltaUTxO : Monoid DeltaUTxO
-  iMonoidDeltaUTxO =
-    record {DefaultMonoid (λ where .DefaultMonoid.mempty → empty)}
+    excluded'x = UTxO.excludingS (excluded x) (received y)
+    received'y = UTxO.excluding (received y) (excluded x)
 
 {-# COMPILE AGDA2HS DeltaUTxO #-}
 {-# COMPILE AGDA2HS null #-}
@@ -94,9 +86,7 @@ instance
 {-# COMPILE AGDA2HS apply #-}
 {-# COMPILE AGDA2HS excludingD #-}
 {-# COMPILE AGDA2HS receiveD #-}
-{-# COMPILE AGDA2HS appendDeltaUTxO #-}
-{-# COMPILE AGDA2HS iSemigroupDeltaUTxO #-}
-{-# COMPILE AGDA2HS iMonoidDeltaUTxO #-}
+{-# COMPILE AGDA2HS append #-}
 
 {-----------------------------------------------------------------------------
     Properties

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -125,17 +125,3 @@ prop-null-empty du eq =
 
     lem2 : Map.null (received du) ≡ True
     lem2 = projr (prop-&&-⋀ eq)
-
---
-@0 prop-apply-empty
-  : ∀ (u : UTxO) (key : TxIn)
-  → Map.lookup key (apply empty u) ≡ Map.lookup key u 
---
-prop-apply-empty u key =
-  begin
-    Map.lookup key (apply empty u)
-  ≡⟨ UTxO.prop-union-empty key _ ⟩
-    Map.lookup key (UTxO.excluding u (excluded empty))
-  ≡⟨ UTxO.prop-excluding-empty key u ⟩
-    Map.lookup key u 
-  ∎

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/Tx.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/Tx.agda
@@ -79,7 +79,7 @@ applyTx isOurs tx u0 =
     let (du10 , u1)  = spendTxD tx u0
         receivedUTxO = UTxO.filterByAddress isOurs (utxoFromTxOutputs tx)
         (du21 , u2)  = DeltaUTxO.receiveD u1 receivedUTxO
-        (du , u) = (du21 <> du10 , u2)
+        (du , u) = (DeltaUTxO.append du21 du10 , u2)
     
         -- NOTE: Performance.
         -- 'applyTx' is part of a tight loop that inspects all transactions
@@ -92,7 +92,7 @@ applyTx isOurs tx u0 =
         --   isUnchangedUTxO =  mempty == du
 
     in  if isUnchangedUTxO
-          then (mempty , u0)
+          then (DeltaUTxO.empty , u0)
           else (du , u)
 
 {-# COMPILE AGDA2HS IsOurs #-}

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -23,7 +23,7 @@ empty = DeltaUTxO Set.empty Map.empty
 
 apply :: DeltaUTxO -> UTxO -> UTxO
 apply du utxo =
-    UTxO.union (UTxO.excluding utxo (excluded du)) (received du)
+    UTxO.union (received du) (UTxO.excluding utxo (excluded du))
 
 excludingD :: UTxO -> Set TxIn -> (DeltaUTxO, UTxO)
 excludingD utxo txins = (du, UTxO.excluding utxo txins)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -37,19 +37,13 @@ receiveD old new = (du, UTxO.union old new)
     du :: DeltaUTxO
     du = DeltaUTxO Set.empty new
 
-appendDeltaUTxO :: DeltaUTxO -> DeltaUTxO -> DeltaUTxO
-appendDeltaUTxO da db =
+append :: DeltaUTxO -> DeltaUTxO -> DeltaUTxO
+append x y =
     DeltaUTxO
-        (Set.union (excluded da) excluded'db)
-        (UTxO.union received'da (received db))
+        (Set.union excluded'x (excluded y))
+        (UTxO.union (received x) received'y)
   where
-    received'da :: UTxO
-    received'da = UTxO.excluding (received da) (excluded db)
-    excluded'db :: Set TxIn
-    excluded'db = UTxO.excludingS (excluded db) (received da)
-
-instance Semigroup DeltaUTxO where
-    (<>) = appendDeltaUTxO
-
-instance Monoid DeltaUTxO where
-    mempty = empty
+    excluded'x :: Set TxIn
+    excluded'x = UTxO.excludingS (excluded x) (received y)
+    received'y :: UTxO
+    received'y = UTxO.excluding (received y) (excluded x)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
@@ -4,7 +4,9 @@ import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     ( DeltaUTxO (excluded, received)
     )
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
-    ( excludingD
+    ( append
+    , empty
+    , excludingD
     , null
     , receiveD
     )
@@ -70,14 +72,16 @@ applyTx isOurs tx u0 =
     if UTxO.null (UTxO.filterByAddress isOurs (utxoFromTxOutputs tx))
         && Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.null
             (fst (spendTxD tx u0))
-        then (mempty, u0)
+        then (Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.empty, u0)
         else
-            ( fst
-                ( Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.receiveD
-                    (snd (spendTxD tx u0))
-                    (UTxO.filterByAddress isOurs (utxoFromTxOutputs tx))
+            ( Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.append
+                ( fst
+                    ( Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.receiveD
+                        (snd (spendTxD tx u0))
+                        (UTxO.filterByAddress isOurs (utxoFromTxOutputs tx))
+                    )
                 )
-                <> fst (spendTxD tx u0)
+                (fst (spendTxD tx u0))
             , snd
                 ( Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO.receiveD
                     (snd (spendTxD tx u0))


### PR DESCRIPTION
This pull request fixes the implementation of `DeltaUTxO` such that `append x y : DeltaUTxO` will apply `x` *after* `y`, i.e. the order of application is right-to-left.

In order to show that the new implementation does what we want, I have now proved the following property which relates `append` to `apply`:

```agda
prop-apply-append
  : ∀ (x y : DeltaUTxO) (utxo : UTxO)
  → Set.intersection (dom (received y)) (dom utxo) ≡ Set.empty
  → apply (append x y) utxo ≡ apply x (apply y utxo)
```

In other words, if `utxo` and `y` have disjoint transaction inputs, then applying `append x y` is the same as first applying `y` and then applying `x`. As `TxIn` are globally distinct, the preconditions always holds at usage sites.

However, as this property is not unconditionally true when duplicate `TxIn` are allowed, the `DeltaUTxO` type is, strictly speaking, not a `Semigroup` and I have removed the corresponding instances.

### Comments

* In the interest of saving time, I have postulated some simpler properties of `UTxO` rather than proving them.
