### PR TITLE
Add `Data.Maps.Maybe`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -149,7 +149,7 @@ prop-apply-empty utxo =
   ∎
 
 --
-lemma-excluding-intersection-dom
+@0 lemma-excluding-intersection-dom
   : ∀ {x : Set.ℙ TxIn} {utxo : UTxO}
   → (Set.intersection x (dom utxo)) ⋪ utxo ≡ x ⋪ utxo
 --
@@ -167,7 +167,7 @@ lemma-excluding-intersection-dom {x} {utxo} =
 -- | The 'UTxO' returned by 'excludingD' agrees
 -- with the application of the delta to the input 'UTxO'.
 --
-prop-apply-excludingD
+@0 prop-apply-excludingD
   : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
   → let (du , u1) = excludingD u0 txins
     in  apply du u0 ≡ u1

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
@@ -137,11 +137,12 @@ postulate
 --
 
 --
-postulate
- prop-excluding-intersection
+@0 prop-excluding-intersection
   : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
   → (Set.intersection x y) ⋪ utxo ≡ (x ⋪ utxo) ∪ (y ⋪ utxo)
 --
+prop-excluding-intersection {x} {y} {utxo} =
+  Map.prop-withoutKeys-intersection utxo x y
 
 --
 postulate

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
@@ -49,16 +49,79 @@ intersectionWith _ _ _ = Nothing
     Properties
 ------------------------------------------------------------------------------}
 
+--
 prop-union-empty-right
   : ∀ {ma : Maybe a}
   → union ma Nothing ≡ ma
+--
 prop-union-empty-right {_} {Nothing} = refl
 prop-union-empty-right {_} {Just x} = refl
 
+--
 prop-union-assoc
   : ∀ {ma mb mc : Maybe a}
   → union (union ma mb) mc ≡ union ma (union mb mc)
+--
 prop-union-assoc {_} {Nothing} {mb} {mc} = refl
 prop-union-assoc {_} {Just x} {Nothing} {mc} = refl
 prop-union-assoc {_} {Just x} {Just y} {Nothing} = refl
 prop-union-assoc {_} {Just x} {Just y} {Just z} = refl
+
+--
+prop-union-left
+  : ∀ (x : a) (mb : Maybe a)
+  → union (Just x) mb ≡ Just x
+--
+prop-union-left x Nothing = refl
+prop-union-left x (Just y) = refl
+
+--
+@0 prop-filter-||
+  : ∀ {ma : Maybe a} {p q : a → Bool}
+  → filter (λ x → p x || q x) ma
+    ≡ union (filter p ma) (filter q ma)
+--
+prop-filter-|| {_} {Nothing} {p} {q} = refl
+prop-filter-|| {_} {Just x} {p} {q} =
+    case p x of λ
+    { True {{eq}} →
+      begin
+        (if p x || q x then Just x else Nothing)
+      ≡⟨ cong (λ o → if (o || q x) then _ else Nothing) eq ⟩
+        (if True || q x then Just x else Nothing)
+      ≡⟨⟩
+        Just x
+      ≡⟨ sym (prop-union-left x (if q x then Just x else Nothing))⟩
+        union
+          (Just x)
+          (if q x then Just x else Nothing)
+      ≡⟨⟩
+        union 
+          (if True then Just x else Nothing)
+          (if q x then Just x else Nothing)
+      ≡⟨ cong (λ o → union (if o then Just x else Nothing) _) (sym eq) ⟩
+        union 
+          (if p x then Just x else Nothing)
+          (if q x then Just x else Nothing)
+      ∎
+    ; False {{eq}} →
+      begin
+        (if p x || q x then Just x else Nothing)
+      ≡⟨ cong (λ o → if (o || q x) then _ else Nothing) eq ⟩
+        (if False || q x then Just x else Nothing)
+      ≡⟨⟩
+        (if q x then Just x else Nothing)
+      ≡⟨⟩
+        union
+          Nothing
+          (if q x then Just x else Nothing)
+      ≡⟨⟩
+        union 
+          (if False then Just x else Nothing)
+          (if q x then Just x else Nothing)
+      ≡⟨ cong (λ o → union (if o then Just x else Nothing) _) (sym eq) ⟩
+        union 
+          (if p x then Just x else Nothing)
+          (if q x then Just x else Nothing)
+      ∎
+    }

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
@@ -1,0 +1,64 @@
+{-# OPTIONS --erasure #-}
+
+module Haskell.Data.Maps.Maybe
+    {-
+    This module adds functions for the 'Maybe' type
+    that are analogous to the functions in 'Data.Map'.
+    This is used to make proofs for 'Data.Map' more transparent.
+    -} where
+
+open import Haskell.Prelude hiding (null; map; filter)
+
+open import Haskell.Data.Maybe using
+    ( isJust
+    )
+
+{-----------------------------------------------------------------------------
+    Data.Maybe
+    Functions
+------------------------------------------------------------------------------}
+
+update : (a → Maybe a) → Maybe a → Maybe a
+update f Nothing = Nothing
+update f (Just x) = f x
+
+filter : (a → Bool) → Maybe a → Maybe a
+filter p Nothing = Nothing
+filter p (Just x) = if p x then Just x else Nothing
+
+unionWith : (a → a → a) → Maybe a → Maybe a → Maybe a
+unionWith f Nothing my = my
+unionWith f (Just x) Nothing = Just x
+unionWith f (Just x) (Just y) = Just (f x y)
+
+union : Maybe a → Maybe a → Maybe a
+union = unionWith (λ x y → x)
+
+intersectionWith : (a → b → c) → Maybe a → Maybe b → Maybe c
+intersectionWith f (Just x) (Just y) = Just (f x y)
+intersectionWith _ _ _ = Nothing
+
+{-# COMPILE AGDA2HS update #-}
+{-# COMPILE AGDA2HS filter #-}
+{-# COMPILE AGDA2HS unionWith #-}
+{-# COMPILE AGDA2HS union #-}
+{-# COMPILE AGDA2HS intersectionWith #-}
+
+{-----------------------------------------------------------------------------
+    Data.Maybe
+    Properties
+------------------------------------------------------------------------------}
+
+prop-union-empty-right
+  : ∀ {ma : Maybe a}
+  → union ma Nothing ≡ ma
+prop-union-empty-right {_} {Nothing} = refl
+prop-union-empty-right {_} {Just x} = refl
+
+prop-union-assoc
+  : ∀ {ma mb mc : Maybe a}
+  → union (union ma mb) mc ≡ union ma (union mb mc)
+prop-union-assoc {_} {Nothing} {mb} {mc} = refl
+prop-union-assoc {_} {Just x} {Nothing} {mc} = refl
+prop-union-assoc {_} {Just x} {Just y} {Nothing} = refl
+prop-union-assoc {_} {Just x} {Just y} {Just z} = refl

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
@@ -96,6 +96,14 @@ prop-||-assoc
 prop-||-assoc False b c = refl
 prop-||-assoc True b c = refl
 
+--
+prop-deMorgan-not-&&
+  : ∀ (a b : Bool)
+  → not (a && b) ≡ (not a || not b)
+--
+prop-deMorgan-not-&& False b = refl
+prop-deMorgan-not-&& True b = refl
+
 {-----------------------------------------------------------------------------
     Properties of if_then_else
 ------------------------------------------------------------------------------}

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -88,6 +88,7 @@ library
     Haskell.Data.ByteString.Short
     Haskell.Data.List
     Haskell.Data.Map
+    Haskell.Data.Maps.Maybe
     Haskell.Data.Maps.InverseMap
     Haskell.Data.Maps.PairMap
     Haskell.Data.Maps.Timeline

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
@@ -1,0 +1,21 @@
+module Haskell.Data.Maps.Maybe where
+
+update :: (a -> Maybe a) -> Maybe a -> Maybe a
+update f Nothing = Nothing
+update f (Just x) = f x
+
+filter :: (a -> Bool) -> Maybe a -> Maybe a
+filter p Nothing = Nothing
+filter p (Just x) = if p x then Just x else Nothing
+
+unionWith :: (a -> a -> a) -> Maybe a -> Maybe a -> Maybe a
+unionWith f Nothing my = my
+unionWith f (Just x) Nothing = Just x
+unionWith f (Just x) (Just y) = Just (f x y)
+
+union :: Maybe a -> Maybe a -> Maybe a
+union = unionWith (\x y -> x)
+
+intersectionWith :: (a -> b -> c) -> Maybe a -> Maybe b -> Maybe c
+intersectionWith f (Just x) (Just y) = Just (f x y)
+intersectionWith _ _ _ = Nothing


### PR DESCRIPTION
This pull request adds a module `Data.Map.Maybe`. This module adds functions for the `Maybe` type that are analogous to the functions in `Data.Map`.

This addition makes proofs of properties of `Map` more transparent, as we base them on the isomorphism `Map k a = k → Maybe a`.

We use this right away to prove the property

```agda
prop-excluding-intersection
  : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
  → (Set.intersection x y) ⋪ utxo ≡ (x ⋪ utxo) ∪ (y ⋪ utxo)
```