### PR TITLE
Add `p:` prefix to property anchors in Haddock

### DIFF
--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Documentation.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Documentation.hs
@@ -104,7 +104,7 @@ renderAgdaProperty doc =
     [prettyAnchor, newline, "[" <> identifier doc <> "]:"]
     <> indent 4 (dropNewLinesAtEnd prettyDoc <> [newline] <> prettyType)
   where
-    prettyAnchor = "#" <> identifier doc <> "#"
+    prettyAnchor = "#p:" <> identifier doc <> "#"
     prettyDoc = lines (docString doc)
     prettyType = ["@"] <> lines (typeSignature doc) <> ["@"]
  

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
@@ -16,6 +16,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.UTxO
         ; prop-excluding-dom
         ; prop-excluding-absorb
         ; prop-excluding-excluding
+        ; prop-excluding-sym
         ; prop-excluding-difference
         ; prop-excluding-intersection
         ; prop-excluding-union
@@ -94,8 +95,8 @@ _∪_ = union
 -- Infix synonym: @x ⋪ utxo  =  excluding utxo x@.
 --
 -- Notable properties:
--- [prop-excluding-intersection](#prop-excluding-intersection),
--- [prop-excluding-sym](#prop-excluding-sym)
+-- [prop-excluding-intersection](#p:prop-excluding-intersection),
+-- [prop-excluding-sym](#p:prop-excluding-sym)
 excluding : UTxO → Set.ℙ TxIn → UTxO
 excluding = Map.withoutKeys
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
@@ -105,7 +105,7 @@ compactAddrFromEnterpriseAddr addr =
 -- * Properties
 
 -- $prop-compactAddrFromEnterpriseAddr-injective
--- #prop-compactAddrFromEnterpriseAddr-injective#
+-- #p:prop-compactAddrFromEnterpriseAddr-injective#
 --
 -- [prop-compactAddrFromEnterpriseAddr-injective]:
 --
@@ -120,7 +120,7 @@ compactAddrFromEnterpriseAddr addr =
 --     @
 
 -- $prop-credentialFromXPub-injective
--- #prop-credentialFromXPub-injective#
+-- #p:prop-credentialFromXPub-injective#
 --
 -- [prop-credentialFromXPub-injective]:
 --

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -287,7 +287,7 @@ mockMaxLengthChangeAddress s =
 -- * Properties
 
 -- $prop-changeAddress-not-Customer
--- #prop-changeAddress-not-Customer#
+-- #p:prop-changeAddress-not-Customer#
 --
 -- [prop-changeAddress-not-Customer]:
 --     /Essential property./
@@ -303,7 +303,7 @@ mockMaxLengthChangeAddress s =
 --     @
 
 -- $prop-create-derive
--- #prop-create-derive#
+-- #p:prop-create-derive#
 --
 -- [prop-create-derive]:
 --     Creating a customer address is deterministic,
@@ -318,7 +318,7 @@ mockMaxLengthChangeAddress s =
 --     @
 
 -- $prop-create-known
--- #prop-create-known#
+-- #p:prop-create-known#
 --
 -- [prop-create-known]:
 --     Creating an address makes it known.
@@ -332,7 +332,7 @@ mockMaxLengthChangeAddress s =
 --     @
 
 -- $prop-isCustomerAddress-deriveCustomerAddress
--- #prop-isCustomerAddress-deriveCustomerAddress#
+-- #p:prop-isCustomerAddress-deriveCustomerAddress#
 --
 -- [prop-isCustomerAddress-deriveCustomerAddress]:
 --     If an address is a known customer address,
@@ -347,7 +347,7 @@ mockMaxLengthChangeAddress s =
 --     @
 
 -- $prop-isOurs-from-isCustomerAddress
--- #prop-isOurs-from-isCustomerAddress#
+-- #p:prop-isOurs-from-isCustomerAddress#
 --
 -- [prop-isOurs-from-isCustomerAddress]:
 --     If known customer address belongs to the wallet.
@@ -361,7 +361,7 @@ mockMaxLengthChangeAddress s =
 --     @
 
 -- $prop-isOurs-mockMaxLengthChangeAddress-False
--- #prop-isOurs-mockMaxLengthChangeAddress-False#
+-- #p:prop-isOurs-mockMaxLengthChangeAddress-False#
 --
 -- [prop-isOurs-mockMaxLengthChangeAddress-False]:
 --     'mockMaxLengthChangeAddress' never belongs to the 'AddressState'.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
@@ -124,7 +124,7 @@ intersection w1 w2 =
 -- * Properties
 
 -- $prop-RollbackWindow-invariant
--- #prop-RollbackWindow-invariant#
+-- #p:prop-RollbackWindow-invariant#
 --
 -- [prop-RollbackWindow-invariant]:
 --
@@ -138,7 +138,7 @@ intersection w1 w2 =
 --     @
 
 -- $prop-member-finality
--- #prop-member-finality#
+-- #p:prop-member-finality#
 --
 -- [prop-member-finality]:
 --
@@ -152,7 +152,7 @@ intersection w1 w2 =
 --     @
 
 -- $prop-member-intersection
--- #prop-member-intersection#
+-- #p:prop-member-intersection#
 --
 -- [prop-member-intersection]:
 --
@@ -169,7 +169,7 @@ intersection w1 w2 =
 --     @
 
 -- $prop-member-singleton
--- #prop-member-singleton#
+-- #p:prop-member-singleton#
 --
 -- [prop-member-singleton]:
 --
@@ -183,7 +183,7 @@ intersection w1 w2 =
 --     @
 
 -- $prop-member-tip
--- #prop-member-tip#
+-- #p:prop-member-tip#
 --
 -- [prop-member-tip]:
 --

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -81,7 +81,7 @@ concat = foldr append empty
 -- * Properties
 
 -- $prop-apply-append
--- #prop-apply-append#
+-- #p:prop-apply-append#
 --
 -- [prop-apply-append]:
 --     Defining property of 'append':
@@ -97,7 +97,7 @@ concat = foldr append empty
 --     @
 
 -- $prop-apply-empty
--- #prop-apply-empty#
+-- #p:prop-apply-empty#
 --
 -- [prop-apply-empty]:
 --
@@ -110,7 +110,7 @@ concat = foldr append empty
 --     @
 
 -- $prop-apply-excludingD
--- #prop-apply-excludingD#
+-- #p:prop-apply-excludingD#
 --
 -- [prop-apply-excludingD]:
 --     Applying the 'DeltaUTxO' returned by 'excludingD'
@@ -124,7 +124,7 @@ concat = foldr append empty
 --     @
 
 -- $prop-apply-receiveD
--- #prop-apply-receiveD#
+-- #p:prop-apply-receiveD#
 --
 -- [prop-apply-receiveD]:
 --     Applying the 'DeltaUTxO' returned by 'receiveD'
@@ -138,7 +138,7 @@ concat = foldr append empty
 --     @
 
 -- $prop-excluding-excludingD
--- #prop-excluding-excludingD#
+-- #p:prop-excluding-excludingD#
 --
 -- [prop-excluding-excludingD]:
 --     The 'UTxO' returned by 'excludingD' is the same as 'excluding'.
@@ -151,7 +151,7 @@ concat = foldr append empty
 --     @
 
 -- $prop-union-receiveD
--- #prop-union-receiveD#
+-- #p:prop-union-receiveD#
 --
 -- [prop-union-receiveD]:
 --     The 'UTxO' returned by 'receiveD' is the same as 'union'.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -13,6 +13,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.UTxO
       -- $prop-excluding-dom
       -- $prop-excluding-absorb
       -- $prop-excluding-excluding
+      -- $prop-excluding-sym
       -- $prop-excluding-difference
       -- $prop-excluding-intersection
       -- $prop-excluding-union
@@ -81,8 +82,8 @@ union = Map.unionWith (\x y -> x)
 -- Infix synonym: @x ⋪ utxo  =  excluding utxo x@.
 --
 -- Notable properties:
--- [prop-excluding-intersection](#prop-excluding-intersection),
--- [prop-excluding-sym](#prop-excluding-sym)
+-- [prop-excluding-intersection](#p:prop-excluding-intersection),
+-- [prop-excluding-sym](#p:prop-excluding-sym)
 excluding :: UTxO -> Set TxIn -> UTxO
 excluding = Map.withoutKeys
 
@@ -105,7 +106,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 -- * Properties
 
 -- $prop-excluding-absorb
--- #prop-excluding-absorb#
+-- #p:prop-excluding-absorb#
 --
 -- [prop-excluding-absorb]:
 --
@@ -119,7 +120,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-excluding-difference
--- #prop-excluding-difference#
+-- #p:prop-excluding-difference#
 --
 -- [prop-excluding-difference]:
 --
@@ -134,7 +135,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-excluding-dom
--- #prop-excluding-dom#
+-- #p:prop-excluding-dom#
 --
 -- [prop-excluding-dom]:
 --
@@ -147,7 +148,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-excluding-empty
--- #prop-excluding-empty#
+-- #p:prop-excluding-empty#
 --
 -- [prop-excluding-empty]:
 --
@@ -160,7 +161,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-excluding-excluding
--- #prop-excluding-excluding#
+-- #p:prop-excluding-excluding#
 --
 -- [prop-excluding-excluding]:
 --
@@ -173,7 +174,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-excluding-excludingS
--- #prop-excluding-excludingS#
+-- #p:prop-excluding-excludingS#
 --
 -- [prop-excluding-excludingS]:
 --
@@ -188,7 +189,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-excluding-intersection
--- #prop-excluding-intersection#
+-- #p:prop-excluding-intersection#
 --
 -- [prop-excluding-intersection]:
 --
@@ -201,7 +202,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-excluding-sym
--- #prop-excluding-sym#
+-- #p:prop-excluding-sym#
 --
 -- [prop-excluding-sym]:
 --
@@ -214,7 +215,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-excluding-union
--- #prop-excluding-union#
+-- #p:prop-excluding-union#
 --
 -- [prop-excluding-union]:
 --
@@ -228,7 +229,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-filterByAddress-filters
--- #prop-filterByAddress-filters#
+-- #p:prop-filterByAddress-filters#
 --
 -- [prop-filterByAddress-filters]:
 --
@@ -244,7 +245,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-union-assoc
--- #prop-union-assoc#
+-- #p:prop-union-assoc#
 --
 -- [prop-union-assoc]:
 --
@@ -257,7 +258,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-union-empty-left
--- #prop-union-empty-left#
+-- #p:prop-union-empty-left#
 --
 -- [prop-union-empty-left]:
 --
@@ -270,7 +271,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     @
 
 -- $prop-union-empty-right
--- #prop-union-empty-right#
+-- #p:prop-union-empty-right#
 --
 -- [prop-union-empty-right]:
 --

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
@@ -282,7 +282,7 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 -- * Properties
 
 -- $prop-rollBackward-future
--- #prop-rollBackward-future#
+-- #p:prop-rollBackward-future#
 --
 -- [prop-rollBackward-future]:
 --     Rolling backward to the future does nothing.
@@ -295,7 +295,7 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 --     @
 
 -- $prop-rollBackward-rollForward-cancel
--- #prop-rollBackward-rollForward-cancel#
+-- #p:prop-rollBackward-rollForward-cancel#
 --
 -- [prop-rollBackward-rollForward-cancel]:
 --     /Essential property:/
@@ -310,7 +310,7 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 --     @
 
 -- $prop-rollBackward-tip
--- #prop-rollBackward-tip#
+-- #p:prop-rollBackward-tip#
 --
 -- [prop-rollBackward-tip]:
 --     Rolling backward to the tip does nothing, as we are already at the tip.
@@ -323,7 +323,7 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 --     @
 
 -- $prop-rollBackward-tip-rollForward
--- #prop-rollBackward-tip-rollForward#
+-- #p:prop-rollBackward-tip-rollForward#
 --
 -- [prop-rollBackward-tip-rollForward]:
 --     Rolling backward after a 'rollForward' will restore the original state.
@@ -335,7 +335,7 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 --     @
 
 -- $prop-rollForward-present
--- #prop-rollForward-present#
+-- #p:prop-rollForward-present#
 --
 -- [prop-rollForward-present]:
 --     Rolling forward to the tip or before the tip does nothing.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
@@ -38,7 +38,7 @@ instance Monoid ValueTransfer where
 -- * Properties
 
 -- $prop-ValueTansfer-<>-comm
--- #prop-ValueTansfer-<>-comm#
+-- #p:prop-ValueTansfer-<>-comm#
 --
 -- [prop-ValueTansfer-<>-comm]:
 --

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
@@ -27,7 +27,7 @@ intersectionWith _ _ _ = Nothing
 -- * Properties
 
 -- $prop-filt-||
--- #prop-filt-||#
+-- #p:prop-filt-||#
 --
 -- [prop-filt-||]:
 --
@@ -44,7 +44,7 @@ intersectionWith _ _ _ = Nothing
 --     @
 
 -- $prop-filter-filt
--- #prop-filter-filt#
+-- #p:prop-filter-filt#
 --
 -- [prop-filter-filt]:
 --
@@ -58,7 +58,7 @@ intersectionWith _ _ _ = Nothing
 --     @
 
 -- $prop-filter-union
--- #prop-filter-union#
+-- #p:prop-filter-union#
 --
 -- [prop-filter-union]:
 --
@@ -76,7 +76,7 @@ intersectionWith _ _ _ = Nothing
 --     @
 
 -- $prop-unionWith-sym
--- #prop-unionWith-sym#
+-- #p:prop-unionWith-sym#
 --
 -- [prop-unionWith-sym]:
 --     'unionWith' is symmetric if we 'flip' the function.


### PR DESCRIPTION
This pull request adds the prefix `p:` to the anchors for properties in the Haddock documentation. This brings the anchor names in line with the naming convention for anchors in Haddock, where `v:` prefixes values and `t:` prefixes types.
