### PR TITLE
Improve `TxHistory` to use `TxSummary`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Type.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Type.agda
@@ -6,6 +6,7 @@ open import Haskell.Prelude
 
 open import Cardano.Wallet.Deposit.Read using
     ( Address
+    ; ChainPoint
     ; Slot
     ; TxId
     )
@@ -40,6 +41,9 @@ its internals are only exported for technical reasons.
 record TxHistory : Set where
   field
     txIds : Timeline Slot TxId
+
+    txBlocks : Map TxId ChainPoint
+        -- ^ Map from transaction to the respective 'ChainPoint'.
 
     txTransfers : PairMap TxId Address ValueTransfer
         -- ^ Map from (transaction × address) to ValueTransfer

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxSummary.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxSummary.agda
@@ -25,6 +25,7 @@ Note: Haddock may be broken. The fields of this record
 refer to types from "Cardano.Wallet.Read".
 -}
 record TxSummary : Set where
+  constructor TxSummaryC
   field
     txSummarized : TxId
     txChainPoint : ChainPoint

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Chain.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Chain.agda
@@ -80,6 +80,10 @@ instance
     x1 == x2 && y1 == y2
   iEqChainPoint ._==_ _      _      = False
 
+instance postulate
+  iOrdChainPoint : Ord ChainPoint
+  iShowChainPoint : Show ChainPoint
+
 slotFromChainPoint : ChainPoint → Slot
 slotFromChainPoint GenesisPoint = WithOrigin.Origin
 slotFromChainPoint (BlockPoint slotNo _) = WithOrigin.At slotNo

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map.agda
@@ -43,6 +43,7 @@ module _ {k a : Set} {{_ : Ord k}} where
 
     unionWith     : (a → a → a) → Map k a → Map k a → Map k a
     filterWithKey : (k → a → Bool) → Map k a → Map k a
+    mapMaybeWithKey : (k → a → Maybe b) → Map k a → Map k b
 
     takeWhileAntitone : (k → Bool) → Map k a → Map k a
     dropWhileAntitone : (k → Bool) → Map k a → Map k a
@@ -185,22 +186,24 @@ module _ {k a : Set} {{_ : Ord k}} where
   foldMap' : ∀ {{_ : Monoid b}} → (a → b) → Map k a → b
   foldMap' f = foldMap f ∘ L.map snd ∘ toAscList
 
-postulate
-  prop-lookup-fmap
-    : ∀ {a b k : Set} {{_ : Ord k}}
-        (key : k)
-        (m : Map k a)
-        (f : a → b)
-    → lookup key (fmap {{iMapFunctor {k} {a}}} f m)
-      ≡ fmap f (lookup key m)
+-- Properties involving 2 type variables.
+module _ {k a b : Set} {{_ : Ord k}} where
+  postulate
 
-  prop-lookup-mapWithKey
-    : ∀ {a b k : Set} {{_ : Ord k}}
-        (key : k)
-        (m : Map k a)
-        (f : k → a → b)
-    → lookup key (mapWithKey f m)
-      ≡ fmap (f key) (lookup key m)
+    prop-lookup-fmap
+      : ∀ (key : k) (m : Map k a) (f : a → b)
+      → lookup key (fmap {{iMapFunctor {k} {a}}} f m)
+        ≡ fmap f (lookup key m)
+
+    prop-lookup-mapWithKey
+      : ∀ (key : k) (m : Map k a) (f : k → a → b)
+      → lookup key (mapWithKey f m)
+        ≡ fmap (f key) (lookup key m)
+
+    prop-lookup-mapMaybeWithKey
+      : ∀ (key : k) (m : Map k a) (f : k → a → Maybe b)
+      → lookup key (mapMaybeWithKey f m)
+        ≡ Maybe.mapMaybe (f key) (lookup key m)
 
 instance
   iMapFoldable : ∀ {k : Set} {{_ : Ord k}} → Foldable (Map k)
@@ -211,8 +214,10 @@ instance
   iEqMap : ∀ {k v : Set} {{_ : Ord k}} {{_ : Eq v}} → Eq (Map k v)
   iEqMap ._==_ m1 m2 = toAscList m1 == toAscList m2
 
+-- Properties involving three type variables.
 module _ {k a b c : Set} {{_ : Ord k}} where
   postulate
+
     intersectionWith : (a → b → c) → Map k a → Map k b → Map k c
 
     prop-lookup-intersectionWith

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
@@ -26,6 +26,10 @@ filter : (a → Bool) → Maybe a → Maybe a
 filter p Nothing = Nothing
 filter p (Just x) = if p x then Just x else Nothing
 
+mapMaybe : (a → Maybe b) → Maybe a → Maybe b
+mapMaybe f Nothing = Nothing
+mapMaybe f (Just x) = f x
+
 unionWith : (a → a → a) → Maybe a → Maybe a → Maybe a
 unionWith f Nothing my = my
 unionWith f (Just x) Nothing = Just x

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
@@ -2,8 +2,9 @@ module Cardano.Wallet.Deposit.Pure.TxHistory.Type where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer (ValueTransfer)
 import Cardano.Wallet.Deposit.Read (Address)
-import Cardano.Wallet.Read.Chain (Slot)
+import Cardano.Wallet.Read.Chain (ChainPoint, Slot)
 import Cardano.Wallet.Read.Tx (TxId)
+import Haskell.Data.Map (Map)
 import Haskell.Data.Maps.PairMap (PairMap)
 import Haskell.Data.Maps.Timeline (Timeline)
 
@@ -20,6 +21,7 @@ import Haskell.Data.Maps.Timeline (Timeline)
 -- its internals are only exported for technical reasons.
 data TxHistory = TxHistory
     { txIds :: Timeline Slot TxId
+    , txBlocks :: Map TxId ChainPoint
     , txTransfers :: PairMap TxId Address ValueTransfer
     , tip :: Slot
     }

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
@@ -12,7 +12,7 @@ import Cardano.Wallet.Read.Tx (Tx, TxId, getTxId)
 --
 -- Note: Haddock may be broken. The fields of this record
 -- refer to types from "Cardano.Wallet.Read".
-data TxSummary = TxSummary
+data TxSummary = TxSummaryC
     { txSummarized :: TxId
     , txChainPoint :: ChainPoint
     , txTransfer :: ValueTransfer
@@ -28,4 +28,4 @@ deriving instance Show TxSummary
 -- FIXME: This is a mock summary for now!
 mkTxSummary :: IsEra era => Tx era -> ValueTransfer -> TxSummary
 mkTxSummary =
-    \tx transfer' -> TxSummary (getTxId tx) GenesisPoint transfer'
+    \tx transfer' -> TxSummaryC (getTxId tx) GenesisPoint transfer'


### PR DESCRIPTION
This pull request changes the functionality of the `TxHistory` module to make use of the `TxSummary` type.

* Added: `getValueTransferInRange` (with the semantics of the old `getValueTransfers`)
* Changed: `getAddressHistory`, `getValueTransfers`, `rollForward`

### Comments

* The function `getAddressHistory` does not yet return the transactions by `Slot`
* The `TxHistory` type does not yet keep track of the order in which transactions appear in a block.