### PR TITLE
Implement documentation for types

### DIFF
--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Parser.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Parser.hs
@@ -53,11 +53,18 @@ collectTopLevelDeclarations
     -> Map HaskellIdentifier LineNo
 collectTopLevelDeclarations = Map.fromList . fromModule
   where
-    fromModule (Hs.Module _ _ _ _ decls) = concatMap fromTypeSig decls
+    fromModule (Hs.Module _ _ _ _ decls) = concatMap fromDeclaration decls
     fromModule _ = []
 
-    fromTypeSig (Hs.TypeSig _ (name:_) _) = fromName name
-    fromTypeSig _ = []
+    fromDeclaration (Hs.TypeSig _ (name:_) _) = fromName name
+    fromDeclaration (Hs.TypeDecl _ x _) = fromDeclHead x
+    fromDeclaration (Hs.DataDecl _ _ _ x _ _) = fromDeclHead x
+    fromDeclaration _ = []
 
     fromName (Hs.Ident info s) = [(s, Hs.startLine info - 1)]
     fromName _ = []
+
+    fromDeclHead (Hs.DHead _ name) = fromName name
+    fromDeclHead (Hs.DHInfix _ _ name) = fromName name
+    fromDeclHead (Hs.DHParen _ x) = fromDeclHead x
+    fromDeclHead (Hs.DHApp _ x _) = fromDeclHead x

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
@@ -95,14 +95,17 @@ prependLines original0 inserted = both
     Agda to Haskell
 ------------------------------------------------------------------------------}
 -- | Attempt to convert an identifier in Agda to a Haskell identifier.
--- Currently only supports values, not types.
+--
+-- Works for both values (starts with lowercase)
+-- and types (starts with uppercase).
 fromAgdaIdentifier :: AgdaIdentifier -> Maybe HaskellIdentifier
 fromAgdaIdentifier [] = Nothing
 fromAgdaIdentifier "_" = Nothing
 fromAgdaIdentifier s@(x:xs)
-    | small x && all valid xs = Just s
+    | validStart x && all valid xs = Just s
     | otherwise = Nothing
   where
+    validStart c = small c || large c
     valid c = small c || large c || digit c || tick c
     small c = Char.isLowerCase c || c == '_'
     large = Char.isUpperCase

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Type.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Type.agda
@@ -26,7 +26,7 @@ open import Haskell.Data.Maps.Timeline using
     Data type
 ------------------------------------------------------------------------------}
 
-{-| Tx History.
+{-| 'TxHistory'.
 
 History of the transactions to and from the Deposit Wallet.
 Information includes:

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxSummary.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxSummary.agda
@@ -18,7 +18,12 @@ import Cardano.Wallet.Deposit.Read as Read
 {-----------------------------------------------------------------------------
     TxSummary
 ------------------------------------------------------------------------------}
+{-|
+A 'TxSummary' summarizes a transaction.
 
+Note: Haddock may be broken. The fields of this record
+refer to types from "Cardano.Wallet.Read".
+-}
 record TxSummary : Set where
   field
     txSummarized : TxId
@@ -27,7 +32,9 @@ record TxSummary : Set where
 
 open TxSummary public
 
--- This is a mock summary for now
+-- | Create a 'TxSummary' from a transaction.
+--
+-- FIXME: This is a mock summary for now!
 mkTxSummary : ∀ {era} → {{IsEra era}} → Tx era → ValueTransfer → TxSummary
 mkTxSummary = λ tx transfer' → record
     { txSummarized = getTxId tx

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
@@ -35,7 +35,14 @@ import Haskell.Data.Set as Set
 {-----------------------------------------------------------------------------
     UTxO
 ------------------------------------------------------------------------------}
-
+{-|
+The type 'UTxO' is used to keep track of unspent transaction outputs.
+This type is a mapping from transaction inputs, 'TxIn',
+which are references, to transaction outputs, 'TxOut',
+which record the actual currency values, addresses, and other data,
+that is available for spending.
+-}
+UTxO : Set
 UTxO = Map.Map TxIn TxOut
 
 -- | Test whether the 'UTxO' is empty.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
@@ -12,6 +12,8 @@ deriving instance Eq DerivationType
 
 deriving instance Ord DerivationType
 
+-- |
+-- An absolute BIP32 Path.
 data BIP32Path
     = Root
     | Segment BIP32Path DerivationType Word31

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
@@ -6,6 +6,14 @@ if' :: Bool -> a -> a -> a
 if' True thn els = thn
 if' False thn els = els
 
+-- |
+-- A 'RollbackWindow' is a time interval.
+-- This time interval is used to keep track of data / transactions
+-- that are not final and may still be rolled back.
+-- The 'tip' is the higher end of the interval,
+-- representing the latest state of the data.
+-- The 'finality' is the lower end of the interval,
+-- until which rollbacks are supported.
 data RollbackWindow time = RollbackWindowC
     { finality :: time
     , tip :: time
@@ -34,6 +42,8 @@ rollForward newTip w =
         then Just (RollbackWindowC (finality w) newTip)
         else Nothing
 
+-- |
+-- Potential results of a 'rollBackwards'.
 data MaybeRollback a
     = Past
     | Present a

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
@@ -7,6 +7,14 @@ import Cardano.Wallet.Read.Tx (TxId)
 import Haskell.Data.Maps.PairMap (PairMap)
 import Haskell.Data.Maps.Timeline (Timeline)
 
+-- |
+-- 'TxHistory'.
+--
+-- History of the transactions to and from the Deposit Wallet.
+-- Information includes:
+--
+-- * Slot of each transaction
+-- * Value transfer for each transaction, indexed by address
 data TxHistory = TxHistory
     { txIds :: Timeline Slot TxId
     , txTransfers :: PairMap TxId Address ValueTransfer

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
@@ -5,12 +5,21 @@ import Cardano.Wallet.Read.Chain (ChainPoint (GenesisPoint))
 import Cardano.Wallet.Read.Eras (IsEra)
 import Cardano.Wallet.Read.Tx (Tx, TxId, getTxId)
 
+-- |
+-- A 'TxSummary' summarizes a transaction.
+--
+-- Note: Haddock may be broken. The fields of this record
+-- refer to types from "Cardano.Wallet.Read".
 data TxSummary = TxSummary
     { txSummarized :: TxId
     , txChainPoint :: ChainPoint
     , txTransfer :: ValueTransfer
     }
 
+-- |
+-- Create a 'TxSummary' from a transaction.
+--
+-- FIXME: This is a mock summary for now!
 mkTxSummary :: IsEra era => Tx era -> ValueTransfer -> TxSummary
 mkTxSummary =
     \tx transfer' -> TxSummary (getTxId tx) GenesisPoint transfer'

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
@@ -97,6 +97,8 @@ applyTx isOurs tx u0 =
                 )
             )
 
+-- |
+-- A transaction whose inputs have been partially resolved.
 data ResolvedTx era = ResolvedTx
     { resolvedTx :: Tx era
     , resolvedInputs :: UTxO

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -17,6 +17,12 @@ import qualified Haskell.Data.Map as Map
     )
 import qualified Haskell.Data.Set as Set (filter)
 
+-- |
+-- The type 'UTxO' is used to keep track of unspent transaction outputs.
+-- This type is a mapping from transaction inputs, 'TxIn',
+-- which are references, to transaction outputs, 'TxOut',
+-- which record the actual currency values, addresses, and other data,
+-- that is available for spending.
 type UTxO = Map.Map TxIn TxOut
 
 -- |

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
@@ -72,6 +72,8 @@ getRollbackWindow x = window x
 getSpent :: UTxOHistory -> Map TxIn SlotNo
 getSpent = Timeline.getMapTime . \r -> spent r
 
+-- |
+-- Changes to the UTxO history.
 data DeltaUTxOHistory
     = AppendBlock SlotNo DeltaUTxO
     | Rollback Slot

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
@@ -7,6 +7,12 @@ import Cardano.Wallet.Read.Chain (Slot)
 import Cardano.Wallet.Read.Tx (TxIn)
 import Haskell.Data.Maps.Timeline (Timeline)
 
+-- |
+-- UTxO history.
+-- Abstract history of the UTxO. We keep track of the creation
+-- and spending of slot of each TxIn.
+-- This allows us to rollback to a given slot
+-- and prune the history to a given slot.
 data UTxOHistory = UTxOHistory
     { history :: UTxO
     , created :: Timeline Slot TxIn

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
@@ -45,6 +45,19 @@ delete2s
     :: (Ord a, Ord b) => [a] -> b -> Map a (Map b v) -> Map a (Map b v)
 delete2s xs b m0 = foldr (\a -> delete2 a b) m0 xs
 
+-- |
+-- The type `PairMap a b v` is essentially the type `Map (a × b) v`,
+-- but with two efficient lookup functions
+--
+-- > lookupA : a → PairMap a b v → Map b v
+-- > lookupB : b → PairMap a b v → Map a v
+--
+-- The property `prop-lookupA-lookupB` states that these lookups
+-- yield the same values.
+--
+-- In the terminology of relational database,
+-- this type stores rows of the form `a × b × v`
+-- and maintains an index on both the first column `a` and the second column `b`.
 data PairMap a b v = PairMap
     { mab :: Map a (Map b v)
     , mba :: Map b (Map a v)

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
@@ -30,6 +30,10 @@ insertManyKeys
 insertManyKeys keys v m0 =
     foldl' (\m key -> Map.insert key v m) m0 keys
 
+-- |
+-- A 'Timeline' is a set of items that are associated with a timestamp.
+-- Each item is unique.
+-- Multiple items can have the same timestamp associated with it.
 data Timeline time a = Timeline
     { events :: Map a time
     , eventsByTime :: InverseMap.InverseMap a time


### PR DESCRIPTION
This pull request improves the `adga2hs-fixer` utility to also include add Haddock documentation for data types.

Specifically, this pull request adds support for `data`, type synonyms, `data` declarations, and `record` types.
