### PR TITLE
Fix off-by-one error in `fromXPubAndCount`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -688,7 +688,15 @@ fromXPubAndCount net xpub knownCustomerCount =
     foldl (λ s c → snd (createAddress c s)) s0 customers
   where
     s0 = emptyFromXPub net xpub
-    customers = enumFromTo 0 knownCustomerCount
+
+    customers : List Customer
+    customers =
+      if fromEnum knownCustomerCount == 0
+      then []
+      else λ {{neq}} →
+        let @0 notMin : _
+            notMin = subst IsFalse (sym neq) IsFalse.itsFalse
+        in  enumFromTo 0 (pred knownCustomerCount {{notMin}})
 
 {-# COMPILE AGDA2HS fromXPubAndCount #-}
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -258,8 +258,11 @@ fromXPubAndCount net xpub knownCustomerCount =
   where
     s0 :: AddressState
     s0 = emptyFromXPub net xpub
-    customers :: [Word31]
-    customers = [0 .. knownCustomerCount]
+    customers :: [Customer]
+    customers =
+        if fromEnum knownCustomerCount == 0
+            then []
+            else [0 .. pred knownCustomerCount]
 
 -- |
 -- Change address generator employed by 'AddressState'.


### PR DESCRIPTION
This pull request fixes an off-by-one error in `fromXPubAndCount`.

I had skipped this in the initial implementation because generating the initial list of customers is not entirely trivial: The simple expression `fromEnumTo 0 (pred knownCustomerCount)` will not be accepted by the compiler — we have to convince the compiler that `pred` is not applied to `0`.