### PR TITLE
Rename record fields of `TxSummary`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Implementation.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Implementation.agda
@@ -60,7 +60,7 @@ fromValueTransfer x = record
 
 fromTxSummary : TxSummary → DepositWallet.TxSummary
 fromTxSummary x =
-    (Read.slotFromChainPoint point , summarizedTx , fromValueTransfer transfer)
+    (Read.slotFromChainPoint txChainPoint , txSummarized , fromValueTransfer txTransfer)
   where
     open TxSummary x
 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxSummary.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxSummary.agda
@@ -21,18 +21,18 @@ import Cardano.Wallet.Deposit.Read as Read
 
 record TxSummary : Set where
   field
-    summarizedTx : TxId
-    point : ChainPoint
-    transfer : ValueTransfer
+    txSummarized : TxId
+    txChainPoint : ChainPoint
+    txTransfer   : ValueTransfer
 
 open TxSummary public
 
 -- This is a mock summary for now
 mkTxSummary : ∀ {era} → {{IsEra era}} → Tx era → ValueTransfer → TxSummary
 mkTxSummary = λ tx transfer' → record
-    { summarizedTx = getTxId tx
-    ; point = ChainPoint.GenesisPoint
-    ; transfer = transfer'
+    { txSummarized = getTxId tx
+    ; txChainPoint = ChainPoint.GenesisPoint
+    ; txTransfer = transfer'
     }
 
 {-# COMPILE AGDA2HS TxSummary #-}

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
@@ -6,9 +6,9 @@ import Cardano.Wallet.Read.Eras (IsEra)
 import Cardano.Wallet.Read.Tx (Tx, TxId, getTxId)
 
 data TxSummary = TxSummary
-    { summarizedTx :: TxId
-    , point :: ChainPoint
-    , transfer :: ValueTransfer
+    { txSummarized :: TxId
+    , txChainPoint :: ChainPoint
+    , txTransfer :: ValueTransfer
     }
 
 mkTxSummary :: IsEra era => Tx era -> ValueTransfer -> TxSummary


### PR DESCRIPTION
This pull request renames the record fields of `TxSummary` for better disambiguation in Haskell client code. In particular, `point` is a common local identifier.