### PR TITLE
Expose `PairMap` and `InverseMap`

### DIFF
--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -82,6 +82,8 @@ library
     Cardano.Wallet.Deposit.Pure.TxSummary
     Cardano.Wallet.Deposit.Read.Temp
     Cardano.Write.Tx.Balance
+    Data.Maps.InverseMap
+    Data.Maps.PairMap
     Data.Maps.Timeline
   other-modules:
     Haskell.Data.ByteString

--- a/lib/customer-deposit-wallet-pure/haskell/Data/Maps/InverseMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Data/Maps/InverseMap.hs
@@ -1,0 +1,5 @@
+module Data.Maps.InverseMap
+    ( module Haskell.Data.Maps.InverseMap
+    ) where
+
+import Haskell.Data.Maps.InverseMap

--- a/lib/customer-deposit-wallet-pure/haskell/Data/Maps/PairMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Data/Maps/PairMap.hs
@@ -1,0 +1,5 @@
+module Data.Maps.PairMap
+    ( module Haskell.Data.Maps.PairMap
+    ) where
+
+import Haskell.Data.Maps.PairMap


### PR DESCRIPTION
This pull request exposes the `PairMap` and `InverseMap` types in order to allow downstream code to implement new queries on `TxHistory`. We may want to move these queries back into the codebase here, but that's for another time.