### PR TITLE
Add monoid and semigroup laws to `Value` and `ValueTransfer`

### DIFF
--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Types.hs
@@ -57,7 +57,7 @@ data DocItem = DocItem
     -- ^ Documentation string (multiline)
     , typeSignature :: TypeSignature
     -- ^ Type signature of the thing to be documented (multiline).
-    }
+    } deriving (Eq, Ord, Show)
 
 type ExportConstructors = Bool
 

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.agda
@@ -1,9 +1,12 @@
 module Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer where
 
 open import Haskell.Prelude
+open import Haskell.Reasoning
 
 open import Cardano.Wallet.Read using
     ( Value
+      ; iIsLawfulSemigroupValue
+      ; iIsLawfulMonoidValue
     )
 
 import Cardano.Wallet.Read as Read
@@ -14,6 +17,7 @@ import Cardano.Wallet.Read as Read
 -- | Records a transfer of 'Value'
 -- — some 'Value' is spent, while other 'Value' is received.
 record ValueTransfer : Set where
+  constructor ValueTransferC
   field
     spent    : Value
     received : Value
@@ -54,3 +58,31 @@ instance
 {-# COMPILE AGDA2HS fromReceived #-}
 {-# COMPILE AGDA2HS iSemigroupValueTansfer #-}
 {-# COMPILE AGDA2HS iMonoidValueTransfer #-}
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+instance
+  
+  iIsLawfulSemigroupValueTransfer : IsLawfulSemigroup ValueTransfer
+  iIsLawfulSemigroupValueTransfer .associativity x y z
+    rewrite associativity iIsLawfulSemigroupValue (spent x) (spent y) (spent z)
+    rewrite associativity iIsLawfulSemigroupValue (received x) (received y) (received z)
+    = refl
+
+  iIsLawfulMonoidValueTransfer : IsLawfulMonoid ValueTransfer
+  iIsLawfulMonoidValueTransfer .rightIdentity x
+    rewrite rightIdentity iIsLawfulMonoidValue (spent x)
+    rewrite rightIdentity iIsLawfulMonoidValue (received x)
+    = refl 
+
+  iIsLawfulMonoidValueTransfer .leftIdentity x
+    rewrite leftIdentity iIsLawfulMonoidValue (spent x)
+    rewrite leftIdentity iIsLawfulMonoidValue (received x)
+    = refl
+
+  iIsLawfulMonoidValueTransfer .concatenation [] = refl
+  iIsLawfulMonoidValueTransfer .concatenation (x ∷ xs)
+    rewrite ++-[] (x ∷ xs)
+      | concatenation xs
+    = refl

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.agda
@@ -7,6 +7,7 @@ open import Cardano.Wallet.Read using
     ( Value
       ; iIsLawfulSemigroupValue
       ; iIsLawfulMonoidValue
+      ; prop-Value-<>-comm
     )
 
 import Cardano.Wallet.Read as Read
@@ -86,3 +87,15 @@ instance
     rewrite ++-[] (x ∷ xs)
       | concatenation xs
     = refl
+
+-- |
+-- 'ValueTransfer' is a commutative semigroup.
+-- 
+prop-ValueTansfer-<>-comm
+  : ∀ (x y : ValueTransfer)
+  → x <> y ≡ y <> x
+--
+prop-ValueTansfer-<>-comm x y
+  rewrite prop-Value-<>-comm (spent x) (spent y)
+  rewrite prop-Value-<>-comm (received x) (received y)
+  = refl

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Value.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Value.agda
@@ -4,6 +4,7 @@
 module Cardano.Wallet.Read.Value where
 
 open import Haskell.Prelude
+open import Haskell.Reasoning
 
 {-----------------------------------------------------------------------------
     Coin
@@ -97,3 +98,7 @@ postulate
   prop-coin-inject
     : ∀ (c : Coin)
     → getCoin (injectCoin c) ≡ c
+
+  instance
+    iIsLawfulSemigroupValue : IsLawfulSemigroup Value
+    iIsLawfulMonoidValue : IsLawfulMonoid Value

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Value.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Read/Value.agda
@@ -102,3 +102,7 @@ postulate
   instance
     iIsLawfulSemigroupValue : IsLawfulSemigroup Value
     iIsLawfulMonoidValue : IsLawfulMonoid Value
+
+  prop-Value-<>-comm
+    : ∀ (x y : Value)
+    → x <> y ≡ y <> x

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
@@ -8,7 +8,7 @@ import Prelude hiding (null, subtract)
 -- |
 -- Records a transfer of 'Value'
 -- — some 'Value' is spent, while other 'Value' is received.
-data ValueTransfer = ValueTransfer
+data ValueTransfer = ValueTransferC
     { spent :: Value
     , received :: Value
     }
@@ -20,17 +20,32 @@ deriving instance Show ValueTransfer
 -- |
 -- Record spending a given 'Value'.
 fromSpent :: Value -> ValueTransfer
-fromSpent = \value -> ValueTransfer value mempty
+fromSpent = \value -> ValueTransferC value mempty
 
 -- |
 -- Record receiving a given 'Value'.
 fromReceived :: Value -> ValueTransfer
-fromReceived = \value -> ValueTransfer mempty value
+fromReceived = \value -> ValueTransferC mempty value
 
 instance Semigroup ValueTransfer where
     (<>) =
         \v1 v2 ->
-            ValueTransfer (spent v1 <> spent v2) (received v1 <> received v2)
+            ValueTransferC (spent v1 <> spent v2) (received v1 <> received v2)
 
 instance Monoid ValueTransfer where
-    mempty = ValueTransfer mempty mempty
+    mempty = ValueTransferC mempty mempty
+
+-- * Properties
+
+-- $prop-ValueTansfer-<>-comm
+-- #prop-ValueTansfer-<>-comm#
+--
+-- [prop-ValueTansfer-<>-comm]:
+--
+--     'ValueTransfer' is a commutative semigroup.
+--
+--     @
+--     prop-ValueTansfer-<>-comm
+--       : ∀ (x y : ValueTransfer)
+--       → x <> y ≡ y <> x
+--     @


### PR DESCRIPTION
This pull request

* postulates instances of `IsLawfulSemigroup Value` and `IsLawfulMonoid Value`
* deduces instances of `IsLawfulSemigroup ValueTransfer` and `IsLawfulMonoid ValueTransfer`
* postulates that `Value` is a commutative semigroup
* decudes that `ValueTransfer` is a commutative semigroup
