### PR TITLE
Document `UTxO` and `TxHistory` functions

### DIFF
--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Documentation.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Documentation.hs
@@ -27,7 +27,7 @@ import Language.Agda2hs.Haskell.Types
     , prettyHaskellModule
     )
 import System.IO
-    ( hPutStr
+    ( hPutStrLn
     , readFile'
     , stderr
     )
@@ -55,7 +55,7 @@ modifyFileAddingDocumentation
 modifyFileAddingDocumentation agdaPath haskellPath = do
     doModify `catch` (\(e :: ErrParseError) -> warning $ show e)
   where
-    warning s = hPutStr stderr $ "Warning: " ++ s
+    warning s = hPutStrLn stderr $ "Warning: " ++ s
 
     doModify = do
         agdaCode <- readFile agdaPath

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
@@ -48,6 +48,7 @@ data HaskellModule = HaskellModule
         -- ^ Location of each top-level declaration.
     , comments :: Map HaskellIdentifier String
     }
+    deriving (Eq, Show)
 
 -- | Prepend multiline Haddock comments before every given identifier.
 prependHaddockLines

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Core.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Core.agda
@@ -52,6 +52,10 @@ import Data.Foldable
 {-----------------------------------------------------------------------------
     Introduction
 ------------------------------------------------------------------------------}
+{-|
+The empty transaction history.
+It starts at genesis and contains no transactions.
+-}
 empty : TxHistory
 empty = record
   { txIds = Timeline.empty
@@ -65,7 +69,11 @@ empty = record
     Observation
 ------------------------------------------------------------------------------}
 
--- | Returns the tip slot.
+{-|
+'getTip' records the slot up to which the transaction history
+includes information from blocks. All blocks from genesis up to and
+including this slot have been inspected for relevant transactions.
+-}
 getTip : TxHistory → Slot
 getTip = TxHistory.tip
 
@@ -107,6 +115,12 @@ getValueTransfers range history =
     Operations
 ------------------------------------------------------------------------------}
 
+{-|
+Include the information contained in the block at 'SlotNo'
+into the transaction history.
+We expect that the block has already been digested into a list
+of 'ResolvedTx'.
+-}
 rollForward
   : ∀{era} → {{IsEra era}}
   → SlotNo → List (TxId × ResolvedTx era) → TxHistory → TxHistory
@@ -135,6 +149,10 @@ rollForward {era} new txs history =
         mv = valueTransferFromResolvedTx tx
         fun = λ m addr v → PairMap.insert txid addr v m
 
+{-|
+Roll back the transaction history to the given 'Slot',
+i.e. forget about all transaction that are strictly later than this slot.
+-}
 rollBackward : Slot → TxHistory → TxHistory
 rollBackward new history = 
     if new > getTip history

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
@@ -38,16 +38,19 @@ import Haskell.Data.Set as Set
 
 UTxO = Map.Map TxIn TxOut
 
+-- | Test whether the 'UTxO' is empty.
 null : UTxO → Bool
 null = Map.null
 
+-- | The empty 'UTxO'.
 empty : UTxO
 empty = Map.empty
 
--- | Domain of a 'UTxO' = the set of /inputs/ of the /utxo/.
+-- | The domain of a 'UTxO' is the set of /inputs/.
 dom : UTxO → Set.ℙ TxIn
 dom = Map.keysSet
 
+-- | The total value contained in the outputs.
 balance : UTxO → Value
 balance = foldMap getValue
 
@@ -69,6 +72,7 @@ excluding = Map.withoutKeys
 _⋪_ : Set.ℙ TxIn → UTxO → UTxO
 _⋪_ x u = excluding u x
 
+-- | Restrict to a given set of inputs.
 restrictedBy : UTxO → Set.ℙ TxIn → UTxO
 restrictedBy = Map.restrictKeys
 
@@ -76,6 +80,7 @@ restrictedBy = Map.restrictKeys
 excludingS : Set.ℙ TxIn → UTxO → Set.ℙ TxIn
 excludingS s utxo = Set.filter (not ∘ (λ txin → Map.member txin utxo)) s
 
+-- | Keep those outputs whose address satisfies the predicate.
 filterByAddress : (Address → Bool) → UTxO → UTxO
 filterByAddress p = Map.filter (p ∘ getCompactAddr)
 
@@ -93,6 +98,8 @@ filterByAddress p = Map.filter (p ∘ getCompactAddr)
 {-----------------------------------------------------------------------------
     Properties
 ------------------------------------------------------------------------------}
+-- |
+-- 'empty' is a left identity of 'union'.
 --
 prop-union-empty-left
   : ∀ {utxo : UTxO}
@@ -100,6 +107,8 @@ prop-union-empty-left
 --
 prop-union-empty-left = Map.prop-union-empty-left
 
+-- |
+-- 'empty' is a right identity of 'union'.
 --
 prop-union-empty-right
   : ∀ {utxo : UTxO}
@@ -107,6 +116,8 @@ prop-union-empty-right
 --
 prop-union-empty-right = Map.prop-union-empty-right
 
+-- |
+-- Excluding the empty set does nothing.
 --
 @0 prop-excluding-empty
   : ∀ (utxo : UTxO)
@@ -115,6 +126,8 @@ prop-union-empty-right = Map.prop-union-empty-right
 prop-excluding-empty utxo =
   Map.prop-equality (λ key → Map.prop-withoutKeys-empty key utxo)
 
+-- |
+-- 'union' is associative.
 --
 prop-union-assoc
   : ∀ {ua ub uc : UTxO}
@@ -122,6 +135,9 @@ prop-union-assoc
 --
 prop-union-assoc = Map.prop-union-assoc
 
+-- |
+-- Excluding from a union is the same as excluding
+-- from each member of the union.
 --
 postulate
  prop-excluding-union
@@ -129,6 +145,8 @@ postulate
   → x ⋪ (ua ∪ ub) ≡ (x ⋪ ua) ∪ (x ⋪ ub)
 --
 
+-- |
+-- Excluding from an exclusion is the same as excluding the union.
 --
 postulate
  prop-excluding-excluding
@@ -136,6 +154,8 @@ postulate
   → x ⋪ (y ⋪ utxo) ≡ (Set.union x y) ⋪ utxo
 --
 
+-- |
+-- Excluding the intersection is the same as the union of the exclusions.
 --
 @0 prop-excluding-intersection
   : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
@@ -144,6 +164,8 @@ postulate
 prop-excluding-intersection {x} {y} {utxo} =
   Map.prop-withoutKeys-intersection utxo x y
 
+-- |
+-- Excluding the entire domain gives the empty 'UTxO'.
 --
 postulate
  prop-excluding-dom
@@ -151,6 +173,8 @@ postulate
   → dom utxo ⋪ utxo ≡ empty
 --
 
+-- |
+-- Excluding two sets of 'TxIn's can be done in either order.
 --
 prop-excluding-sym
   : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
@@ -167,6 +191,9 @@ prop-excluding-sym {x} {y} {utxo} =
     y ⋪ (x ⋪ utxo)
   ∎
 
+-- |
+-- Not excluding inputs makes no difference if these
+-- inputs have nothing in common with the 'UTxO'.
 --
 postulate
  prop-excluding-excludingS
@@ -175,6 +202,8 @@ postulate
   → (excludingS x ua) ⋪ ub ≡ x ⋪ ub
 --
 
+-- |
+-- Those outputs whose address satisfies the predicate are kept.
 --
 prop-filterByAddress-filters
     : ∀ (p : Address → Bool)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
@@ -11,12 +11,19 @@ data RollbackWindow time = RollbackWindowC
     , tip :: time
     }
 
+-- |
+-- Test whether a given time is within a 'RollbackWindow'.
 member :: Ord time => time -> RollbackWindow time -> Bool
 member time w = finality w <= time && time <= tip w
 
+-- |
+-- Interval containing a single point
 singleton :: Ord time => time -> RollbackWindow time
 singleton time = RollbackWindowC time time
 
+-- |
+-- Move forward the tip of the 'RollbackWindow'.
+-- Return 'Nothing' if the new tip would not actually be moving forward.
 rollForward
     :: Ord time
     => time
@@ -32,6 +39,9 @@ data MaybeRollback a
     | Present a
     | Future
 
+-- |
+-- Roll back the tip of the 'RollbackWindow' to a point within the window.
+-- Return different error conditions if the target is outside the window.
 rollBackward
     :: Ord time
     => time
@@ -45,6 +55,9 @@ rollBackward newTip w =
                 then Present (RollbackWindowC (finality w) newTip)
                 else Past
 
+-- |
+-- Move forward the finality of the 'RollbackWindow'.
+-- Return 'Nothing' if the finality is not moving forward, or too far.
 prune
     :: Ord time
     => time

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
@@ -66,6 +66,10 @@ utxoFromTxOutputs = utxoFromEraTx
 
 type IsOurs addr = addr -> Bool
 
+-- |
+-- Apply a transactions to the 'UTxO'.
+--
+-- Returns both a delta and the new value.
 applyTx
     :: IsEra era
     => IsOurs Read.Addr
@@ -111,6 +115,8 @@ groupByAddress :: UTxO -> Map.Map Read.Address Read.Value
 groupByAddress =
     Map.fromListWith (<>) . map pairFromTxOut . Map.elems
 
+-- |
+-- Compute the 'ValueTransfer' corresponding to 'DeltaUTxO'.
 valueTransferFromDeltaUTxO
     :: UTxO -> DeltaUTxO -> Map.Map Read.Address ValueTransfer
 valueTransferFromDeltaUTxO u0 du = Map.unionWith (<>) ins outs
@@ -122,6 +128,10 @@ valueTransferFromDeltaUTxO u0 du = Map.unionWith (<>) ins outs
     outs :: Map.Map Read.Address ValueTransfer
     outs = Map.map fromReceived (groupByAddress (received du))
 
+-- |
+-- Compute the 'ValueTransfer' corresponding to a 'ResolvedTx'.
+-- Spent transaction outputs that have not been resolved will not
+-- be considered.
 valueTransferFromResolvedTx
     :: IsEra era => ResolvedTx era -> Map.Map Read.Address ValueTransfer
 valueTransferFromResolvedTx tx = valueTransferFromDeltaUTxO u0 du

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -19,17 +19,23 @@ import qualified Haskell.Data.Set as Set (filter)
 
 type UTxO = Map.Map TxIn TxOut
 
+-- |
+-- Test whether the 'UTxO' is empty.
 null :: UTxO -> Bool
 null = Map.null
 
+-- |
+-- The empty 'UTxO'.
 empty :: UTxO
 empty = Map.empty
 
 -- |
--- Domain of a 'UTxO' = the set of /inputs/ of the /utxo/.
+-- The domain of a 'UTxO' is the set of /inputs/.
 dom :: UTxO -> Set TxIn
 dom = Map.keysSet
 
+-- |
+-- The total value contained in the outputs.
 balance :: UTxO -> Value
 balance = foldMap getValue
 
@@ -43,6 +49,8 @@ union = Map.unionWith (\x y -> x)
 excluding :: UTxO -> Set TxIn -> UTxO
 excluding = Map.withoutKeys
 
+-- |
+-- Restrict to a given set of inputs.
 restrictedBy :: UTxO -> Set TxIn -> UTxO
 restrictedBy = Map.restrictKeys
 
@@ -52,5 +60,7 @@ excludingS :: Set TxIn -> UTxO -> Set TxIn
 excludingS s utxo =
     Set.filter (not . \txin -> Map.member txin utxo) s
 
+-- |
+-- Keep those outputs whose address satisfies the predicate.
 filterByAddress :: (Address -> Bool) -> UTxO -> UTxO
 filterByAddress p = Map.filter (p . getCompactAddr)

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/InverseMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/InverseMap.hs
@@ -25,6 +25,8 @@ inverseMapFromMap m =
             (key, v) <- Map.toAscList m
             pure (v, Set.singleton key)
 
+-- |
+-- Insert a key-value pair into an 'InverseMap'.
 insert
     :: (Ord key, Ord v)
     => key
@@ -33,6 +35,8 @@ insert
     -> InverseMap key v
 insert key v = Map.insertWith Set.union v (Set.singleton key)
 
+-- |
+-- Insert a set of keys that all have the same value.
 insertManyKeys
     :: (Ord key, Ord v)
     => Set key
@@ -56,6 +60,8 @@ delete
     -> InverseMap key v
 delete key x = Map.update (deleteFromSet key) x
 
+-- |
+-- Take the difference between an 'InverseMap' and an ordinary 'Map'
 difference
     :: (Ord v, Ord key)
     => InverseMap key v


### PR DESCRIPTION
This pull request adds documentation, primarily for functions on the `UTxO` and `TxHistory` types.

This pull request also fixes `agda2hs-fixer` to parse Agda identifiers whose type signature starts on the next line.

### Comments

* Documentation for data types and properties has not been implemented yet.