### PR TITLE
Drop Agda `stdlib`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Experimental.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Experimental.agda
@@ -117,9 +117,6 @@ import Cardano.Wallet.Deposit.Pure.UTxO.Tx as UTxO
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 import Haskell.Data.Map as Map
 
--- The import of the cong! tactic slows down type checking…
-open import Tactic.Cong using (cong!)
-
 {-----------------------------------------------------------------------------
     Type definition
 ------------------------------------------------------------------------------}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -13,11 +13,11 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     -}
     where
 
+open import Haskell.Reasoning
 open import Haskell.Prelude hiding
     ( null
     ; concat
     )
-open import Haskell.Reasoning
 
 open import Cardano.Wallet.Deposit.Pure.UTxO.UTxO using
     ( UTxO

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
@@ -15,6 +15,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.UTxO
     -}
     where
 
+open import Haskell.Reasoning
 open import Haskell.Prelude hiding (null; f)
 
 open import Cardano.Wallet.Deposit.Read.Temp using

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Address.agda
@@ -10,6 +10,7 @@ module Cardano.Wallet.Read.Address
     -}
     where
 
+open import Haskell.Reasoning
 open import Haskell.Prelude
 
 open import Haskell.Data.ByteString.Short using

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Block.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Block.agda
@@ -3,7 +3,9 @@
 -- Synchronized manually with the corresponding Haskell module.
 module Cardano.Wallet.Read.Block where
 
+open import Haskell.Reasoning
 open import Haskell.Prelude
+
 open import Cardano.Wallet.Read.Eras using (IsEra)
 open import Cardano.Wallet.Read.Tx using (Tx)
 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Chain.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Chain.agda
@@ -3,7 +3,9 @@
 -- Synchronized manually with the corresponding Haskell module.
 module Cardano.Wallet.Read.Chain where
 
+open import Haskell.Reasoning
 open import Haskell.Prelude
+
 open import Cardano.Wallet.Read.Eras using
     ( IsEra
     )

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Tx.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Tx.agda
@@ -3,6 +3,7 @@
 -- Synchronized manually with the corresponding Haskell module.
 module Cardano.Wallet.Read.Tx where
 
+open import Haskell.Reasoning
 open import Haskell.Prelude
 
 open import Haskell.Data.Map using

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString.agda
@@ -7,6 +7,8 @@ module Haskell.Data.ByteString
     where
 
 open import Haskell.Prelude hiding (lookup; null; map)
+open import Haskell.Reasoning
+
 open import Haskell.Data.Word using
     ( Word8
     )

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString/Short.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString/Short.agda
@@ -7,6 +7,7 @@ module Haskell.Data.ByteString.Short
     where
 
 open import Haskell.Prelude hiding (lookup; null; map)
+open import Haskell.Reasoning
 
 open import Haskell.Data.Word using
     ( Word8

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
@@ -7,6 +7,7 @@ module Haskell.Data.Maps.Maybe
     This is used to make proofs for 'Data.Map' more transparent.
     -} where
 
+open import Haskell.Reasoning
 open import Haskell.Prelude hiding (null; map; filter)
 
 open import Haskell.Data.Maybe using


### PR DESCRIPTION
This pull request drops the dependency on the [Agda `stdlib`](https://github.com/agda/agda-stdlib) for the sake of improving compile-time performance. It also foreshadows some changes in `agda2hs` version 1.3
