### PR TITLE
Add `getValidityInterval` to `Cardano.Wallet.Read`

### DIFF
--- a/lib/cardano-wallet-read/cardano-wallet-read.cabal
+++ b/lib/cardano-wallet-read/cardano-wallet-read.cabal
@@ -114,6 +114,7 @@ library
     Cardano.Wallet.Read.Tx.TxId
     Cardano.Wallet.Read.Tx.TxIn
     Cardano.Wallet.Read.Tx.TxOut
+    Cardano.Wallet.Read.Tx.Validity
 
   build-depends:
     , base

--- a/lib/cardano-wallet-read/haskell/Cardano/Read/Ledger/Block/SlotNo.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Read/Ledger/Block/SlotNo.hs
@@ -8,6 +8,8 @@
 module Cardano.Read.Ledger.Block.SlotNo
     ( getEraSlotNo
     , SlotNo (..)
+    , fromLedgerSlotNo
+    , toLedgerSlotNo
     , prettySlotNo
     ) where
 
@@ -37,26 +39,33 @@ import Ouroboros.Consensus.Shelley.Protocol.Praos
 import Ouroboros.Consensus.Shelley.Protocol.TPraos
     ()
 
+import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Data.Text as T
 import qualified Ouroboros.Network.Block as O
 
 {-# INLINABLE getEraSlotNo #-}
 getEraSlotNo :: forall era. IsEra era => BHeader era -> SlotNo
 getEraSlotNo = case theEra @era of
-    Byron -> \(BHeader h) -> k $ O.blockSlot h
-    Shelley -> \(BHeader h) -> k $ pHeaderSlot h
-    Allegra -> \(BHeader h) -> k $ pHeaderSlot h
-    Mary -> \(BHeader h) -> k $ pHeaderSlot h
-    Alonzo -> \(BHeader h) -> k $ pHeaderSlot h
-    Babbage -> \(BHeader h) -> k $ pHeaderSlot h
-    Conway -> \(BHeader h) -> k $ pHeaderSlot h
-  where
-    k = SlotNo . fromIntegral . O.unSlotNo
+    Byron -> \(BHeader h) -> fromLedgerSlotNo $ O.blockSlot h
+    Shelley -> \(BHeader h) -> fromLedgerSlotNo $ pHeaderSlot h
+    Allegra -> \(BHeader h) -> fromLedgerSlotNo $ pHeaderSlot h
+    Mary -> \(BHeader h) -> fromLedgerSlotNo $ pHeaderSlot h
+    Alonzo -> \(BHeader h) -> fromLedgerSlotNo $ pHeaderSlot h
+    Babbage -> \(BHeader h) -> fromLedgerSlotNo $ pHeaderSlot h
+    Conway -> \(BHeader h) -> fromLedgerSlotNo $ pHeaderSlot h
 
 newtype SlotNo = SlotNo {unSlotNo :: Natural}
     deriving (Eq, Ord, Show, Generic, Enum, Num)
 
 instance NoThunks SlotNo
+
+-- | Convert 'SlotNo' from @cardano-ledger-core@.
+fromLedgerSlotNo :: Ledger.SlotNo -> SlotNo
+fromLedgerSlotNo = SlotNo . fromIntegral . Ledger.unSlotNo
+
+-- | Convert 'SlotNo' to @cardano-ledger-core@.
+toLedgerSlotNo :: SlotNo -> Ledger.SlotNo
+toLedgerSlotNo = Ledger.SlotNo . fromInteger . fromIntegral . unSlotNo
 
 -- | Short printed representation of a 'ChainPoint'.
 prettySlotNo :: SlotNo -> T.Text

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx.hs
@@ -15,6 +15,10 @@ module Cardano.Wallet.Read.Tx
     , getCollateralInputs
     , IsValid (IsValidC)
     , getScriptValidity
+    , ValidityInterval (..)
+    , invalidBefore
+    , invalidHereafter
+    , getValidityInterval
 
     -- * TxId
     , TxId
@@ -83,4 +87,10 @@ import Cardano.Wallet.Read.Tx.TxOut
     , toConwayOutput
     , upgradeTxOutToBabbageOrLater
     , utxoFromEraTx
+    )
+import Cardano.Wallet.Read.Tx.Validity
+    ( ValidityInterval (..)
+    , getValidityInterval
+    , invalidBefore
+    , invalidHereafter
     )

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Validity.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Validity.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
+
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Validity interval of a transaction.
+-}
+module Cardano.Wallet.Read.Tx.Validity
+    (
+    ValidityInterval (ValidityIntervalC)
+    , invalidBefore
+    , invalidHereafter
+    , getValidityInterval
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( ValidityInterval (ValidityInterval)
+    )
+import Cardano.Read.Ledger.Block.SlotNo
+    ( SlotNo (..)
+    , fromLedgerSlotNo
+    , toLedgerSlotNo
+    )
+import Cardano.Read.Ledger.Tx.Validity
+    ( Validity (..)
+    , ValidityType
+    , getEraValidity
+    )
+import Cardano.Wallet.Read.Eras
+    ( Era (..)
+    , IsEra (..)
+    )
+import Cardano.Wallet.Read.Tx.Tx
+    ( Tx (..)
+    )
+import Data.Maybe.Strict
+    ( StrictMaybe (..)
+    , maybeToStrictMaybe
+    , strictMaybeToMaybe
+    )
+
+{-# COMPLETE ValidityIntervalC #-}
+-- | Alternative view on 'Cardano.Ledger.Api.ValidityInterval'
+-- from "Cardano.Ledger.Api".
+pattern ValidityIntervalC
+    :: Maybe SlotNo
+    -- ^ 'invalidBefore'
+    -> Maybe SlotNo
+    -- ^ 'invalidHereafter'
+    -> ValidityInterval
+pattern ValidityIntervalC{invalidBefore,invalidHereafter} <-
+    (toPair -> (invalidBefore,invalidHereafter))
+  where
+    ValidityIntervalC x y = fromPair (x,y)
+
+fromPair :: (Maybe SlotNo, Maybe SlotNo) -> ValidityInterval
+fromPair (x,y) = ValidityInterval (f x) (f y)
+  where
+    f = fmap toLedgerSlotNo . maybeToStrictMaybe
+
+toPair :: ValidityInterval -> (Maybe SlotNo, Maybe SlotNo)
+toPair (ValidityInterval x y) = (f x, f y)
+  where
+    f = fmap fromLedgerSlotNo . strictMaybeToMaybe
+
+{-# INLINABLE getValidityInterval #-}
+-- | Get the validity interval of a transaction.
+getValidityInterval :: forall era. IsEra era => Tx era -> ValidityInterval
+getValidityInterval = case theEra :: Era era of
+    Byron -> onValidity (const $ ValidityInterval SNothing SNothing)
+    Shelley -> onValidity (ValidityInterval SNothing . SJust)
+    Allegra -> onValidity id
+    Mary -> onValidity id
+    Alonzo -> onValidity id
+    Babbage -> onValidity id
+    Conway -> onValidity id
+
+-- Helper function for type inference.
+onValidity
+    :: IsEra era
+    => (ValidityType era -> t)
+    -> Tx era -> t
+onValidity f x =
+    case getEraValidity x of
+        Validity v -> f v


### PR DESCRIPTION
This pull request implements and exports a function

```hs
getValidityInterval :: forall era. IsEra era => Tx era -> ValidityInterval
```

in `Cardano.Wallet.Read`. This function returns a uniform `ValidityInterval` for transactions in all eras.
