### PR TITLE
Support `Testnet` addresses in `AddressState`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/Encoding.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/Encoding.agda
@@ -1,11 +1,6 @@
 {-# OPTIONS --erasure #-}
 
-module Cardano.Wallet.Address.Encoding
-    {-
-    ; mkEnterpriseAddress
-    ; prop-mkEnterpriseAddress-injective
-    -}
-    where
+module Cardano.Wallet.Address.Encoding where
 
 open import Haskell.Prelude hiding (fromJust)
 
@@ -22,6 +17,9 @@ open import Cardano.Wallet.Read using
   ( CompactAddr
     ; fromShortByteString
     ; prop-fromShortByteString-partially-injective
+  ; NetworkId
+    ; Mainnet
+    ; Testnet
   )
 open import Haskell.Data.ByteString.Short using
   ( ShortByteString
@@ -41,64 +39,134 @@ open import Haskell.Data.Word using
   )
 
 {-----------------------------------------------------------------------------
-    Create addresses from public keys
+    Algebraic data type for Enterprise addresses
+------------------------------------------------------------------------------}
+KeyHash : Set
+KeyHash = ShortByteString
+
+data Credential : Set where
+  KeyHashObj : KeyHash → Credential
+
+-- | Tag to distinguish addresses from Cardano test networks and mainnet.
+--
+-- This tag is used to disallow testnet addresses on mainnet.
+-- This is because testnet addresses tend to be generated
+-- with little security in mind, and resuing them on mainnet by accident
+-- could lead to a loss of funds.
+data NetworkTag : Set where
+  MainnetTag : NetworkTag
+  TestnetTag : NetworkTag
+
+-- | Get 'NetworkTag' from 'NetworkId'.
+fromNetworkId : NetworkId → NetworkTag
+fromNetworkId Mainnet = MainnetTag
+fromNetworkId (Testnet x) = TestnetTag
+
+-- | Algebraic representation of an enterprise address.
+record EnterpriseAddr : Set where
+  constructor EnterpriseAddrC
+  field
+    net : NetworkTag
+    pay : Credential
+
+open EnterpriseAddr public
+
+{-# COMPILE AGDA2HS KeyHash #-}
+{-# COMPILE AGDA2HS Credential #-}
+{-# COMPILE AGDA2HS NetworkTag #-}
+{-# COMPILE AGDA2HS fromNetworkId #-}
+{-# COMPILE AGDA2HS EnterpriseAddr #-}
+
+--
+prop-KeyHashObj-injective
+  : ∀ (x y : KeyHash)
+  → KeyHashObj x ≡ KeyHashObj y
+  → x ≡ y
+--
+prop-KeyHashObj-injective x y refl = refl
+
+{-----------------------------------------------------------------------------
+    XPubs and hashes
+------------------------------------------------------------------------------}
+keyHashFromXPub : XPub → KeyHash
+keyHashFromXPub xpub = toShort (blake2b'224 (rawSerialiseXPub xpub))
+
+-- | Hash public key to obtain a payment or stake credential.
+credentialFromXPub : XPub → Credential
+credentialFromXPub xpub =
+  KeyHashObj (toShort (blake2b'224 (rawSerialiseXPub xpub)))
+
+{-# COMPILE AGDA2HS keyHashFromXPub #-}
+{-# COMPILE AGDA2HS credentialFromXPub #-}
+
+{-----------------------------------------------------------------------------
+    Binary format of enterprise addresses.
 
     For magic numbers, see
     https://github.com/cardano-foundation/CIPs/tree/master/CIP-0019
 ------------------------------------------------------------------------------}
 
--- | Network tag for enterprise addresses on mainnet.
-tagEnterprise : Word8 
-tagEnterprise = 0b01100001
+-- | Magic tag for enterprise addresses on testnet and mainnet.
+toEnterpriseTag : NetworkTag → Word8
+toEnterpriseTag TestnetTag = 0b01100000
+toEnterpriseTag MainnetTag = 0b01100001
 
-{-# COMPILE AGDA2HS tagEnterprise #-}
+{-# COMPILE AGDA2HS toEnterpriseTag #-}
 
--- | Create an enterprise address on mainnet in binary format.
+-- | Canonical binary format of an 'EnterpriseAddr'.
 --
 -- The binary format of addresses is described in
 -- [CIP-19](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0019/README.md)
-mkEnterpriseAddressBytes : XPub → ShortByteString
-mkEnterpriseAddressBytes xpub =
-    singleton tagEnterprise <>
-      toShort (blake2b'224 (rawSerialiseXPub xpub))
-
-{-# COMPILE AGDA2HS mkEnterpriseAddressBytes #-}
+--
+bytesFromEnterpriseAddr : EnterpriseAddr → ShortByteString
+bytesFromEnterpriseAddr (EnterpriseAddrC network0 (KeyHashObj hash)) =
+  singleton (toEnterpriseTag network0) <> hash
 
 postulate
-  prop-mkEnterpriseAddress-isJust
-    : ∀ (xpub : XPub)
-    → isJust (fromShortByteString (mkEnterpriseAddressBytes xpub)) ≡ True
+  prop-bytesFromEnterpriseAddr-isJust
+    : ∀ (addr : EnterpriseAddr)
+    → isJust (fromShortByteString (bytesFromEnterpriseAddr addr)) ≡ True
 
--- | Create an enterprise address on mainnet from a public key.
--- Knowing the private key allows you to spend outputs with this address.
-mkEnterpriseAddress : XPub → CompactAddr
-mkEnterpriseAddress xpub =
+-- | Compact from of an 'EnterpriseAddr'.
+compactAddrFromEnterpriseAddr : EnterpriseAddr → CompactAddr
+compactAddrFromEnterpriseAddr addr =
   fromJust
-    (fromShortByteString (mkEnterpriseAddressBytes xpub))
-    {prop-mkEnterpriseAddress-isJust xpub}
+    (fromShortByteString (bytesFromEnterpriseAddr addr))
+    {prop-bytesFromEnterpriseAddr-isJust addr}
 
-{-# COMPILE AGDA2HS mkEnterpriseAddress #-}
+{-# COMPILE AGDA2HS bytesFromEnterpriseAddr #-}
+{-# COMPILE AGDA2HS compactAddrFromEnterpriseAddr #-}
 
 {-----------------------------------------------------------------------------
     Properties
 ------------------------------------------------------------------------------}
-
-prop-mkEnterpriseAddressBytes-injective
+--
+prop-credentialFromXPub-injective
   : ∀ (x y : XPub)
-  → mkEnterpriseAddressBytes x ≡ mkEnterpriseAddressBytes y
+  → credentialFromXPub x ≡ credentialFromXPub y
   → x ≡ y
-prop-mkEnterpriseAddressBytes-injective x y =
+--
+prop-credentialFromXPub-injective x y =
   prop-rawSerialiseXPub-injective _ _
-    ∘ prop-blake2b'224-injective _ _
-    ∘ prop-toShort-injective _ _
-    ∘ prop-<>-cancel-left (singleton tagEnterprise) _ _
+  ∘ prop-blake2b'224-injective _ _
+  ∘ prop-toShort-injective _ _
+  ∘ prop-KeyHashObj-injective _ _
 
-@0 prop-mkEnterpriseAddress-injective
-  : ∀ (x y : XPub)
-  → mkEnterpriseAddress x ≡ mkEnterpriseAddress y
+--
+postulate
+ prop-bytesFromEnterpriseAddr-injective
+  : ∀ (x y : EnterpriseAddr)
+  → bytesFromEnterpriseAddr x ≡ bytesFromEnterpriseAddr y
   → x ≡ y
-prop-mkEnterpriseAddress-injective x y =
-  prop-mkEnterpriseAddressBytes-injective _ _
+
+--
+@0 prop-compactAddrFromEnterpriseAddr-injective
+  : ∀ (x y : EnterpriseAddr)
+  → compactAddrFromEnterpriseAddr x ≡ compactAddrFromEnterpriseAddr y
+  → x ≡ y
+--
+prop-compactAddrFromEnterpriseAddr-injective x y =
+  prop-bytesFromEnterpriseAddr-injective _ _
   ∘ prop-fromShortByteString-partially-injective _ _
-      (prop-mkEnterpriseAddress-isJust x)
+      (prop-bytesFromEnterpriseAddr-isJust x)
   ∘ prop-fromJust-injective _ _

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Implementation.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Implementation.agda
@@ -89,7 +89,8 @@ pairFromTxOut =
 @0 properties : DepositWallet.Properties operations
 properties = record
     { prop-create-known = Wallet.prop-create-known
-    ; deriveAddress = Wallet.deriveCustomerAddress ∘ Wallet.getXPub
+    ; deriveAddress = λ s →
+        Wallet.deriveCustomerAddress (Wallet.getNetworkTag s) (Wallet.getXPub s)
     ; prop-create-derive = Wallet.prop-create-derive
 
     ; summarize = {!  !}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -47,6 +47,9 @@ open import Cardano.Wallet.Address.Encoding using
 open import Cardano.Wallet.Deposit.Read.Temp using
     ( Address
     )
+open import Cardano.Wallet.Read using
+    ( NetworkId
+    )
 open import Cardano.Write.Tx.Balance using
     ( ChangeAddressGen
     ; isChange
@@ -197,6 +200,7 @@ lemma-derive-notCustomer xpub c eq = bang (lemma-derive-injective {xpub} eq)
 record AddressState : Set where
   constructor AddressStateC
   field
+    networkId : NetworkId
     stateXPub : XPub
     addresses : Map.Map Address Customer
 --    customers : Map.Map Customer Address
@@ -496,7 +500,8 @@ createAddress c s0 = ( addr , s1 )
 
     s1 : AddressState
     s1 = record
-      { stateXPub = stateXPub s0
+      { networkId = networkId s0
+      ; stateXPub = stateXPub s0
       ; addresses = addresses1
       ; change = change s0
       ; invariant-change = invariant-change s0
@@ -563,11 +568,12 @@ getXPub = stateXPub
 
 {-# COMPILE AGDA2HS getXPub #-}
 
--- | Create an empty 'AddressState' from a public key.
-emptyFromXPub : XPub → AddressState
-emptyFromXPub xpub =
+-- | Create an empty 'AddressState' for a given 'NetworkId' from a public key.
+emptyFromXPub : NetworkId → XPub → AddressState
+emptyFromXPub net xpub =
   record
-    { stateXPub = xpub
+    { networkId = net
+    ; stateXPub = xpub
     ; addresses = Map.empty
     ; change = deriveAddress xpub DerivationChange
     ; invariant-change = refl
@@ -577,13 +583,13 @@ emptyFromXPub xpub =
 
 {-# COMPILE AGDA2HS emptyFromXPub #-}
 
--- | Create an 'AddressState' from a public key and
+-- | Create an 'AddressState' for a given 'NetworkId' from a public key and
 -- a count of known customers.
-fromXPubAndCount : XPub → Word31 → AddressState
-fromXPubAndCount xpub knownCustomerCount =
+fromXPubAndCount : NetworkId → XPub → Word31 → AddressState
+fromXPubAndCount net xpub knownCustomerCount =
     foldl (λ s c → snd (createAddress c s)) s0 customers
   where
-    s0 = emptyFromXPub xpub
+    s0 = emptyFromXPub net xpub
     customers = enumFromTo 0 knownCustomerCount
 
 {-# COMPILE AGDA2HS fromXPubAndCount #-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Experimental.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Experimental.agda
@@ -49,6 +49,9 @@ import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 open import Cardano.Wallet.Address.BIP32_Ed25519 using
     ( XPub
     )
+open import Cardano.Wallet.Address.Encoding using
+    ( NetworkTag
+    )
 open import Cardano.Wallet.Deposit.Pure.Address public using
     ( deriveCustomerAddress
     )
@@ -82,6 +85,7 @@ open import Cardano.Wallet.Read using
     ; ChainPoint
       ; getChainPoint
     ; IsEra
+    ; NetworkId
     ; Slot
     ; Tx
     ; TxId
@@ -139,7 +143,11 @@ open WalletState public
 getXPub : WalletState → XPub
 getXPub = Addr.getXPub ∘ addresses
 
+getNetworkTag : WalletState → NetworkTag
+getNetworkTag s = Addr.getNetworkTag (addresses s)
+
 {-# COMPILE AGDA2HS getXPub #-}
+{-# COMPILE AGDA2HS getNetworkTag #-}
 
 {-----------------------------------------------------------------------------
     Mapping between Customers and Address
@@ -203,7 +211,7 @@ prop-create-derive
   : ∀ (c : Customer)
       (s0 : WalletState)
   → let (address , _) = createAddress c s0
-    in  deriveCustomerAddress (getXPub s0) c ≡ address
+    in  deriveCustomerAddress (getNetworkTag s0) (getXPub s0) c ≡ address
 --
 prop-create-derive c s0 = Addr.prop-create-derive c (addresses s0)
  

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/ByteString.agda
@@ -67,10 +67,12 @@ postulate
   instance
     iLawfulEqByteString : IsLawfulEq ByteString
 
+--
 prop-pack-injective
   : ∀ (x y : List Word8)
   → pack x ≡ pack y
   → x ≡ y
+--
 prop-pack-injective x y eq =
   begin
     x
@@ -82,10 +84,12 @@ prop-pack-injective x y eq =
     y
   ∎
 
+--
 prop-unpack-injective
   : ∀ (x y : ByteString)
   → unpack x ≡ unpack y
   → x ≡ y
+--
 prop-unpack-injective x y eq =
   begin
     x
@@ -97,9 +101,11 @@ prop-unpack-injective x y eq =
     y
   ∎
 
+--
 prop-pack-morphism
   : ∀ (x y : List Word8)
   → pack x <> pack y ≡ pack (x ++ y)
+--
 prop-pack-morphism x y =
   begin
     pack x <> pack y
@@ -111,9 +117,11 @@ prop-pack-morphism x y =
     pack (x ++ y)
   ∎
 
+--
 prop-unpack-morphism
   : ∀ (x y : ByteString)
   → unpack (x <> y) ≡ unpack x ++ unpack y
+--
 prop-unpack-morphism x y =
   begin
     unpack (x <> y)
@@ -123,10 +131,12 @@ prop-unpack-morphism x y =
     unpack x ++ unpack y
   ∎
 
+--
 prop-<>-cancel-left
   : ∀ (x y z : ByteString)
   → x <> y ≡ x <> z
   → y ≡ z
+--
 prop-<>-cancel-left x y z =
   prop-unpack-injective _ _
   ∘ ++-cancel-left (unpack x) (unpack y)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
@@ -3,28 +3,67 @@ module Cardano.Wallet.Address.Encoding where
 import Cardano.Wallet.Address.BIP32_Ed25519 (XPub, rawSerialiseXPub)
 import Cardano.Wallet.Address.Hash (blake2b'224)
 import Cardano.Wallet.Read.Address (CompactAddr, fromShortByteString)
+import Cardano.Wallet.Read.Chain (NetworkId (Mainnet, Testnet))
 import Data.Word (Word8)
 import Haskell.Data.ByteString.Short (ShortByteString, singleton, toShort)
 import Haskell.Data.Maybe (fromJust)
 
--- |
--- Network tag for enterprise addresses on mainnet.
-tagEnterprise :: Word8
-tagEnterprise = 97
+type KeyHash = ShortByteString
+
+data Credential = KeyHashObj KeyHash
 
 -- |
--- Create an enterprise address on mainnet in binary format.
+-- Tag to distinguish addresses from Cardano test networks and mainnet.
+--
+-- This tag is used to disallow testnet addresses on mainnet.
+-- This is because testnet addresses tend to be generated
+-- with little security in mind, and resuing them on mainnet by accident
+-- could lead to a loss of funds.
+data NetworkTag
+    = MainnetTag
+    | TestnetTag
+
+-- |
+-- Get 'NetworkTag' from 'NetworkId'.
+fromNetworkId :: NetworkId -> NetworkTag
+fromNetworkId Mainnet = MainnetTag
+fromNetworkId (Testnet x) = TestnetTag
+
+-- |
+-- Algebraic representation of an enterprise address.
+data EnterpriseAddr = EnterpriseAddrC
+    { net :: NetworkTag
+    , pay :: Credential
+    }
+
+keyHashFromXPub :: XPub -> KeyHash
+keyHashFromXPub xpub =
+    toShort (blake2b'224 (rawSerialiseXPub xpub))
+
+-- |
+-- Hash public key to obtain a payment or stake credential.
+credentialFromXPub :: XPub -> Credential
+credentialFromXPub xpub =
+    KeyHashObj (toShort (blake2b'224 (rawSerialiseXPub xpub)))
+
+-- |
+-- Magic tag for enterprise addresses on testnet and mainnet.
+toEnterpriseTag :: NetworkTag -> Word8
+toEnterpriseTag TestnetTag = 96
+toEnterpriseTag MainnetTag = 97
+
+-- |
+-- Canonical binary format of an 'EnterpriseAddr'.
 --
 -- The binary format of addresses is described in
 -- [CIP-19](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0019/README.md)
-mkEnterpriseAddressBytes :: XPub -> ShortByteString
-mkEnterpriseAddressBytes xpub =
-    singleton tagEnterprise
-        <> toShort (blake2b'224 (rawSerialiseXPub xpub))
+bytesFromEnterpriseAddr :: EnterpriseAddr -> ShortByteString
+bytesFromEnterpriseAddr
+    (EnterpriseAddrC network0 (KeyHashObj hash)) =
+        singleton (toEnterpriseTag network0) <> hash
 
 -- |
--- Create an enterprise address on mainnet from a public key.
--- Knowing the private key allows you to spend outputs with this address.
-mkEnterpriseAddress :: XPub -> CompactAddr
-mkEnterpriseAddress xpub =
-    fromJust (fromShortByteString (mkEnterpriseAddressBytes xpub))
+-- Compact from of an 'EnterpriseAddr'.
+compactAddrFromEnterpriseAddr :: EnterpriseAddr -> CompactAddr
+compactAddrFromEnterpriseAddr addr =
+    fromJust (fromShortByteString (bytesFromEnterpriseAddr addr))

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Experimental.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Experimental.hs
@@ -1,9 +1,11 @@
 module Cardano.Wallet.Deposit.Pure.Experimental where
 
 import Cardano.Wallet.Address.BIP32_Ed25519 (XPub)
+import Cardano.Wallet.Address.Encoding (NetworkTag)
 import Cardano.Wallet.Deposit.Pure.Address (AddressState, Customer)
 import qualified Cardano.Wallet.Deposit.Pure.Address as Addr
     ( createAddress
+    , getNetworkTag
     , getXPub
     , isOurs
     , listCustomers
@@ -50,6 +52,9 @@ data WalletState = WalletState
 
 getXPub :: WalletState -> XPub
 getXPub = Addr.getXPub . \r -> addresses r
+
+getNetworkTag :: WalletState -> NetworkTag
+getNetworkTag s = Addr.getNetworkTag (addresses s)
 
 listCustomers :: WalletState -> [(Customer, Address)]
 listCustomers = Addr.listCustomers . \r -> addresses r


### PR DESCRIPTION
This pull request adds support for `Testnet` addresses in the `AddressState`. Specifically, the address state can be initialized for a particular `Network`, and all addresses will be generated for this network.