### PR TITLE
Add `mockMaxLengthChangeAddress`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -17,7 +17,9 @@ module Cardano.Wallet.Deposit.Pure.Address
 
     -- ** Address observation
       ; isCustomerAddress
+        ; prop-isCustomerAddress-deriveCustomerAddress
       ; isOurs
+        ; prop-isOurs-from-isCustomerAddress
       ; getBIP32Path
       ; listCustomers
       ; knownCustomerAddress
@@ -355,6 +357,30 @@ prop-lookupDerivationPath-isOurs s addr
 ... | True | r = refl
 ... | False | Nothing = refl
 ... | False | Just c = refl
+
+-- | If an address is a known customer address,
+-- then it was derived from a 'Customer' ID.
+--
+@0 prop-isCustomerAddress-deriveCustomerAddress
+  : ∀ (s : AddressState)
+      (addr : Address)
+  → isCustomerAddress s addr ≡ True
+  → ∃ (λ c → addr ≡ deriveCustomerAddress (getNetworkTag s) (getXPub s) c)
+--
+prop-isCustomerAddress-deriveCustomerAddress s addr
+  with Map.lookup addr (addresses s) in eq
+... | Just c = λ refl → c `witness` invariant-customer s addr c eq
+
+-- | If known customer address belongs to the wallet.
+--
+@0 prop-isOurs-from-isCustomerAddress
+  : ∀ (s : AddressState)
+      (addr : Address)
+  → isCustomerAddress s addr ≡ True
+  → isOurs s addr ≡ True
+--
+prop-isOurs-from-isCustomerAddress s addr eq
+  rewrite eq = prop-x-||-True _
 
 {-----------------------------------------------------------------------------
     Observations, basic

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
@@ -74,6 +74,12 @@ prop-x-&&-False
 prop-x-&&-False True = refl
 prop-x-&&-False False = refl
 
+prop-x-||-True
+  : ∀ (x : Bool)
+  → (x || True) ≡ True
+prop-x-||-True True = refl
+prop-x-||-True False = refl
+
 {-----------------------------------------------------------------------------
     Algebraic laws for logical connectives
 ------------------------------------------------------------------------------}

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -14,7 +14,9 @@ module Cardano.Wallet.Deposit.Pure.Address
 
       -- ** Address observation
     , isCustomerAddress
+      -- $prop-isCustomerAddress-deriveCustomerAddress
     , isOurs
+      -- $prop-isOurs-from-isCustomerAddress
     , getBIP32Path
     , listCustomers
     , knownCustomerAddress
@@ -324,6 +326,35 @@ mockMaxLengthChangeAddress s =
 --           (s0 : AddressState)
 --       → let (address , s1) = createAddress c s0
 --         in  knownCustomerAddress address s1 ≡ True
+--     @
+
+-- $prop-isCustomerAddress-deriveCustomerAddress
+-- #prop-isCustomerAddress-deriveCustomerAddress#
+--
+-- [prop-isCustomerAddress-deriveCustomerAddress]:
+--     If an address is a known customer address,
+--     then it was derived from a 'Customer' ID.
+--
+--     @
+--     @0 prop-isCustomerAddress-deriveCustomerAddress
+--       : ∀ (s : AddressState)
+--           (addr : Address)
+--       → isCustomerAddress s addr ≡ True
+--       → ∃ (λ c → addr ≡ deriveCustomerAddress (getNetworkTag s) (getXPub s) c)
+--     @
+
+-- $prop-isOurs-from-isCustomerAddress
+-- #prop-isOurs-from-isCustomerAddress#
+--
+-- [prop-isOurs-from-isCustomerAddress]:
+--     If known customer address belongs to the wallet.
+--
+--     @
+--     @0 prop-isOurs-from-isCustomerAddress
+--       : ∀ (s : AddressState)
+--           (addr : Address)
+--       → isCustomerAddress s addr ≡ True
+--       → isOurs s addr ≡ True
 --     @
 
 -- $prop-isOurs-mockMaxLengthChangeAddress-False


### PR DESCRIPTION
This pull request adds a function `mockMaxLengthChangeAddress` to `AddressState` that returns a mock address of maximum length which is not used within the wallet. Such an address is required for transaction balancing.

We prove that this address is never used, in other words, that `isOurs` always returns `False` on this address, but we do not prove the length requirement here.

We also prove a couple of properties for `isCustomerAddress` for documentation purposes.