### PR TITLE
Support export lists in the Haddock documentation

### DIFF
--- a/lib/agda2hs-fixer/agda2hs-fixer.cabal
+++ b/lib/agda2hs-fixer/agda2hs-fixer.cabal
@@ -58,6 +58,9 @@ executable agda2hs-fixer
   main-is:          agda2hs-fixer.hs
   other-modules:
     Language.Agda2hs.Agda.Parser
+    Language.Agda2hs.Agda.Parser.ExportList
+    Language.Agda2hs.Agda.Parser.Lexer
+    Language.Agda2hs.Agda.Parser.Types
     Language.Agda2hs.Agda.Types
     Language.Agda2hs.Documentation
     Language.Agda2hs.Haskell.Parser

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser.hs
@@ -14,8 +14,8 @@ import Prelude
 import Data.List
     ( isPrefixOf
     )
-import Data.Void
-    ( Void
+import Language.Agda2hs.Agda.Parser.Types
+    ( Parser
     )
 import Language.Agda2hs.Agda.Types
     ( AgdaIdentifier
@@ -26,7 +26,6 @@ import Language.Agda2hs.Agda.Types
     )
 import Text.Megaparsec
     ( MonadParsec (notFollowedBy, takeWhileP, try)
-    , Parsec
     , (<|>)
     , anySingle
     , empty
@@ -41,8 +40,6 @@ import Text.Megaparsec
 import qualified Data.Map.Strict as Map
 import qualified Text.Megaparsec.Char as C
 import qualified Text.Megaparsec.Char.Lexer as L
-
-type Parser = Parsec Void String
 
 {-----------------------------------------------------------------------------
     Parser functions

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser/ExportList.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser/ExportList.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-|
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Simple approximate parser for ad-hoc export lists.
+-}
+module Language.Agda2hs.Agda.Parser.ExportList
+    ( ExportList
+    , parseFileExportList
+    ) where
+
+import Prelude
+
+import Language.Agda2hs.Agda.Parser.Lexer
+    ( space
+    , symbol
+    )
+import Language.Agda2hs.Agda.Parser.Types
+    ( Parser
+    )
+import Language.Agda2hs.Agda.Types
+    ( AgdaIdentifier
+    , ExportItem (..)
+    , ExportList
+    , HeaderLevel (..)
+    )
+import Text.Megaparsec
+    ( MonadParsec (takeWhileP)
+    , (<|>)
+    , empty
+    , many
+    , parse
+    , satisfy
+    , takeRest
+    , sepBy
+    , option
+    , optional
+    )
+
+import qualified Text.Megaparsec.Char as C
+import qualified Text.Megaparsec.Char.Lexer as L
+
+{-----------------------------------------------------------------------------
+    Parser functions
+------------------------------------------------------------------------------}
+
+parseFileExportList
+    :: FilePath
+        -- ^ Name of the file.
+    -> String 
+        -- ^ Contents of the file.
+    -> Maybe (Maybe ExportList)
+parseFileExportList filename file =
+    case parse moduleFull filename file of
+        Left _ -> Nothing
+        Right x -> Just x
+
+{-----------------------------------------------------------------------------
+    Parser
+------------------------------------------------------------------------------}
+moduleFull :: Parser (Maybe ExportList)
+moduleFull = space *> module'
+
+module' :: Parser (Maybe ExportList)
+module' = do
+    _ <- symbol "module"
+    _ <- moduleName
+    es <- optional exportList
+    _ <- symbol "where"
+    _ <- takeRest
+    pure es
+
+exportList :: Parser ExportList
+exportList = do
+    _ <- symbolNoComments "{-|"
+    s0 <- sectionHeaders
+    ess <- optional semicolon *> (exportItems `sepBy` semicolon)
+    _ <- symbolNoComments "-}"
+    pure $ s0 <> concat ess
+  where
+    semicolon = symbolNoComments ";"
+
+exportItems :: Parser [ExportItem]
+exportItems = do
+    before <- sectionHeaders
+    identifier <- exportIdentifier
+    after <- sectionHeaders
+    pure $ before <> [identifier] <> after
+
+exportIdentifier :: Parser ExportItem
+exportIdentifier =
+    ExportIdentifier <$> agdaNamePart <*> constructors
+  where
+    constructors = option False (True <$ symbolNoComments "(..)")
+
+sectionHeaders :: Parser [ExportItem]
+sectionHeaders =
+    many (SectionHeader <$> headerLevel <*> line <* spaceNoComments)
+
+headerLevel :: Parser HeaderLevel
+headerLevel =
+    (H3 <$ symbol' "-- ***")
+    <|> (H2 <$ symbol' "-- **")
+    <|> (H1 <$ symbol' "-- *")
+  where
+    symbol' = L.lexeme C.hspace1
+
+{-----------------------------------------------------------------------------
+    Lexer
+------------------------------------------------------------------------------}
+type ModuleName = String
+
+moduleName :: Parser ModuleName
+moduleName =
+    L.lexeme space
+        $ (:)
+            <$> C.upperChar
+            <*> many (C.alphaNumChar <|> satisfy (`elem` ['.']))
+
+agdaNamePart :: Parser AgdaIdentifier
+agdaNamePart =
+    L.lexeme spaceNoComments
+        $ (:)
+            <$> satisfy (notForbidden ("'" <> forbiddenChars))
+            <*> takeWhileP Nothing (notForbidden forbiddenChars)
+  where
+    notForbidden xs = not . (`elem` xs)
+
+    forbiddenChars :: [Char]
+    forbiddenChars = ".;{}()@ \n"
+
+-- | Parse the rest of a line, without the newline character.
+line :: Parser String
+line = takeWhileP (Just "character") (/= '\n')
+
+spaceNoComments :: Parser ()
+spaceNoComments = L.space C.space1 empty empty
+
+symbolNoComments :: String -> Parser String
+symbolNoComments = L.symbol spaceNoComments

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser/Lexer.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser/Lexer.hs
@@ -1,0 +1,57 @@
+{-|
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Simple approximate lexer for Agda.
+-}
+module Language.Agda2hs.Agda.Parser.Lexer where
+
+import Prelude
+
+import Control.Monad
+    ( void
+    )
+import Language.Agda2hs.Agda.Parser.Types
+    ( Parser
+    )
+import Text.Megaparsec
+    ( MonadParsec (notFollowedBy, takeWhileP, try)
+    , anySingle
+    , between
+    , manyTill
+    , satisfy
+    )
+
+import qualified Text.Megaparsec.Char as C
+import qualified Text.Megaparsec.Char.Lexer as L
+
+{-----------------------------------------------------------------------------
+    Lexer
+------------------------------------------------------------------------------}
+-- | Parse the rest of a line, without the newline character.
+line :: Parser String
+line = takeWhileP (Just "character") (/= '\n')
+
+lineComment :: Parser ()
+lineComment =
+    try start <* line
+  where
+    start = C.string "--" *> notFollowedBy (satisfy (`elem` ("^|" :: String)))
+
+blockComment :: Parser ()
+blockComment =
+    void (try start *> manyTill anySingle (C.string "-}"))
+  where
+    start = C.string "{-" *> notFollowedBy (C.char '|')
+
+space :: Parser ()
+space = L.space C.space1 lineComment blockComment
+
+symbol :: String -> Parser String
+symbol = L.symbol space
+
+parens :: Parser a -> Parser a
+parens = between (symbol "(") (symbol ")")
+
+braces :: Parser a -> Parser a
+braces = between (symbol "{") (symbol "}")

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser/Types.hs
@@ -1,0 +1,15 @@
+{-|
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Parser type.
+-}
+module Language.Agda2hs.Agda.Parser.Types
+    ( Parser
+    ) where
+
+import Data.String (String)
+import Data.Void (Void)
+import Text.Megaparsec (Parsec)
+
+type Parser = Parsec Void String

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
@@ -5,12 +5,22 @@ License: Apache-2.0
 Types for representing Agda modules.
 -}
 module Language.Agda2hs.Agda.Types
-    ( AgdaIdentifier
+    ( -- * Identifiers
+      AgdaIdentifier
+    , TypeSignature
+
+    -- * Documentation
     , AgdaDocumentation
+    , filterProperties
     , DocString
     , DocItem (..)
-    , TypeSignature
-    , filterProperties
+
+    -- * Export lists
+    , ExportList
+    , ExportItem (..)
+    , ExportConstructors
+    , HeaderLevel (..)
+    , collectIdentifiers
     ) where
 
 import Prelude
@@ -21,13 +31,16 @@ import Data.List
 import Data.Map
     ( Map
     )
+import Data.Set
+    ( Set
+    )
 
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 {-----------------------------------------------------------------------------
     Types
 ------------------------------------------------------------------------------}
-
 type AgdaIdentifier = String
 
 type AgdaDocumentation = Map AgdaIdentifier DocItem
@@ -45,13 +58,28 @@ data DocItem = DocItem
     -- ^ Type signature of the thing to be documented (multiline).
     }
 
+type ExportConstructors = Bool
+
+data HeaderLevel = H1 | H2 | H3
+    deriving (Eq, Ord, Show)
+
+data ExportItem
+    = ExportIdentifier AgdaIdentifier ExportConstructors
+    | SectionHeader HeaderLevel String
+    deriving (Eq, Ord, Show)
+
+type ExportList = [ExportItem]
+
 {-----------------------------------------------------------------------------
     Operations
 ------------------------------------------------------------------------------}
 -- | Keep those documentation items that are logical properties.
 filterProperties :: AgdaDocumentation -> AgdaDocumentation
-filterProperties = Map.filterWithKey isProperty
+filterProperties = Map.filterWithKey (const . isProperty)
 
 -- My naming convention for logical properties.
-isProperty :: AgdaIdentifier -> DocItem -> Bool
-isProperty name _ = "prop-" `isPrefixOf` name
+isProperty :: AgdaIdentifier -> Bool
+isProperty name = "prop-" `isPrefixOf` name
+
+collectIdentifiers :: ExportList -> Set AgdaIdentifier
+collectIdentifiers xs = Set.fromList [name | ExportIdentifier name _ <- xs ]

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
@@ -8,6 +8,7 @@ module Language.Agda2hs.Agda.Types
     ( -- * Identifiers
       AgdaIdentifier
     , TypeSignature
+    , isProperty
 
     -- * Documentation
     , AgdaDocumentation
@@ -77,7 +78,7 @@ type ExportList = [ExportItem]
 filterProperties :: AgdaDocumentation -> AgdaDocumentation
 filterProperties = Map.filterWithKey (const . isProperty)
 
--- My naming convention for logical properties.
+-- | My naming convention for logical properties.
 isProperty :: AgdaIdentifier -> Bool
 isProperty name = "prop-" `isPrefixOf` name
 

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Parser.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Parser.hs
@@ -45,6 +45,7 @@ parseFileHaskellModule filename file =
         HaskellModule
         { contents = lines file
         , topLevelDeclarations = collectTopLevelDeclarations parsedModule
+        , exportList = Nothing
         , comments = Map.empty
         }
 

--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Haskell/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-|
 Copyright: © 2024 Cardano Foundation
@@ -8,32 +9,46 @@ Types for representing Haskell modules.
 module Language.Agda2hs.Haskell.Types
     ( HaskellModule (..)
     , prettyHaskellModule
+
     , Line
     , LineNo
     , prependHaddockLines
     , appendHaddockNamedChunks
     , appendHaddockSection
+
     , HaskellIdentifier
     , fromAgdaIdentifier
+    , completeExportsWithInternals
     ) where
 
 import Prelude
 
 import Data.List
     ( foldl'
+    , isPrefixOf
+    , isSuffixOf
     )
 import Data.Map
     ( Map
     )
+import Data.Maybe
+    ( fromMaybe
+    )
 import Language.Agda2hs.Agda.Types
     ( AgdaIdentifier
+    , ExportList
+    , ExportItem (..)
+    , HeaderLevel (..)
+    , collectIdentifiers
+    , isProperty
     )
 
 import qualified Data.Char as Char
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 {-----------------------------------------------------------------------------
-    Haskell
+    Types
 ------------------------------------------------------------------------------}
 type HaskellIdentifier = String
 
@@ -45,13 +60,19 @@ type Line = String
 -- | Source-level representation of a Haskell module.
 data HaskellModule = HaskellModule
     { contents :: [Line]
-        -- ^ Vanilla source code of the module
+        -- ^ Original source code of the module.
     , topLevelDeclarations :: Map HaskellIdentifier LineNo
         -- ^ Location of each top-level declaration.
+    , exportList :: Maybe ExportList
+        -- ^ Export list to be added to the module.
     , comments :: Map HaskellIdentifier String
+        -- ^ Comments to be added before each identifier.
     }
     deriving (Eq, Show)
 
+{-----------------------------------------------------------------------------
+    Haddock documentation
+------------------------------------------------------------------------------}
 -- | Prepend multiline Haddock comments before every given identifier.
 prependHaddockLines
     :: Map HaskellIdentifier [String]
@@ -84,11 +105,40 @@ appendHaddockNamedChunks chunks m = m
     renderNamedChunk (name, chunk) =
         ["{- $" <> name] <> chunk <> ["-}"]
 
+{-----------------------------------------------------------------------------
+    Export lists
+------------------------------------------------------------------------------}
+-- | Fill an export list with all internal definitions.
+--
+-- FIXME: Currently does not export constructors and fields for
+-- data types correctly.
+completeExportsWithInternals :: HaskellModule -> HaskellModule
+completeExportsWithInternals m
+    | not (Set.null internals) = m
+        { exportList = Just $
+            exports
+            <> [SectionHeader H1 "Internal"]
+            <> Set.toList
+                (Set.map (\name -> ExportIdentifier name False) internals)
+        }
+    | otherwise = m
+  where
+    exports = fromMaybe [] (exportList m)
+    internals =
+        Set.difference
+            (Map.keysSet (topLevelDeclarations m))
+            (collectIdentifiers exports)
+
+{-----------------------------------------------------------------------------
+    Pretty printing and rendering
+------------------------------------------------------------------------------}
+
 -- | Pretty print a Haskell module
 prettyHaskellModule :: HaskellModule -> String
 prettyHaskellModule m =
-    unlines $
-        prependLines
+    unlines
+    $ replaceExportList (exportList m)
+    $ prependLines
             (contents m)
             (joinMaps
                 (topLevelDeclarations m)
@@ -114,6 +164,59 @@ prependLines original0 inserted = both
   where
     original = Map.fromList $ zip [0..] original0
     both = Map.elems $ Map.unionWith (\x y -> x <> y) inserted original
+
+-- | Replace the export list of a Haskell module given in source form.
+--
+-- Assumes that the module name is on a single line of the form
+--   @module Module.Name where@
+replaceExportList
+    :: Maybe ExportList -> [Line] -> [Line]
+replaceExportList Nothing fileLines = fileLines
+replaceExportList (Just exports) fileLines =
+    foldMap replaceModuleDeclaration m
+  where
+    m = Map.fromList $ zip [0 :: Int ..] fileLines
+
+    replaceModuleDeclaration line
+        | "module" `isPrefixOf` line && "where" `isSuffixOf` line =
+            [dropWhere line]
+            <> indent 4 (renderExportList exports <> ["where"])
+        | otherwise = [line]
+
+    dropWhere = reverse . drop (length ("where" :: String)) . reverse
+
+-- | Render an export list as individual lines
+renderExportList :: ExportList -> [Line]
+renderExportList xs =
+    ["("] <> dropLastComma (concat $ map renderExportItem xs) <> [")"]
+  where
+    renderExportItem :: ExportItem -> [Line]
+    renderExportItem (ExportIdentifier agdaName doConstructors)
+        | Just hsName <- fromAgdaIdentifier agdaName =
+            [hsName <> (if doConstructors then " (..)" else "") <> ","]
+        | isProperty agdaName =
+            ["-- $" <> agdaName, ""]
+    renderExportItem (SectionHeader headerLevel text) =
+        [renderHeaderLevel headerLevel <> " " <> text]
+    renderExportItem _ = []
+
+dropLastComma :: [Line] -> [Line]
+dropLastComma = reverse . onHead dropComma . reverse
+  where
+    dropComma [] = []
+    dropComma (',':xs) = xs
+    dropComma (x:xs) = x:xs
+
+    onHead _ [] = []
+    onHead f (x:xs) = f x : xs
+
+renderHeaderLevel :: HeaderLevel -> String
+renderHeaderLevel H1 = "-- *"
+renderHeaderLevel H2 = "-- **"
+renderHeaderLevel H3 = "-- ***"
+
+indent :: Int -> [Line] -> [Line]
+indent n = map (replicate n ' ' <>)
 
 {-----------------------------------------------------------------------------
     Agda to Haskell

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
@@ -1,6 +1,25 @@
 {-# OPTIONS --erasure #-}
 
-module Cardano.Wallet.Address.BIP32_Ed25519 where
+module Cardano.Wallet.Address.BIP32_Ed25519
+  {-|
+  -- * Types
+  ; XPub
+  ; XPrv
+  ; XSignature
+    ; toXPub
+    ; sign
+    ; verify
+
+  -- * Serialization
+  ; rawSerialiseXPub
+  ; rawSerialiseXPrv
+  ; rawSerialiseXSignature
+
+  -- * Key derivation
+  ; deriveXPubSoft
+  ; deriveXPrvSoft
+  ; deriveXPrvHard
+  -} where
 
 open import Haskell.Prelude hiding (fromJust)
 open import Haskell.Reasoning
@@ -55,6 +74,8 @@ postulate
       in  verify xpub msg (sign xprv msg) ≡ True
 
 {-# FOREIGN AGDA2HS
+  -- * Types
+
   -- FIXME: We define type synonyms here so that
   -- they can be exported. Ideally, we would re-export from
   -- the Cardano.Wallet.Crypto module.
@@ -104,6 +125,8 @@ postulate
     → x ≡ y
 
 {-# FOREIGN AGDA2HS
+  -- * Serialization
+
   -- | Serialize an 'XPub' to a sequence of bytes.
   rawSerialiseXPub :: XPub → ByteString
   rawSerialiseXPub = CC.unXPub
@@ -160,6 +183,8 @@ postulate
     → ix1 ≡ ix2
 
 {-# FOREIGN AGDA2HS
+  -- * Key derivation
+
   -- | Embed a smaller Word into a larger Word.
   word32fromWord31 :: Word31 → Word32
   word32fromWord31 = fromInteger . toInteger

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -2,21 +2,30 @@
 
 -- Address management for the Customer Deposit Wallet
 module Cardano.Wallet.Deposit.Pure.Address
-    {-
-    ; deriveAddress
+    {-|
+    -- * Deriving addresses
     ; Customer
       ; deriveCustomerAddress
+
+    -- * AddressState
+    -- ** Construction
     ; AddressState
+      ; getNetworkTag
+      ; getXPub
+      ; emptyFromXPub
+      ; fromXPubAndCount
+
+    -- ** Address observation
+      ; isCustomerAddress
       ; isOurs
+      ; getBIP32Path
       ; listCustomers
       ; knownCustomerAddress
 
+    -- ** Address creation
       ; createAddress
       ; prop-create-derive
       ; prop-create-known
-
-      ; fromXPubAndCount
-      ; getXPub
 
       ; newChangeAddress
       ; prop-changeAddress-not-Customer

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/Tx.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/Tx.agda
@@ -1,7 +1,20 @@
 {-# OPTIONS --erasure #-}
 
 -- | Applying transactions to a UTxO set.
-module Cardano.Wallet.Deposit.Pure.UTxO.Tx where
+module Cardano.Wallet.Deposit.Pure.UTxO.Tx
+  {-|
+  -- * Applying Transactions to UTxO
+  ; IsOurs
+  ; applyTx
+
+  -- * Resolved Transactions
+  ; ResolvedTx (..)
+  ; resolveInputs
+  
+  -- * Value transfer from transactions
+  ; valueTransferFromDeltaUTxO
+  ; valueTransferFromResolvedTx
+  -} where
 
 open import Haskell.Prelude
 
@@ -63,7 +76,7 @@ utxoFromTxOutputs = utxoFromEraTx
 {-----------------------------------------------------------------------------
     Apply Transactions
 ------------------------------------------------------------------------------}
--- | Tyep for a predicate that tests whether @addr@ belongs to us.
+-- | Type for a predicate that tests whether @addr@ belongs to us.
 IsOurs : Set → Set
 IsOurs addr = addr -> Bool
 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
@@ -1,22 +1,38 @@
 {-# OPTIONS --erasure #-}
 
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxO
-    {-
+    {-|
     ; UTxO
       ; null
       ; empty
       ; dom
       ; balance
       ; union
+        ; prop-union-empty-left
+        ; prop-union-empty-right
+        ; prop-union-assoc
       ; excluding
+        ; prop-excluding-empty
+        ; prop-excluding-dom
+        ; prop-excluding-absorb
+        ; prop-excluding-excluding
+        ; prop-excluding-difference
+        ; prop-excluding-intersection
+        ; prop-excluding-union
       ; restrictedBy
       ; excludingS
+        ; prop-excluding-excludingS
       ; filterByAddress
+        ; prop-filterByAddress-filters
     -}
     where
 
 open import Haskell.Reasoning
 open import Haskell.Prelude hiding (null; f)
+
+{-# FOREIGN ADGA2HS
+import Prelude hiding (null)
+#-}
 
 open import Cardano.Wallet.Deposit.Read.Temp using
     ( Address
@@ -148,6 +164,16 @@ prop-excluding-empty utxo =
   Map.prop-withoutKeys-empty utxo
 
 -- |
+-- Excluding the entire domain gives the empty 'UTxO'.
+--
+prop-excluding-dom
+  : ∀ {utxo : UTxO}
+  → dom utxo ⋪ utxo ≡ empty
+--
+prop-excluding-dom {utxo} =
+  Map.prop-withoutKeys-keysSet utxo
+
+-- |
 -- 'union' is associative.
 --
 prop-union-assoc
@@ -225,16 +251,6 @@ prop-excluding-difference
 --
 prop-excluding-difference {x} {y} {utxo} =
   Map.prop-withoutKeys-difference utxo x y
-
--- |
--- Excluding the entire domain gives the empty 'UTxO'.
---
-prop-excluding-dom
-  : ∀ {utxo : UTxO}
-  → dom utxo ⋪ utxo ≡ empty
---
-prop-excluding-dom {utxo} =
-  Map.prop-withoutKeys-keysSet utxo
 
 -- |
 -- Restricting to the entire domain does nothing.

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
@@ -2,28 +2,23 @@
 -- 'UTxOHistory' represents a history of a UTxO set that can be rolled
 -- back (up to the 'finality' point).
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core
-    {-
-      -- * Types
-      UTxOHistory
-    , Spent (..)
+    {-|
+      -- * UTxOHistory
+    ; UTxOHistory
 
-      -- * Observations
-    , getTip
-    , getFinality
-    , empty
-    , getUTxO
+    ; empty
+    ; getUTxO
+    ; getRollbackWindow
 
       -- * Changes
-    , DeltaUTxOHistory (..)
+    ; DeltaUTxOHistory (..)
+    ; applyDeltaUTxOHistory
+    ; appendBlock
+    ; rollback
+    ; prune
 
-      -- * For testing
-    , getSpent
-
-      -- * Store helpers
-    , constrainingPrune
-    , constrainingRollback
-    , constrainingAppendBlock
-    , reverseMapOfSets
+      -- * Internal
+    ; getSpent
     -}
     where
 
@@ -75,13 +70,6 @@ import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
 
 variable
   key v : Set
-
--- | (Internal, exported for technical reasons.)
-guard : Bool → Maybe ⊤
-guard True = Just tt
-guard False = Nothing
-
-{-# COMPILE AGDA2HS guard #-}
 
 {-----------------------------------------------------------------------------
     Basic functions
@@ -247,3 +235,5 @@ applyDeltaUTxOHistory (Rollback newTip) =
     rollback newTip
 applyDeltaUTxOHistory (Prune newFinality) =
     prune newFinality
+
+{-# COMPILE AGDA2HS applyDeltaUTxOHistory #-}

--- a/lib/customer-deposit-wallet-pure/agda2hs-rewrites.yaml
+++ b/lib/customer-deposit-wallet-pure/agda2hs-rewrites.yaml
@@ -1,5 +1,8 @@
 prelude:
   implicit: true
+  hiding:
+    - "null"
+    - "subtract"
 
 rewrites:
   - from: "Haskell.Data.Set.ℙ"

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32.hs
@@ -3,6 +3,7 @@
 module Cardano.Wallet.Address.BIP32 where
 
 import Data.Word.Odd (Word31)
+import Prelude hiding (null, subtract)
 
 -- |
 -- Method for deriving child keys.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
@@ -2,6 +2,8 @@
 
 module Cardano.Wallet.Address.BIP32_Ed25519 where
 
+import Prelude hiding (null, subtract)
+
 import qualified Cardano.Crypto.Wallet as CC
 import Data.ByteString
     ( ByteString

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
@@ -17,6 +17,8 @@ import Data.Word.Odd
     ( Word31
     )
 
+-- * Types
+
 -- FIXME: We define type synonyms here so that
 -- they can be exported. Ideally, we would re-export from
 -- the Cardano.Wallet.Crypto module.
@@ -54,6 +56,8 @@ sign = CC.sign BS.empty
 verify :: XPub -> ByteString -> XSignature -> Bool
 verify = CC.verify
 
+-- * Serialization
+
 -- | Serialize an 'XPub' to a sequence of bytes.
 rawSerialiseXPub :: XPub -> ByteString
 rawSerialiseXPub = CC.unXPub
@@ -65,6 +69,8 @@ rawSerialiseXPrv = CC.unXPrv
 -- | Serialize an 'XSignature' to a sequence of bytes.
 rawSerialiseXSignature :: XSignature -> ByteString
 rawSerialiseXSignature = CC.unXSignature
+
+-- * Key derivation
 
 -- | Embed a smaller Word into a larger Word.
 word32fromWord31 :: Word31 -> Word32

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
@@ -26,6 +26,7 @@ import Cardano.Wallet.Read.Chain (NetworkId (Mainnet, Testnet))
 import Data.Word (Word8)
 import Haskell.Data.ByteString.Short (ShortByteString, singleton, toShort)
 import Haskell.Data.Maybe (fromJust)
+import Prelude hiding (null, subtract)
 
 -- |
 -- Hash of a public key.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Hash.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Hash.hs
@@ -2,6 +2,8 @@
 
 module Cardano.Wallet.Address.Hash where
 
+import Prelude hiding (null, subtract)
+
 import Cardano.Crypto.Hash
     ( Blake2b_224
     , Blake2b_256

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -47,6 +47,7 @@ import Cardano.Write.Tx.Balance (ChangeAddressGen)
 import Data.Word.Odd (Word31)
 import qualified Haskell.Data.Map as Map (Map, empty, insert, lookup, toAscList)
 import Haskell.Data.Maybe (isJust)
+import Prelude hiding (null, subtract)
 
 -- |
 -- A 'Customer' is represented as a numerical ID.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -1,4 +1,32 @@
-module Cardano.Wallet.Deposit.Pure.Address where
+module Cardano.Wallet.Deposit.Pure.Address
+    ( -- * Deriving addresses
+      Customer
+    , deriveCustomerAddress
+
+      -- * AddressState
+
+      -- ** Construction
+    , AddressState
+    , getNetworkTag
+    , getXPub
+    , emptyFromXPub
+    , fromXPubAndCount
+
+      -- ** Address observation
+    , isCustomerAddress
+    , isOurs
+    , getBIP32Path
+    , listCustomers
+    , knownCustomerAddress
+
+      -- ** Address creation
+    , createAddress
+      -- $prop-create-derive
+      -- $prop-create-known
+    , newChangeAddress
+      -- $prop-changeAddress-not-Customer
+    )
+where
 
 import Cardano.Wallet.Address.BIP32
     ( BIP32Path (Root, Segment)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Experimental.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Experimental.hs
@@ -27,6 +27,7 @@ import Cardano.Write.Tx.Balance
     , balanceTransaction
     )
 import qualified Haskell.Data.Map as Map (Map, lookup)
+import Prelude hiding (null, subtract)
 
 -- Working around a limitation in agda2hs.
 import Cardano.Wallet.Deposit.Pure.Address

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
@@ -2,6 +2,8 @@
 
 module Cardano.Wallet.Deposit.Pure.RollbackWindow where
 
+import Prelude hiding (null, subtract)
+
 -- |
 -- (Internal function, exported for technical reasons.)
 if' :: Bool -> a -> a -> a

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Core.hs
@@ -52,6 +52,7 @@ import qualified Haskell.Data.Maps.Timeline as Timeline
     , toAscList
     )
 import qualified Haskell.Data.Set as Set (fromList)
+import Prelude hiding (null, subtract)
 
 -- Working around a limitation in agda2hs.
 import Cardano.Wallet.Deposit.Pure.TxHistory.Type

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
@@ -7,6 +7,7 @@ import Cardano.Wallet.Read.Tx (TxId)
 import Haskell.Data.Map (Map)
 import Haskell.Data.Maps.PairMap (PairMap)
 import Haskell.Data.Maps.Timeline (Timeline)
+import Prelude hiding (null, subtract)
 
 -- |
 -- 'TxHistory'.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxSummary.hs
@@ -6,6 +6,7 @@ import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer (ValueTransfer)
 import Cardano.Wallet.Read.Chain (ChainPoint (GenesisPoint))
 import Cardano.Wallet.Read.Eras (IsEra)
 import Cardano.Wallet.Read.Tx (Tx, TxId, getTxId)
+import Prelude hiding (null, subtract)
 
 -- |
 -- A 'TxSummary' summarizes a transaction.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -14,6 +14,7 @@ import Cardano.Wallet.Read.Tx (TxIn)
 import Data.Set (Set)
 import qualified Haskell.Data.Map as Map (empty)
 import qualified Haskell.Data.Set as Set (empty, intersection, null, union)
+import Prelude hiding (null, subtract)
 
 -- |
 -- Representation of a change (delta) to a 'UTxO'.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
@@ -1,4 +1,17 @@
-module Cardano.Wallet.Deposit.Pure.UTxO.Tx where
+module Cardano.Wallet.Deposit.Pure.UTxO.Tx
+    ( -- * Applying Transactions to UTxO
+      IsOurs
+    , applyTx
+
+      -- * Resolved Transactions
+    , ResolvedTx (..)
+    , resolveInputs
+
+      -- * Value transfer from transactions
+    , valueTransferFromDeltaUTxO
+    , valueTransferFromResolvedTx
+    )
+where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     ( DeltaUTxO (excluded, received)
@@ -66,7 +79,7 @@ utxoFromTxOutputs :: IsEra era => Tx era -> UTxO
 utxoFromTxOutputs = utxoFromEraTx
 
 -- |
--- Tyep for a predicate that tests whether @addr@ belongs to us.
+-- Type for a predicate that tests whether @addr@ belongs to us.
 type IsOurs addr = addr -> Bool
 
 -- |

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
@@ -57,6 +57,7 @@ import qualified Haskell.Data.Map as Map
     , map
     , unionWith
     )
+import Prelude hiding (null, subtract)
 
 -- |
 -- Remove unspent outputs that are consumed by the given transaction.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -1,4 +1,28 @@
-module Cardano.Wallet.Deposit.Pure.UTxO.UTxO where
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxO
+    ( UTxO
+    , null
+    , empty
+    , dom
+    , balance
+    , union
+      -- $prop-union-empty-left
+      -- $prop-union-empty-right
+      -- $prop-union-assoc
+    , excluding
+      -- $prop-excluding-empty
+      -- $prop-excluding-dom
+      -- $prop-excluding-absorb
+      -- $prop-excluding-excluding
+      -- $prop-excluding-difference
+      -- $prop-excluding-intersection
+      -- $prop-excluding-union
+    , restrictedBy
+    , excludingS
+      -- $prop-excluding-excludingS
+    , filterByAddress
+      -- $prop-filterByAddress-filters
+    )
+where
 
 import Cardano.Wallet.Deposit.Read.Temp (Address)
 import Cardano.Wallet.Read.Tx (TxIn, TxOut, getCompactAddr, getValue)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -40,6 +40,7 @@ import qualified Haskell.Data.Map as Map
     , withoutKeys
     )
 import qualified Haskell.Data.Set as Set (filter)
+import Prelude hiding (null, subtract)
 
 -- |
 -- The type 'UTxO' is used to keep track of unspent transaction outputs.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
@@ -49,6 +49,7 @@ import qualified Haskell.Data.Maps.Timeline as Timeline
     , takeWhileAntitone
     )
 import qualified Haskell.Data.Set as Set (difference, intersection)
+import Prelude hiding (null, subtract)
 
 -- Working around a limitation in agda2hs.
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
@@ -1,4 +1,21 @@
-module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core where
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core
+    ( -- * UTxOHistory
+      UTxOHistory
+    , empty
+    , getUTxO
+    , getRollbackWindow
+
+      -- * Changes
+    , DeltaUTxOHistory (..)
+    , applyDeltaUTxOHistory
+    , appendBlock
+    , rollback
+    , prune
+
+      -- * Internal
+    , getSpent
+    )
+where
 
 import qualified Cardano.Wallet.Deposit.Pure.RollbackWindow as RollbackWindow
     ( MaybeRollback (Future, Past, Present)
@@ -37,12 +54,6 @@ import qualified Haskell.Data.Set as Set (difference, intersection)
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
     ( UTxOHistory (..)
     )
-
--- |
--- (Internal, exported for technical reasons.)
-guard :: Bool -> Maybe ()
-guard True = Just ()
-guard False = Nothing
 
 -- |
 -- An empty UTxO history
@@ -172,3 +183,12 @@ prune newFinality old =
                 (snd (Timeline.dropWhileAntitone (<= newFinality) (spent old)))
                 window'
                 (boot old)
+
+-- |
+-- How to apply a DeltaUTxOHistory to a UTxOHistory
+applyDeltaUTxOHistory
+    :: DeltaUTxOHistory -> UTxOHistory -> UTxOHistory
+applyDeltaUTxOHistory (AppendBlock newTip delta) =
+    appendBlock newTip delta
+applyDeltaUTxOHistory (Rollback newTip) = rollback newTip
+applyDeltaUTxOHistory (Prune newFinality) = prune newFinality

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
@@ -6,6 +6,7 @@ import Cardano.Wallet.Read.Block (SlotNo)
 import Cardano.Wallet.Read.Chain (Slot)
 import Cardano.Wallet.Read.Tx (TxIn)
 import Haskell.Data.Maps.Timeline (Timeline)
+import Prelude hiding (null, subtract)
 
 -- |
 -- UTxO history.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
@@ -3,6 +3,7 @@
 module Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer where
 
 import Cardano.Wallet.Read.Value (Value)
+import Prelude hiding (null, subtract)
 
 -- |
 -- Records a transfer of 'Value'

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read/Temp.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Read/Temp.hs
@@ -2,6 +2,7 @@ module Cardano.Wallet.Deposit.Read.Temp where
 
 import Cardano.Wallet.Read.Address (CompactAddr)
 import Cardano.Wallet.Read.Tx (TxIn, TxOut)
+import Prelude hiding (null, subtract)
 
 -- |
 -- Default type for addresses on the Cardano ledger.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Write/Tx/Balance.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Write/Tx/Balance.hs
@@ -6,6 +6,7 @@ import Cardano.Wallet.Deposit.Read.Temp (Address, TxBody (TxBodyC))
 import Cardano.Wallet.Read.Tx (TxIn, TxOut, getValue, mkBasicTxOut)
 import Cardano.Wallet.Read.Value (Value, largerOrEqual, subtract)
 import qualified Haskell.Data.Map as Map (toAscList)
+import Prelude hiding (null, subtract)
 
 import Prelude hiding (subtract)
 

--- a/lib/customer-deposit-wallet-pure/haskell/Everything.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Everything.hs
@@ -1,1 +1,3 @@
 module Everything where
+
+import Prelude hiding (null, subtract)

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/List.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/List.hs
@@ -2,6 +2,8 @@
 
 module Haskell.Data.List where
 
+import Prelude hiding (null, subtract)
+
 import qualified Data.List
 
 foldl'

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/InverseMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/InverseMap.hs
@@ -11,6 +11,7 @@ import qualified Haskell.Data.Map as Map
     , update
     )
 import qualified Haskell.Data.Set as Set (delete, null, singleton, union)
+import Prelude hiding (null, subtract)
 
 type InverseMap key v = Map v (Set key)
 

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
@@ -1,5 +1,7 @@
 module Haskell.Data.Maps.Maybe where
 
+import Prelude hiding (null, subtract)
+
 update :: (a -> Maybe a) -> Maybe a -> Maybe a
 update f Nothing = Nothing
 update f (Just x) = f x

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
@@ -15,6 +15,7 @@ import qualified Haskell.Data.Map as Map
     , update
     )
 import Haskell.Data.Maybe (fromMaybe)
+import Prelude hiding (null, subtract)
 
 explicitEmpty :: Ord a => Map a v -> Maybe (Map a v)
 explicitEmpty m = if Map.null m then Nothing else Just m

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
@@ -22,6 +22,7 @@ import qualified Haskell.Data.Maps.InverseMap as InverseMap
     )
 import Haskell.Data.Maybe (fromMaybe)
 import qualified Haskell.Data.Set as Set (empty, toAscList)
+import Prelude hiding (null, subtract)
 
 -- |
 -- Insert a set of keys into a 'Map' that all have the same value.

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maybe.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maybe.hs
@@ -1,5 +1,7 @@
 module Haskell.Data.Maybe where
 
+import Prelude hiding (null, subtract)
+
 isNothing :: Maybe a -> Bool
 isNothing (Just _) = False
 isNothing Nothing = True


### PR DESCRIPTION
This pull request adds support for export lists in the `.agda` file which are used to filter the exports and the Haddock documentation of the generated `.hs` module.

In Agda, all identifiers are exported as they are needed for type-checking. By using export lists, the generated Haskell code may fail to compile if you hide an identifier that is imported from another module. The main use case for export lists is documentation, not control over exported identifiers. In particular:

* The export list specifies the order in which identifiers appears in the documentation.
* Section headings group identifiers.

The syntax for export lists is

```agda
module My.Module
    {-|

    -- * Section heading
    ; value1
    ; Type2
    -} where
```

This pull requests also uses this features and adds export lists to several `.agda` files in order to improve documentation