### PR TITLE
Support Haddock documentation for Agda properties

### DIFF
--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser.hs
@@ -140,8 +140,8 @@ agdaDeclarationIdentifier :: Parser String
 agdaDeclarationIdentifier =
     option () (() <$ keyword) *> agdaNamePart
   where
-    keyword =
-        L.lexeme C.space1 (C.string "data" <|> C.string "record")
+    keyword = L.lexeme C.space1 (foldr1 (<|>) $ map C.string keywords)
+    keywords = ["data", "record", "@0"]
 
 agdaNamePart :: Parser String
 agdaNamePart =

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser.hs
@@ -11,13 +11,18 @@ module Language.Agda2hs.Agda.Parser
 
 import Prelude
 
+import Data.List
+    ( isPrefixOf
+    )
 import Data.Void
     ( Void
     )
 import Language.Agda2hs.Agda.Types
     ( AgdaIdentifier
     , AgdaDocumentation
+    , DocItem (..)
     , DocString
+    , TypeSignature
     )
 import Text.Megaparsec
     ( MonadParsec (notFollowedBy, takeWhileP, try)
@@ -62,7 +67,7 @@ haddocks = mkHaddocks <$> sections
     mkHaddocks xs = Map.fromList $ do
         (doc, ys) <- xs
         Just ident <- [getIdentifier ys]
-        [(ident, doc)]
+        [(ident, DocItem ident doc (getTypeSignature ys))]
 
 sections :: Parser [(DocString, [Line])]
 sections =
@@ -72,12 +77,18 @@ section :: Parser (DocString, [Line])
 section = (,) <$> documentationPre <*> many codeLine
 
 -- | Get an 'AgdaIdentifier' from a list of code lines.
+-- Not very robust — parses an Agda name part from the first line.
 getIdentifier :: [Line] -> Maybe AgdaIdentifier
 getIdentifier [] = Nothing
 getIdentifier (x:_) =
     case parse agdaDeclarationIdentifier "" x of
         Left _ -> Nothing
         Right a -> Just a
+
+-- | Get a type signature from a list of code lines.
+-- Not very robust — takes all lines until the first single-line comment.
+getTypeSignature :: [Line] -> TypeSignature
+getTypeSignature = unlines . takeWhile (not . ("--" `isPrefixOf`))
 
 {-----------------------------------------------------------------------------
     Lexer

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
@@ -10,10 +10,14 @@ module Language.Agda2hs.Agda.Types
     , DocString
     , DocItem (..)
     , TypeSignature
+    , filterProperties
     ) where
 
 import Prelude
 
+import Data.List
+    ( isPrefixOf
+    )
 import Data.Map
     ( Map
     )
@@ -41,3 +45,13 @@ data DocItem = DocItem
     -- ^ Type signature of the thing to be documented (multiline).
     }
 
+{-----------------------------------------------------------------------------
+    Operations
+------------------------------------------------------------------------------}
+-- | Keep those documentation items that are logical properties.
+filterProperties :: AgdaDocumentation -> AgdaDocumentation
+filterProperties = Map.filterWithKey isProperty
+
+-- My naming convention for logical properties.
+isProperty :: AgdaIdentifier -> DocItem -> Bool
+isProperty name _ = "prop-" `isPrefixOf` name

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
@@ -8,6 +8,8 @@ module Language.Agda2hs.Agda.Types
     ( AgdaIdentifier
     , AgdaDocumentation
     , DocString
+    , DocItem (..)
+    , TypeSignature
     ) where
 
 import Prelude
@@ -16,11 +18,26 @@ import Data.Map
     ( Map
     )
 
+import qualified Data.Map.Strict as Map
+
 {-----------------------------------------------------------------------------
-    Agda
+    Types
 ------------------------------------------------------------------------------}
+
 type AgdaIdentifier = String
 
-type AgdaDocumentation = Map AgdaIdentifier DocString
+type AgdaDocumentation = Map AgdaIdentifier DocItem
 
 type DocString = String
+
+type TypeSignature = String
+
+data DocItem = DocItem
+    { identifier :: AgdaIdentifier
+    -- ^ Name of the thing to be documented.
+    , docString :: DocString
+    -- ^ Documentation string (multiline)
+    , typeSignature :: TypeSignature
+    -- ^ Type signature of the thing to be documented (multiline).
+    }
+

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Documentation.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Documentation.hs
@@ -19,11 +19,16 @@ import Control.Exception
 import Language.Agda2hs.Agda.Parser
     ( parseFileAgdaDocumentation
     )
+import Language.Agda2hs.Agda.Types
+    ( AgdaDocumentation
+    , DocItem (..)
+    )
 import Language.Agda2hs.Haskell.Parser
     ( parseFileHaskellModule
     )
 import Language.Agda2hs.Haskell.Types
-    ( prependHaddockLines
+    ( HaskellModule
+    , prependHaddockLines
     , prettyHaskellModule
     )
 import System.IO
@@ -68,7 +73,13 @@ modifyFileAddingDocumentation agdaPath haskellPath = do
             maybe (throw $ ErrParseErrorHaskell haskellPath) pure
                 $ parseFileHaskellModule haskellPath haskellCode
 
-        let haskell1 = prependHaddockLines (Map.map lines agdaDoc) haskell0
+        let haskell1 = patchAgdaDocumentation agdaDoc haskell0
 
 --        putStrLn $ prettyHaskellModule haskell1
         writeFile haskellPath $ prettyHaskellModule haskell1
+
+-- | Add documentation from the .agda module to a generated .hs module.
+patchAgdaDocumentation
+    :: AgdaDocumentation -> HaskellModule -> HaskellModule
+patchAgdaDocumentation agdaDoc =
+    prependHaddockLines (Map.map (lines . docString) agdaDoc)

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
@@ -11,6 +11,7 @@ module Language.Agda2hs.Haskell.Types
     , Line
     , LineNo
     , prependHaddockLines
+    , appendHaddockNamedChunks
     , HaskellIdentifier
     , fromAgdaIdentifier
     ) where
@@ -55,8 +56,8 @@ prependHaddockLines
     :: Map HaskellIdentifier [String]
     -> HaskellModule
     -> HaskellModule
-prependHaddockLines haddocks m =
-    m { comments =
+prependHaddockLines haddocks m = m
+    { comments =
         Map.unionWith (<>) (Map.map unlines haddocks) (comments m)
     }
 

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
@@ -12,6 +12,7 @@ module Language.Agda2hs.Haskell.Types
     , LineNo
     , prependHaddockLines
     , appendHaddockNamedChunks
+    , appendHaddockSection
     , HaskellIdentifier
     , fromAgdaIdentifier
     ) where
@@ -60,6 +61,28 @@ prependHaddockLines haddocks m = m
     { comments =
         Map.unionWith (<>) (Map.map unlines haddocks) (comments m)
     }
+
+-- | Append a Haddock section title.
+appendHaddockSection
+    :: String
+    -> HaskellModule
+    -> HaskellModule
+appendHaddockSection title m =
+    m { contents = contents m <> ["-- * " <> title]}
+
+-- | Append named chunks of Haddock documentation.
+appendHaddockNamedChunks
+    :: Map String [Line]
+    -> HaskellModule
+    -> HaskellModule
+appendHaddockNamedChunks chunks m = m
+    { contents =
+        contents m
+            <> mconcat (map renderNamedChunk $ Map.toList chunks)
+    }
+  where
+    renderNamedChunk (name, chunk) =
+        ["{- $" <> name] <> chunk <> ["-}"]
 
 -- | Pretty print a Haskell module
 prettyHaskellModule :: HaskellModule -> String

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/Encoding.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/Encoding.agda
@@ -150,7 +150,9 @@ compactAddrFromEnterpriseAddr addr =
 {-----------------------------------------------------------------------------
     Properties
 ------------------------------------------------------------------------------}
---
+-- |
+-- Two 'XPub' that yield the same credential are equal
+-- — assuming that inverting a cryptographic hash is difficult.
 prop-credentialFromXPub-injective
   : ∀ (x y : XPub)
   → credentialFromXPub x ≡ credentialFromXPub y
@@ -177,7 +179,9 @@ prop-bytesFromEnterpriseAddr-injective
       prop-singleton-<>-injective (toEnterpriseTag netx) _ hashx hashy eq
     eqNet = prop-toEnterpriseTag-injective _ _ (projl eqPair)
 
---
+-- |
+-- Two 'EnterpriseAddr' with the same serialized 'CompactAddr' are equal
+-- — assuming that inverting a cryptographic hash is difficult.
 @0 prop-compactAddrFromEnterpriseAddr-injective
   : ∀ (x y : EnterpriseAddr)
   → compactAddrFromEnterpriseAddr x ≡ compactAddrFromEnterpriseAddr y

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -544,7 +544,8 @@ createAddress c s0 = ( addr , s1 )
 
 {-# COMPILE AGDA2HS createAddress #-}
 
---
+-- | Creating a customer address is deterministic,
+-- and depends essentially on the 'XPub'.
 prop-create-derive
   : ∀ (c : Customer)
       (s0 : AddressState)
@@ -573,7 +574,8 @@ lemma-lookup-insert-same a c m =
     Just c
   ∎
 
---
+-- |
+-- Creating an address makes it known.
 @0 prop-create-known
   : ∀ (c  : Customer)
       (s0 : AddressState)
@@ -649,7 +651,9 @@ lemma-isChange-isChangeAddress
 lemma-isChange-isChangeAddress s addr (_c0 `witness` eq) =
   equality' _ _ eq
 
+-- | /Essential property./
 --
+-- Customer addresses are never change addresses.
 @0 prop-changeAddress-not-Customer
   : ∀ (s : AddressState)
       (addr : Address)

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/RollbackWindow.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/RollbackWindow.agda
@@ -174,7 +174,8 @@ module _ {time : Set} {{_ : Ord time}} where
 {-----------------------------------------------------------------------------
     Properties
 ------------------------------------------------------------------------------}
---
+-- |
+-- The 'tip' is always a 'member' of a 'RollbackWindow'.
 @0 prop-tip-member
   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
       (w : RollbackWindow time)
@@ -193,7 +194,8 @@ prop-tip-member w =
     True
   ∎
 
---
+-- |
+-- The 'finality' is always a 'member' of a 'RollbackWindow'.
 @0 prop-finality-member
   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
       (w : RollbackWindow time)
@@ -246,7 +248,9 @@ lemma-between-max-min t1 t2 t3 t4 t =
     shuffle True False True b4 = refl
     shuffle True True b3 b4 = refl
 
---
+-- |
+-- A time @t@ is a 'member' of an intersection
+-- if it is a member of both 'RollbackWindow's.
 @0 prop-member-intersect
   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
       (w1 w2 w3 : RollbackWindow time)

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -146,7 +146,8 @@ prop-null-empty du eq =
     lem2 : Map.null (received du) ≡ True
     lem2 = projr (prop-&&-⋀ eq)
 
---
+-- |
+-- Applying the empty delta does nothing.
 @0 prop-apply-empty
   : ∀ (utxo : UTxO)
   → apply empty utxo ≡ utxo
@@ -211,7 +212,7 @@ prop-apply-excludingD {txins} {u0} =
     du = fst (excludingD u0 txins)
     u1 = snd (excludingD u0 txins)
 
--- | The 'UTxO' returned by 'receiveD' is obtained by 'union'.
+-- | The 'UTxO' returned by 'receiveD' is the same as 'union'.
 --
 prop-union-receiveD
   : ∀ {ua : UTxO} {u0 : UTxO}
@@ -242,13 +243,16 @@ prop-apply-receiveD {ua} {u0} =
     du = fst (receiveD u0 ua)
     u1 = snd (receiveD u0 ua)
 
+-- | Defining property of 'append':
+-- Applying the combination of two deltas is the same as
+-- applying each delta in turn (right-to-left),
+-- assuming that the delta and the utxo have disjoint 'TxIn's.
 --
--- This is the most important property:
--- The semigroup operation `_<>_` is an application of `apply`.
 prop-apply-append
   : ∀ (x y : DeltaUTxO) (utxo : UTxO)
   → Set.intersection (dom (received y)) (dom utxo) ≡ Set.empty
   → apply (append x y) utxo ≡ apply x (apply y utxo)
+--
 prop-apply-append x y utxo cond =
     begin
       apply (append x y) utxo

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
@@ -74,6 +74,12 @@ _∪_ : UTxO → UTxO → UTxO
 _∪_ = union
 
 -- | Exclude a set of inputs.
+--
+-- Infix synonym: @x ⋪ utxo  =  excluding utxo x@.
+--
+-- Notable properties:
+-- [prop-excluding-intersection](#prop-excluding-intersection),
+-- [prop-excluding-sym](#prop-excluding-sym)
 excluding : UTxO → Set.ℙ TxIn → UTxO
 excluding = Map.withoutKeys
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
@@ -67,3 +67,35 @@ bytesFromEnterpriseAddr
 compactAddrFromEnterpriseAddr :: EnterpriseAddr -> CompactAddr
 compactAddrFromEnterpriseAddr addr =
     fromJust (fromShortByteString (bytesFromEnterpriseAddr addr))
+
+-- * Properties
+
+-- $prop-compactAddrFromEnterpriseAddr-injective
+-- #prop-compactAddrFromEnterpriseAddr-injective#
+--
+-- [prop-compactAddrFromEnterpriseAddr-injective]:
+--
+--     Two 'EnterpriseAddr' with the same serialized 'CompactAddr' are equal
+--     — assuming that inverting a cryptographic hash is difficult.
+--
+--     @
+--     @0 prop-compactAddrFromEnterpriseAddr-injective
+--       : ∀ (x y : EnterpriseAddr)
+--       → compactAddrFromEnterpriseAddr x ≡ compactAddrFromEnterpriseAddr y
+--       → x ≡ y
+--     @
+
+-- $prop-credentialFromXPub-injective
+-- #prop-credentialFromXPub-injective#
+--
+-- [prop-credentialFromXPub-injective]:
+--
+--     Two 'XPub' that yield the same credential are equal
+--     — assuming that inverting a cryptographic hash is difficult.
+--
+--     @
+--     prop-credentialFromXPub-injective
+--       : ∀ (x y : XPub)
+--       → credentialFromXPub x ≡ credentialFromXPub y
+--       → x ≡ y
+--     @

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -208,3 +208,51 @@ fromXPubAndCount net xpub knownCustomerCount =
 -- Change address generator employed by 'AddressState'.
 newChangeAddress :: AddressState -> ChangeAddressGen ()
 newChangeAddress s = \_ -> (change s, ())
+
+-- * Properties
+
+-- $prop-changeAddress-not-Customer
+-- #prop-changeAddress-not-Customer#
+--
+-- [prop-changeAddress-not-Customer]:
+--     /Essential property./
+--
+--     Customer addresses are never change addresses.
+--
+--     @
+--     @0 prop-changeAddress-not-Customer
+--       : ∀ (s : AddressState)
+--           (addr : Address)
+--       → knownCustomerAddress addr s ≡ True
+--       → ¬(isChange (newChangeAddress s) addr)
+--     @
+
+-- $prop-create-derive
+-- #prop-create-derive#
+--
+-- [prop-create-derive]:
+--     Creating a customer address is deterministic,
+--     and depends essentially on the 'XPub'.
+--
+--     @
+--     prop-create-derive
+--       : ∀ (c : Customer)
+--           (s0 : AddressState)
+--       → let (address , _) = createAddress c s0
+--         in  deriveCustomerAddress (getNetworkTag s0) (stateXPub s0) c ≡ address
+--     @
+
+-- $prop-create-known
+-- #prop-create-known#
+--
+-- [prop-create-known]:
+--
+--     Creating an address makes it known.
+--
+--     @
+--     @0 prop-create-known
+--       : ∀ (c  : Customer)
+--           (s0 : AddressState)
+--       → let (address , s1) = createAddress c s0
+--         in  knownCustomerAddress address s1 ≡ True
+--     @

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
@@ -94,3 +94,50 @@ intersect w1 w2 =
     fin3 = max (finality w1) (finality w2)
     tip3 :: time
     tip3 = min (tip w1) (tip w2)
+
+-- * Properties
+
+-- $prop-finality-member
+-- #prop-finality-member#
+--
+-- [prop-finality-member]:
+--
+--     The 'finality' is always a 'member' of a 'RollbackWindow'.
+--
+--     @
+--     @0 prop-finality-member
+--       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--           (w : RollbackWindow time)
+--       → member (finality w) w ≡ True
+--     @
+
+-- $prop-member-intersect
+-- #prop-member-intersect#
+--
+-- [prop-member-intersect]:
+--
+--     A time @t@ is a 'member' of an intersection
+--     if it is a member of both 'RollbackWindow's.
+--
+--     @
+--     @0 prop-member-intersect
+--       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--           (w1 w2 w3 : RollbackWindow time)
+--           (t : time)
+--       → intersect w1 w2 ≡ Just w3
+--       → member t w3 ≡ (member t w1 && member t w2)
+--     @
+
+-- $prop-tip-member
+-- #prop-tip-member#
+--
+-- [prop-tip-member]:
+--
+--     The 'tip' is always a 'member' of a 'RollbackWindow'.
+--
+--     @
+--     @0 prop-tip-member
+--       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--           (w : RollbackWindow time)
+--       → member (tip w) w ≡ True
+--     @

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -76,3 +76,88 @@ append x y =
 -- Combine a sequence of 'DeltaUTxO' using `append`
 concat :: [DeltaUTxO] -> DeltaUTxO
 concat = foldr append empty
+
+-- * Properties
+
+-- $prop-apply-append
+-- #prop-apply-append#
+--
+-- [prop-apply-append]:
+--     Defining property of 'append':
+--     Applying the combination of two deltas is the same as
+--     applying each delta in turn (right-to-left),
+--     assuming that the delta and the utxo have disjoint 'TxIn's.
+--
+--     @
+--     prop-apply-append
+--       : ∀ (x y : DeltaUTxO) (utxo : UTxO)
+--       → Set.intersection (dom (received y)) (dom utxo) ≡ Set.empty
+--       → apply (append x y) utxo ≡ apply x (apply y utxo)
+--     @
+
+-- $prop-apply-empty
+-- #prop-apply-empty#
+--
+-- [prop-apply-empty]:
+--
+--     Applying the empty delta does nothing.
+--
+--     @
+--     @0 prop-apply-empty
+--       : ∀ (utxo : UTxO)
+--       → apply empty utxo ≡ utxo
+--     @
+
+-- $prop-apply-excludingD
+-- #prop-apply-excludingD#
+--
+-- [prop-apply-excludingD]:
+--     Applying the 'DeltaUTxO' returned by 'excludingD'
+--     to the argument 'UTxO' yields the result 'UTxO'.
+--
+--     @
+--     @0 prop-apply-excludingD
+--       : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
+--       → let (du , u1) = excludingD u0 txins
+--         in  apply du u0 ≡ u1
+--     @
+
+-- $prop-apply-receiveD
+-- #prop-apply-receiveD#
+--
+-- [prop-apply-receiveD]:
+--     Applying the 'DeltaUTxO' returned by 'receiveD'
+--     to the argument 'UTxO' yields the result 'UTxO'.
+--
+--     @
+--     @0 prop-apply-receiveD
+--       : ∀ {ua : UTxO} {u0 : UTxO}
+--       → let (du , u1) = receiveD u0 ua
+--         in  apply du u0 ≡ u1
+--     @
+
+-- $prop-excluding-excludingD
+-- #prop-excluding-excludingD#
+--
+-- [prop-excluding-excludingD]:
+--     The 'UTxO' returned by 'excludingD' is the same as 'excluding'.
+--
+--     @
+--     prop-excluding-excludingD
+--       : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
+--       → let (du , u1) = excludingD u0 txins
+--         in  u1 ≡ UTxO.excluding u0 txins
+--     @
+
+-- $prop-union-receiveD
+-- #prop-union-receiveD#
+--
+-- [prop-union-receiveD]:
+--     The 'UTxO' returned by 'receiveD' is the same as 'union'.
+--
+--     @
+--     prop-union-receiveD
+--       : ∀ {ua : UTxO} {u0 : UTxO}
+--       → let (du , u1) = receiveD u0 ua
+--         in  u1 ≡ UTxO.union ua u0
+--     @

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -52,6 +52,12 @@ union = Map.unionWith (\x y -> x)
 
 -- |
 -- Exclude a set of inputs.
+--
+-- Infix synonym: @x ⋪ utxo  =  excluding utxo x@.
+--
+-- Notable properties:
+-- [prop-excluding-intersection](#prop-excluding-intersection),
+-- [prop-excluding-sym](#prop-excluding-sym)
 excluding :: UTxO -> Set TxIn -> UTxO
 excluding = Map.withoutKeys
 
@@ -70,3 +76,99 @@ excludingS s utxo =
 -- Keep those outputs whose address satisfies the predicate.
 filterByAddress :: (Address -> Bool) -> UTxO -> UTxO
 filterByAddress p = Map.filter (p . getCompactAddr)
+
+-- * Properties
+
+-- $prop-excluding-empty
+-- #prop-excluding-empty#
+--
+-- [prop-excluding-empty]:
+--
+--     Excluding the empty set does nothing.
+--
+--     @
+--     @0 prop-excluding-empty
+--       : ∀ (utxo : UTxO)
+--       → excluding utxo Set.empty ≡ utxo
+--     @
+
+-- $prop-excluding-intersection
+-- #prop-excluding-intersection#
+--
+-- [prop-excluding-intersection]:
+--
+--     Excluding the intersection is the same as the union of the exclusions.
+--
+--     @
+--     @0 prop-excluding-intersection
+--       : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
+--       → (Set.intersection x y) ⋪ utxo ≡ (x ⋪ utxo) ∪ (y ⋪ utxo)
+--     @
+
+-- $prop-excluding-sym
+-- #prop-excluding-sym#
+--
+-- [prop-excluding-sym]:
+--
+--     Excluding two sets of 'TxIn's can be done in either order.
+--
+--     @
+--     prop-excluding-sym
+--       : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
+--       → x ⋪ (y ⋪ utxo) ≡ y ⋪ (x ⋪ utxo)
+--     @
+
+-- $prop-filterByAddress-filters
+-- #prop-filterByAddress-filters#
+--
+-- [prop-filterByAddress-filters]:
+--
+--     Those outputs whose address satisfies the predicate are kept.
+--
+--     @
+--     prop-filterByAddress-filters
+--         : ∀ (p : Address → Bool)
+--             (utxo : UTxO) (txin : TxIn) (txout : TxOut)
+--         → Map.lookup txin utxo ≡ Just txout
+--         → Map.member txin (filterByAddress p utxo)
+--             ≡ p (getCompactAddr txout)
+--     @
+
+-- $prop-union-assoc
+-- #prop-union-assoc#
+--
+-- [prop-union-assoc]:
+--
+--     'union' is associative.
+--
+--     @
+--     prop-union-assoc
+--       : ∀ {ua ub uc : UTxO}
+--       → (ua ∪ ub) ∪ uc ≡ ua ∪ (ub ∪ uc)
+--     @
+
+-- $prop-union-empty-left
+-- #prop-union-empty-left#
+--
+-- [prop-union-empty-left]:
+--
+--     'empty' is a left identity of 'union'.
+--
+--     @
+--     prop-union-empty-left
+--       : ∀ {utxo : UTxO}
+--       → union empty utxo ≡ utxo
+--     @
+
+-- $prop-union-empty-right
+-- #prop-union-empty-right#
+--
+-- [prop-union-empty-right]:
+--
+--     'empty' is a right identity of 'union'.
+--
+--     @
+--     prop-union-empty-right
+--       : ∀ {utxo : UTxO}
+--       → union utxo empty ≡ utxo
+--     @

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
@@ -21,3 +21,18 @@ union = unionWith (\x y -> x)
 intersectionWith :: (a -> b -> c) -> Maybe a -> Maybe b -> Maybe c
 intersectionWith f (Just x) (Just y) = Just (f x y)
 intersectionWith _ _ _ = Nothing
+
+-- * Properties
+
+-- $prop-unionWith-sym
+-- #prop-unionWith-sym#
+--
+-- [prop-unionWith-sym]:
+--     'unionWith' is symmetric if we 'flip' the function.
+--     Note that 'union' is left-biased, not symmetric.
+--
+--     @
+--     prop-unionWith-sym
+--       : ∀ {f : a → a → a} {ma mb : Maybe a}
+--       → unionWith f ma mb ≡ unionWith (flip f) mb ma
+--     @


### PR DESCRIPTION
This pull request adds support for documenting properties in the generated Haddock documentation.

Specifically, properties that have been proven about the Haskell-in-Agda code are now added to the Haddock documentation if they have a Haddock-style comment.

### Example

Function `excluding`:

<img width="538" alt="excluding" src="https://github.com/user-attachments/assets/c897cf25-03de-4efd-aade-4a1e322af235">

Source code of a property with Haddock-style comment:

```agda
-- |
-- Excluding two sets of 'TxIn's can be done in either order.
--
prop-excluding-sym
  : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
  → x ⋪ (y ⋪ utxo) ≡ y ⋪ (x ⋪ utxo)
--
prop-excluding-sym {x} {y} {utxo} = [… proof here …]
```

Rendering:

<img width="552" alt="prop-excluding-sym" src="https://github.com/user-attachments/assets/5133cebf-33a7-4c3b-9058-c94112bf7f1f">


### Comments

* The parsers are very rudimentary — the type signature of a property is currently recognized by the fact that it ends with a single-line comment `--`. I like this style because it helps visually with the Agda code as well, but it's not a robust parser.