### PR TITLE
Fix `excludingD` and prove `prop-apply-excludingD`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -45,6 +45,12 @@ record DeltaUTxO : Set where
 
 open DeltaUTxO public
 
+postulate
+  instance
+    iShowDeltaUTxO : Show DeltaUTxO
+
+{-# COMPILE AGDA2HS iShowDeltaUTxO derive #-}
+
 null : DeltaUTxO → Bool
 null du = Set.null (excluded du) && UTxO.null (received du)
 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -15,6 +15,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
 
 open import Haskell.Prelude hiding
     ( null
+    ; concat
     )
 open import Haskell.Reasoning
 
@@ -92,6 +93,10 @@ append x y = record
     excluded'x = UTxO.excludingS (excluded x) (received y)
     received'y = UTxO.excluding (received y) (excluded x)
 
+-- | Combine a sequence of 'DeltaUTxO' using `append`
+concat : List DeltaUTxO → DeltaUTxO
+concat = foldr append empty
+
 {-# COMPILE AGDA2HS DeltaUTxO #-}
 {-# COMPILE AGDA2HS null #-}
 {-# COMPILE AGDA2HS empty #-}
@@ -99,6 +104,7 @@ append x y = record
 {-# COMPILE AGDA2HS excludingD #-}
 {-# COMPILE AGDA2HS receiveD #-}
 {-# COMPILE AGDA2HS append #-}
+{-# COMPILE AGDA2HS concat #-}
 
 {-----------------------------------------------------------------------------
     Properties
@@ -227,3 +233,11 @@ prop-apply-append x y utxo cond =
       ≡⟨ UTxO.prop-excluding-sym ⟩
         excluded x ⋪ (excluded y ⋪ utxo)
       ∎
+
+--
+-- Unit test for 'concat'.
+prop-concat-two
+  : ∀ (x y : DeltaUTxO)
+  → concat (x ∷ y ∷ []) ≡ append x (append y empty)
+--
+prop-concat-two x y = refl

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -51,3 +51,6 @@ append x y =
     excluded'x = UTxO.excludingS (excluded x) (received y)
     received'y :: UTxO
     received'y = UTxO.excluding (received y) (excluded x)
+
+concat :: [DeltaUTxO] -> DeltaUTxO
+concat = foldr append empty

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -1,6 +1,6 @@
 module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO where
 
-import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO)
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO, dom)
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
     ( empty
     , excluding
@@ -10,8 +10,8 @@ import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
     )
 import Cardano.Wallet.Read.Tx (TxIn)
 import Data.Set (Set)
-import qualified Haskell.Data.Map as Map (empty, keysSet)
-import qualified Haskell.Data.Set as Set (difference, empty, null, union)
+import qualified Haskell.Data.Map as Map (empty)
+import qualified Haskell.Data.Set as Set (empty, intersection, null, union)
 
 data DeltaUTxO = DeltaUTxO {excluded :: Set TxIn, received :: UTxO}
 
@@ -29,7 +29,7 @@ excludingD :: UTxO -> Set TxIn -> (DeltaUTxO, UTxO)
 excludingD utxo txins = (du, UTxO.excluding utxo txins)
   where
     du :: DeltaUTxO
-    du = DeltaUTxO (Set.difference (Map.keysSet utxo) txins) UTxO.empty
+    du = DeltaUTxO (Set.intersection txins (dom utxo)) UTxO.empty
 
 receiveD :: UTxO -> UTxO -> (DeltaUTxO, UTxO)
 receiveD old new = (du, UTxO.union old new)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StandaloneDeriving #-}
+
 module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO, dom)
@@ -14,6 +16,8 @@ import qualified Haskell.Data.Map as Map (empty)
 import qualified Haskell.Data.Set as Set (empty, intersection, null, union)
 
 data DeltaUTxO = DeltaUTxO {excluded :: Set TxIn, received :: UTxO}
+
+deriving instance Show DeltaUTxO
 
 null :: DeltaUTxO -> Bool
 null du = Set.null (excluded du) && UTxO.null (received du)


### PR DESCRIPTION
This pull request fixes the implementation of `excludingD` and proves that the new implementation satisfies the following expected property:


```agda
-- | The 'UTxO' returned by 'excludingD' agrees
-- with the application of the delta to the input 'UTxO'.
--
prop-apply-excludingD
  : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
  → let (du , u1) = excludingD u0 txins
    in  apply du u0 ≡ u1
```

Somewhat unrelatedly, this pull request also adds minor conveniences to the `DeltaUTxO` type.

