### PR TITLE
Prove properties of `receiveD`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -76,7 +76,7 @@ excludingD utxo txins =
 
 receiveD : UTxO → UTxO → (DeltaUTxO × UTxO)
 receiveD old new =
-    (du , UTxO.union old new)
+    (du , UTxO.union new old)
   where
     du = record 
       { excluded = Set.empty
@@ -164,8 +164,17 @@ lemma-excluding-intersection-dom {x} {utxo} =
     (x ⋪ utxo)
   ∎
 
--- | The 'UTxO' returned by 'excludingD' agrees
--- with the application of the delta to the input 'UTxO'.
+-- | The 'UTxO' returned by 'excludingD' is the same as 'excluding'.
+--
+prop-excluding-excludingD
+  : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
+  → let (du , u1) = excludingD u0 txins
+    in  u1 ≡ UTxO.excluding u0 txins
+--
+prop-excluding-excludingD {txins} {u0} = refl
+
+-- | Applying the 'DeltaUTxO' returned by 'excludingD'
+-- to the argument 'UTxO' yields the result 'UTxO'.
 --
 @0 prop-apply-excludingD
   : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
@@ -189,6 +198,37 @@ prop-apply-excludingD {txins} {u0} =
   where
     du = fst (excludingD u0 txins)
     u1 = snd (excludingD u0 txins)
+
+-- | The 'UTxO' returned by 'receiveD' is obtained by 'union'.
+--
+prop-union-receiveD
+  : ∀ {ua : UTxO} {u0 : UTxO}
+  → let (du , u1) = receiveD u0 ua
+    in  u1 ≡ UTxO.union ua u0
+--
+prop-union-receiveD {ua} {u0} = refl
+
+-- | Applying the 'DeltaUTxO' returned by 'receiveD'
+-- to the argument 'UTxO' yields the result 'UTxO'.
+--
+@0 prop-apply-receiveD
+  : ∀ {ua : UTxO} {u0 : UTxO}
+  → let (du , u1) = receiveD u0 ua
+    in  apply du u0 ≡ u1
+--
+prop-apply-receiveD {ua} {u0} =
+  begin
+    apply du u0
+  ≡⟨⟩
+    (received du) ∪ (excluded du ⋪ u0)
+  ≡⟨ cong (λ o → received du ∪ o) (UTxO.prop-excluding-empty _) ⟩
+    (received du) ∪ u0
+  ≡⟨⟩
+    u1
+  ∎
+  where
+    du = fst (receiveD u0 ua)
+    u1 = snd (receiveD u0 ua)
 
 --
 -- This is the most important property:

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
@@ -103,7 +103,7 @@ module _ {k a : Set} {{_ : Ord k}} where
       → (elem key ∘ L.map fst ∘ toAscList) m ≡ False
 
     prop-lookup-unionWith
-      : ∀ (key : k) (m n : Map k a) (f : a → a → a)
+      : ∀ (key : k) (f : a → a → a) (m n : Map k a)
       → lookup key (unionWith f m n)
         ≡ Maybe.unionWith f (lookup key m) (lookup key n)
 
@@ -230,7 +230,7 @@ module _ {k a : Set} {{_ : Ord k}} where
     : ∀ (key : k) (m n : Map k a)
     → lookup key (union m n)
       ≡ Maybe.union (lookup key m) (lookup key n)
-  prop-lookup-union key m n = prop-lookup-unionWith key m n (λ x y → x)
+  prop-lookup-union key m n = prop-lookup-unionWith key (λ x y → x) m n
 
   --
   prop-union-empty-left
@@ -266,6 +266,24 @@ module _ {k a : Set} {{_ : Ord k}} where
           Maybe.union (lookup key ma) Nothing
         ≡⟨ Maybe.prop-union-empty-right ⟩
           lookup key ma
+        ∎
+
+  --
+  prop-unionWith-sym
+    : ∀ {f : a → a → a} {ma mb : Map k a}
+    → unionWith f ma mb ≡ unionWith (flip f) mb ma
+  --
+  prop-unionWith-sym {f} {ma} {mb} = prop-equality eq-key
+    where
+      eq-key = λ key →
+        begin
+          lookup key (unionWith f ma mb)
+        ≡⟨ prop-lookup-unionWith key f _ _ ⟩
+          Maybe.unionWith f (lookup key ma) (lookup key mb)
+        ≡⟨ Maybe.prop-unionWith-sym {_} {f} {lookup key ma} {lookup key mb} ⟩
+          Maybe.unionWith (flip f) (lookup key mb) (lookup key ma)
+        ≡⟨ sym (prop-lookup-unionWith key (flip f) _ _) ⟩
+          lookup key (unionWith (flip f) mb ma)
         ∎
 
   --

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
@@ -31,6 +31,7 @@ unionWith f Nothing my = my
 unionWith f (Just x) Nothing = Just x
 unionWith f (Just x) (Just y) = Just (f x y)
 
+-- | Left-biased union.
 union : Maybe a → Maybe a → Maybe a
 union = unionWith (λ x y → x)
 
@@ -56,6 +57,18 @@ prop-union-empty-right
 --
 prop-union-empty-right {_} {Nothing} = refl
 prop-union-empty-right {_} {Just x} = refl
+
+-- | 'unionWith' is symmetric if we 'flip' the function.
+-- Note that 'union' is left-biased, not symmetric.
+--
+prop-unionWith-sym
+  : ∀ {f : a → a → a} {ma mb : Maybe a}
+  → unionWith f ma mb ≡ unionWith (flip f) mb ma
+--
+prop-unionWith-sym {_} {f} {Nothing} {Nothing} = refl
+prop-unionWith-sym {_} {f} {Just x}  {Nothing} = refl
+prop-unionWith-sym {_} {f} {Nothing} {Just y} = refl
+prop-unionWith-sym {_} {f} {Just x}  {Just y} = refl
 
 --
 prop-union-assoc

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -36,7 +36,7 @@ excludingD utxo txins = (du, UTxO.excluding utxo txins)
     du = DeltaUTxO (Set.intersection txins (dom utxo)) UTxO.empty
 
 receiveD :: UTxO -> UTxO -> (DeltaUTxO, UTxO)
-receiveD old new = (du, UTxO.union old new)
+receiveD old new = (du, UTxO.union new old)
   where
     du :: DeltaUTxO
     du = DeltaUTxO Set.empty new


### PR DESCRIPTION
This pull request fixes the definition of `receiveD` for duplicate `TxIn`s (which do not occur at usage sites, but still) and proves the two defining properties of `receiveD`.