### PR TITLE
Add `union` to `Data.Set` and `Data.Map`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -30,17 +30,6 @@ import Haskell.Data.Map as Map
 import Haskell.Data.Set as Set
 
 {-----------------------------------------------------------------------------
-    Helper functions
-------------------------------------------------------------------------------}
---
-prop-reflect-&& 
-  : ∀ (x y : Bool)
-  → (x && y) ≡ True
-  → (x ≡ True) ⋀ (y ≡ True)
---
-prop-reflect-&& True y refl = refl `and` refl
-
-{-----------------------------------------------------------------------------
     DeltaUTxO
 ------------------------------------------------------------------------------}
 record DeltaUTxO : Set where
@@ -132,10 +121,10 @@ prop-null-empty du eq =
       (Map.prop-null-empty (received du) lem2)
   where
     lem1 : Set.null (excluded du) ≡ True
-    lem1 = projl (prop-reflect-&& _ _ eq)
+    lem1 = projl (prop-&&-⋀ eq)
 
     lem2 : Map.null (received du) ≡ True
-    lem2 = projr (prop-reflect-&& _ _ eq)
+    lem2 = projr (prop-&&-⋀ eq)
 
 --
 @0 prop-apply-empty

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
@@ -84,6 +84,11 @@ module _ {k a : Set} {{_ : Ord k}} where
       → null m ≡ True
       → m ≡ empty
 
+    prop-equality
+      : ∀ {m1 m2 : Map k a}
+      → (∀ (key : k) → lookup key m1 ≡ lookup key m2)
+      → m1 ≡ m2
+
     prop-lookup-eq
       : ∀ (key1 key2 : k) (m : Map k a)
       → (key1 == key2) ≡ True

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
@@ -35,6 +35,9 @@ unionWithMaybe f Nothing my = my
 unionWithMaybe f (Just x) Nothing = Just x
 unionWithMaybe f (Just x) (Just y) = Just (f x y)
 
+unionMaybe : Maybe a → Maybe a → Maybe a
+unionMaybe = unionWithMaybe (λ x y → x)
+
 intersectionWithMaybe : (a → b → c) → Maybe a → Maybe b → Maybe c
 intersectionWithMaybe f (Just x) (Just y) = Just (f x y)
 intersectionWithMaybe _ _ _ = Nothing
@@ -42,6 +45,20 @@ intersectionWithMaybe _ _ _ = Nothing
 updateMaybe : (a → Maybe a) → Maybe a → Maybe a
 updateMaybe f Nothing = Nothing
 updateMaybe f (Just x) = f x
+
+prop-unionMaybe-empty-right
+  : ∀ {ma : Maybe a}
+  → unionMaybe ma Nothing ≡ ma
+prop-unionMaybe-empty-right {_} {Nothing} = refl
+prop-unionMaybe-empty-right {_} {Just x} = refl
+
+prop-unionMaybe-assoc
+  : ∀ {ma mb mc : Maybe a}
+  → unionMaybe (unionMaybe ma mb) mc ≡ unionMaybe ma (unionMaybe mb mc)
+prop-unionMaybe-assoc {_} {Nothing} {mb} {mc} = refl
+prop-unionMaybe-assoc {_} {Just x} {Nothing} {mc} = refl
+prop-unionMaybe-assoc {_} {Just x} {Just x₁} {Nothing} = refl
+prop-unionMaybe-assoc {_} {Just x} {Just x₁} {Just x₂} = refl
 
 {-----------------------------------------------------------------------------
     Data.Map
@@ -189,6 +206,9 @@ module _ {k a : Set} {{_ : Ord k}} where
   filter : (a → Bool) → Map k a → Map k a
   filter p = filterWithKey (λ _ x → p x)
 
+  union : Map k a → Map k a → Map k a
+  union = unionWith (λ x y → x)
+
   spanAntitone : (k → Bool) → Map k a → (Map k a × Map k a)
   spanAntitone p m = (takeWhileAntitone p m , dropWhileAntitone p m)
 
@@ -245,6 +265,69 @@ module _ {k a b c : Set} {{_ : Ord k}} where
           (f : a → b → c)
       → lookup key (intersectionWith f ma mb)
         ≡ intersectionWithMaybe f (lookup key ma) (lookup key mb)
+
+{-----------------------------------------------------------------------------
+    Proofs
+------------------------------------------------------------------------------}
+module _ {k a : Set} {{_ : Ord k}} where
+
+  prop-lookup-union
+    : ∀ (key : k) (m n : Map k a)
+    → lookup key (union m n)
+      ≡ unionMaybe (lookup key m) (lookup key n)
+  prop-lookup-union key m n = prop-lookup-unionWith key m n (λ x y → x)
+
+  prop-union-empty-left
+    : ∀ {ma : Map k a}
+    → union empty ma ≡ ma
+  prop-union-empty-left {ma} = prop-equality eq-key
+    where
+      eq-key = λ key →
+        begin
+          lookup key (union empty ma)
+        ≡⟨ prop-lookup-union key empty ma ⟩
+          unionMaybe (lookup key empty) (lookup key ma)
+        ≡⟨ cong (λ o → unionMaybe o (lookup key ma)) (prop-lookup-empty key) ⟩
+          unionMaybe Nothing (lookup key ma)
+        ≡⟨⟩
+          lookup key ma
+        ∎
+
+  prop-union-empty-right
+    : ∀ {ma : Map k a}
+    → union ma empty ≡ ma
+  prop-union-empty-right {ma} = prop-equality eq-key
+    where
+      eq-key = λ key →
+        begin
+          lookup key (union ma empty)
+        ≡⟨ prop-lookup-union key ma empty ⟩
+          unionMaybe (lookup key ma) (lookup key empty)
+        ≡⟨ cong (λ o → unionMaybe (lookup key ma) o) (prop-lookup-empty key) ⟩
+          unionMaybe (lookup key ma) Nothing
+        ≡⟨ prop-unionMaybe-empty-right ⟩
+          lookup key ma
+        ∎
+
+  prop-union-assoc
+    : ∀ {ma mb mc : Map k a}
+    → union (union ma mb) mc ≡ union ma (union mb mc)
+  prop-union-assoc {ma} {mb} {mc} = prop-equality eq-key
+    where
+      eq-key = λ key →
+        begin
+          lookup key (union (union ma mb) mc)
+        ≡⟨ prop-lookup-union key _ _ ⟩
+          unionMaybe (lookup key (union ma mb)) (lookup key mc)
+        ≡⟨ cong (λ o → unionMaybe o (lookup key mc)) (prop-lookup-union key _ _) ⟩
+          unionMaybe (unionMaybe (lookup key ma) (lookup key mb)) (lookup key mc)
+        ≡⟨ prop-unionMaybe-assoc {_} {lookup key ma} {_} {_} ⟩
+          unionMaybe (lookup key ma) (unionMaybe (lookup key mb) (lookup key mc))
+        ≡⟨ cong (λ o → unionMaybe (lookup key ma) o) (sym (prop-lookup-union key _ _)) ⟩
+          unionMaybe (lookup key ma) (lookup key (union mb mc))
+        ≡⟨ sym (prop-lookup-union key _ _) ⟩
+          lookup key (union ma (union mb mc))
+        ∎
 
 {-----------------------------------------------------------------------------
     Test proofs

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
@@ -16,6 +16,8 @@ module Haskell.Data.Set
     where
 
 open import Haskell.Prelude hiding (null; map; filter)
+open import Haskell.Reasoning
+
 import Haskell.Prelude as L using (map)
 
 {-----------------------------------------------------------------------------
@@ -121,3 +123,42 @@ instance
 
   iSetMonoid : {{Ord a}} → Monoid (ℙ a)
   iSetMonoid = record {DefaultMonoid (record {mempty = empty})}
+
+module _ {a : Set} {{_ : Ord a}} where
+  prop-union-sym
+    : ∀ {s1 s2 : ℙ a}
+    → union s1 s2 ≡ union s2 s1
+  prop-union-sym {s1} {s2} =
+      prop-equality eq
+    where
+      eq = λ x →
+        begin
+          member x (union s1 s2)
+        ≡⟨ prop-member-union _ _ _ ⟩
+          (member x s1 || member x s2)
+        ≡⟨ prop-||-sym (member x s1) (member x s2) ⟩
+          (member x s2 || member x s1)
+        ≡⟨ sym (prop-member-union _ _ _) ⟩
+          member x (union s2 s1)
+        ∎
+
+  prop-union-assoc
+    : ∀ {s1 s2 s3 : ℙ a}
+    → union (union s1 s2) s3 ≡ union s1 (union s2 s3)
+  prop-union-assoc {s1} {s2} {s3} =
+      prop-equality eq
+    where
+      eq = λ x →
+        begin
+          member x (union (union s1 s2) s3)
+        ≡⟨ prop-member-union _ _ _ ⟩
+          (member x (union s1 s2) || member x s3)
+        ≡⟨ cong (λ o → o || _) (prop-member-union _ _ _) ⟩
+          ((member x s1 || member x s2) || member x s3)
+        ≡⟨ prop-||-assoc (member x s1) (member x s2) (member x s3) ⟩
+          (member x s1 || (member x s2 || member x s3))
+        ≡⟨ sym (cong (λ o → _ || o) (prop-member-union _ _ _)) ⟩
+          (member x s1 || member x (union s2 s3))
+        ≡⟨ sym (prop-member-union _ _ _) ⟩
+          member x (union s1 (union s2 s3))
+        ∎

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
@@ -56,6 +56,11 @@ module _ {a : Set} {{_ : Ord a}} where
       → null s ≡ True
       → s ≡ empty
 
+    prop-equality
+      : ∀ {s1 s2 : ℙ a}
+      → (∀ (x : a) → member x s1 ≡ member x s2)
+      → s1 ≡ s2
+
     prop-member-empty
       : ∀ (x : a)
       → member x empty ≡ False

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
@@ -75,6 +75,28 @@ prop-x-&&-False True = refl
 prop-x-&&-False False = refl
 
 {-----------------------------------------------------------------------------
+    Algebraic laws for logical connectives
+------------------------------------------------------------------------------}
+
+--
+prop-||-sym
+  : ∀ (a b : Bool)
+  → (a || b) ≡ (b || a)
+--
+prop-||-sym False False = refl
+prop-||-sym False True = refl
+prop-||-sym True False = refl
+prop-||-sym True True = refl
+
+--
+prop-||-assoc
+  : ∀ (a b c : Bool)
+  → ((a || b) || c) ≡ (a || (b || c))
+--
+prop-||-assoc False b c = refl
+prop-||-assoc True b c = refl
+
+{-----------------------------------------------------------------------------
     Properties of if_then_else
 ------------------------------------------------------------------------------}
 prop-if-apply
@@ -115,3 +137,4 @@ prop-if-eq-subst x y t e subst =
         (if x == y then t y else e)
       ∎
     }
+ 


### PR DESCRIPTION
This pull request adds the `union` function and some of its properties to `Data.Set` and `Data.Map`.

Importantly, in order to simplify reasoning about `Map` and sets `ℙ`, we also add two postulates:

* Two `Map` are propositionally equal if `lookup` gives the same result

    ```agda
    Map.prop-equality
          : ∀ {m1 m2 : Map k a}
          → (∀ (key : k) → lookup key m1 ≡ lookup key m2)
          → m1 ≡ m2
    ```

* Two `Map` are propositionally equal if `member` gives the same result

    ```agda
    Set.prop-equality
          : ∀ {s1 s2 : ℙ a}
          → (∀ (x : a) → member x s1 ≡ member x s2)
          → s1 ≡ s2
    ```

I have decided against using Setoids, as this will complicate equational reasoning unnecessarily. Instead, we use `≡` and enjoy the fact that it can be used for substitution in *any* context, not just for contexts that preserve setoid equality.