### PR TITLE
Add `TimelineUTxO`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.agda
@@ -1,0 +1,178 @@
+-- |
+-- Implementation of 'TimelineUTxO'.
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Timeline
+    {-|
+      -- * TimelineUTxO
+    ; TimelineUTxO (..)
+    ; getUTxO
+    ; fromOrigin
+
+      -- * Operations
+    ; insertDeltaUTxO
+    ; dropAfter
+    ; pruneBefore
+
+      -- * Internal
+    ; getSpent
+    -}
+    where
+
+open import Haskell.Prelude
+
+open import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO using
+    ( DeltaUTxO
+    )
+open import Cardano.Wallet.Deposit.Pure.UTxO.UTxO using
+    ( UTxO
+    ; dom
+    ; excluding
+    ; _⋪_
+    ; _⊲_
+    ; _∪_
+    )
+open import Cardano.Wallet.Read using
+    ( Slot
+    ; SlotNo
+    ; TxIn
+    ; WithOrigin
+    )
+open import Haskell.Data.Map using
+    ( Map
+    )
+open import Haskell.Data.Maps.Timeline using
+    ( Timeline
+    )
+open import Haskell.Data.Set using
+    ( ℙ
+    )
+
+import Cardano.Wallet.Deposit.Pure.RollbackWindow as RollbackWindow
+import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO as DeltaUTxO
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
+import Haskell.Data.Map as Map
+import Haskell.Data.Maps.Timeline as Timeline
+import Haskell.Data.Set as Set
+
+{-----------------------------------------------------------------------------
+    Type
+------------------------------------------------------------------------------}
+
+-- | 'TimelineUTxO' represents a timeline of changes to the 'UTxO' set.
+--
+-- We keep track of the creation
+-- and spending of slot of each TxIn.
+-- This allows us to rollback to a given slot
+-- and prune to a given slot.
+record TimelineUTxO : Set where
+  field
+    history : UTxO
+        -- ^ All UTxO , spent and unspent.
+    created : Timeline Slot TxIn
+        -- ^ Creation slots of the TxIn, spent and unspent.
+    spent : Timeline SlotNo TxIn
+        -- ^ Spending slot number of the TxIn, spent.
+    boot : UTxO
+        -- ^ UTxO created at genesis.
+
+open TimelineUTxO public
+
+{-# COMPILE AGDA2HS TimelineUTxO #-}
+
+{-----------------------------------------------------------------------------
+    Functions
+------------------------------------------------------------------------------}
+
+-- | Apply all changes to the 'UTxO'.
+getUTxO : TimelineUTxO → UTxO
+getUTxO us = excluding (history us) (Timeline.items (spent us))
+
+{-# COMPILE AGDA2HS getUTxO #-}
+
+-- | The spent 'TxIn's that can be rolled back.
+--
+-- (Internal, exported for specification.)
+getSpent : TimelineUTxO → Map TxIn SlotNo
+getSpent = Timeline.getMapTime ∘ spent
+
+{-# COMPILE AGDA2HS getSpent #-}
+
+-- | An empty 'TimelineUTxO'.
+fromOrigin : UTxO → TimelineUTxO
+fromOrigin utxo = record
+    { history = utxo
+    ; created =
+        Timeline.insertMany WithOrigin.Origin (dom utxo)
+        (Timeline.empty)
+    ; spent = Timeline.empty
+    ; boot = utxo
+    }
+
+{-# COMPILE AGDA2HS fromOrigin #-}
+
+-- | Insert a 'UTxO' change at a specific slot.
+insertDeltaUTxO
+  : SlotNo → DeltaUTxO → TimelineUTxO → TimelineUTxO
+insertDeltaUTxO newTip delta old = record
+    { history = UTxO.union (history old) (DeltaUTxO.received delta)
+    ; created =
+        Timeline.insertMany
+            (WithOrigin.At newTip) receivedTxIns (created old)
+    ; spent =
+        Timeline.insertMany
+            newTip excludedTxIns (spent old)
+    ; boot = boot old
+    }
+  where
+    receivedTxIns =
+        Set.difference
+            (dom (DeltaUTxO.received delta))
+            (dom (history old))
+    excludedTxIns =
+        Set.difference
+            (Set.intersection (DeltaUTxO.excluded delta) (dom (history old)))
+            (Timeline.items (spent old))
+
+{-# COMPILE AGDA2HS insertDeltaUTxO #-}
+
+-- | Helper for 'dropAfter'.
+dropAfterSpent
+  : Slot → Timeline.Timeline SlotNo TxIn → Timeline.Timeline SlotNo TxIn
+dropAfterSpent WithOrigin.Origin spents = Timeline.empty
+dropAfterSpent (WithOrigin.At slot) spents = Timeline.dropAfter slot spents
+
+-- | Drop all 'UTxO' changes after a given slot.
+dropAfter
+  : Slot → TimelineUTxO → TimelineUTxO
+dropAfter newTip old = record
+    { history = excluding (history old) rolledCreated
+    ; created = created'
+    ; spent = dropAfterSpent newTip (spent old)
+    ; boot = boot old
+    }
+  where
+    deletedAfter = Timeline.deleteAfter newTip (created old)
+    rolledCreated = fst deletedAfter
+    created' = snd deletedAfter
+
+{-# COMPILE AGDA2HS dropAfterSpent #-}
+{-# COMPILE AGDA2HS dropAfter #-}
+
+{-|
+Combine all changes before the given 'SlotNo'.
+
+Using 'prune' will free up some space as old information
+can be summarized and discarded.
+-}
+pruneBefore : SlotNo → TimelineUTxO → TimelineUTxO
+pruneBefore newFinality old = record
+    { history = excluding (history old) prunedTxIns
+    ; created = Timeline.difference (created old) prunedTxIns
+    ; spent = spent1
+    ; boot = boot old
+    }
+  where
+    pruned = Timeline.dropWhileAntitone (_<= newFinality) (spent old)
+    prunedTxIns = fst pruned
+    spent1 = snd pruned
+
+{-# COMPILE AGDA2HS pruneBefore #-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.agda
@@ -25,14 +25,11 @@ open import Haskell.Data.Set using
     )
 
 {-----------------------------------------------------------------------------
-    UTxOHistory
+    Types
 ------------------------------------------------------------------------------}
 
--- | UTxO history.
--- Abstract history of the UTxO. We keep track of the creation
--- and spending of slot of each TxIn.
--- This allows us to rollback to a given slot
--- and prune the history to a given slot.
+-- | 'UTxOHistory' represents a history of a UTxO set that can be
+-- rolled back (up to the 'finality' point).
 --
 -- NOTE: This is an abstract data type,
 -- its internals are only exported for technical reasons.

--- a/lib/customer-deposit-wallet-pure/agda/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Everything.agda
@@ -11,6 +11,7 @@ import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO
 import Cardano.Wallet.Deposit.Pure.UTxO.Tx
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Timeline
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
 
 import Cardano.Wallet.Deposit.Pure.Experimental

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -74,6 +74,7 @@ library
     Cardano.Wallet.Deposit.Pure.UTxO.UTxO
     Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
     Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core
+    Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Timeline
     Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
     Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
     Cardano.Wallet.Deposit.Pure.TxHistory

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.hs
@@ -1,0 +1,159 @@
+module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Timeline
+    ( -- * TimelineUTxO
+      TimelineUTxO (..)
+    , getUTxO
+    , fromOrigin
+
+      -- * Operations
+    , insertDeltaUTxO
+    , dropAfter
+    , pruneBefore
+
+      -- * Internal
+    , getSpent
+    )
+where
+
+import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
+    ( DeltaUTxO (excluded, received)
+    )
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO, dom, excluding)
+import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO (union)
+import Cardano.Wallet.Read.Block (SlotNo)
+import Cardano.Wallet.Read.Chain (Slot, WithOrigin (At, Origin))
+import Cardano.Wallet.Read.Tx (TxIn)
+import Data.Set (Set)
+import Haskell.Data.Map.Def (Map)
+import Haskell.Data.Maps.Timeline (Timeline)
+import qualified Haskell.Data.Maps.Timeline
+    ( deleteAfter
+    , difference
+    , dropAfter
+    , dropWhileAntitone
+    , empty
+    , getMapTime
+    , insertMany
+    , items
+    )
+import qualified Haskell.Data.Set as Set (difference, intersection)
+import Prelude hiding (null, subtract)
+
+-- |
+-- 'TimelineUTxO' represents a timeline of changes to the 'UTxO' set.
+--
+-- We keep track of the creation
+-- and spending of slot of each TxIn.
+-- This allows us to rollback to a given slot
+-- and prune to a given slot.
+data TimelineUTxO = TimelineUTxO
+    { history :: UTxO
+    , created :: Timeline Slot TxIn
+    , spent :: Timeline SlotNo TxIn
+    , boot :: UTxO
+    }
+
+-- |
+-- Apply all changes to the 'UTxO'.
+getUTxO :: TimelineUTxO -> UTxO
+getUTxO us =
+    excluding
+        (history us)
+        (Haskell.Data.Maps.Timeline.items (spent us))
+
+-- |
+-- The spent 'TxIn's that can be rolled back.
+--
+-- (Internal, exported for specification.)
+getSpent :: TimelineUTxO -> Map TxIn SlotNo
+getSpent = Haskell.Data.Maps.Timeline.getMapTime . \r -> spent r
+
+-- |
+-- An empty 'TimelineUTxO'.
+fromOrigin :: UTxO -> TimelineUTxO
+fromOrigin utxo =
+    TimelineUTxO
+        utxo
+        ( Haskell.Data.Maps.Timeline.insertMany
+            Origin
+            (dom utxo)
+            Haskell.Data.Maps.Timeline.empty
+        )
+        Haskell.Data.Maps.Timeline.empty
+        utxo
+
+-- |
+-- Insert a 'UTxO' change at a specific slot.
+insertDeltaUTxO
+    :: SlotNo -> DeltaUTxO -> TimelineUTxO -> TimelineUTxO
+insertDeltaUTxO newTip delta old =
+    TimelineUTxO
+        (UTxO.union (history old) (received delta))
+        ( Haskell.Data.Maps.Timeline.insertMany
+            (At newTip)
+            receivedTxIns
+            (created old)
+        )
+        ( Haskell.Data.Maps.Timeline.insertMany
+            newTip
+            excludedTxIns
+            (spent old)
+        )
+        (boot old)
+  where
+    receivedTxIns :: Set TxIn
+    receivedTxIns =
+        Set.difference (dom (received delta)) (dom (history old))
+    excludedTxIns :: Set TxIn
+    excludedTxIns =
+        Set.difference
+            (Set.intersection (excluded delta) (dom (history old)))
+            (Haskell.Data.Maps.Timeline.items (spent old))
+
+-- |
+-- Helper for 'dropAfter'.
+dropAfterSpent
+    :: Slot -> Timeline SlotNo TxIn -> Timeline SlotNo TxIn
+dropAfterSpent Origin spents = Haskell.Data.Maps.Timeline.empty
+dropAfterSpent (At slot) spents =
+    Haskell.Data.Maps.Timeline.dropAfter slot spents
+
+-- |
+-- Drop all 'UTxO' changes after a given slot.
+dropAfter :: Slot -> TimelineUTxO -> TimelineUTxO
+dropAfter newTip old =
+    TimelineUTxO
+        (excluding (history old) rolledCreated)
+        created'
+        (dropAfterSpent newTip (spent old))
+        (boot old)
+  where
+    deletedAfter :: (Set TxIn, Timeline (WithOrigin SlotNo) TxIn)
+    deletedAfter =
+        Haskell.Data.Maps.Timeline.deleteAfter newTip (created old)
+    rolledCreated :: Set TxIn
+    rolledCreated = fst deletedAfter
+    created' :: Timeline (WithOrigin SlotNo) TxIn
+    created' = snd deletedAfter
+
+-- |
+-- Combine all changes before the given 'SlotNo'.
+--
+-- Using 'prune' will free up some space as old information
+-- can be summarized and discarded.
+pruneBefore :: SlotNo -> TimelineUTxO -> TimelineUTxO
+pruneBefore newFinality old =
+    TimelineUTxO
+        (excluding (history old) prunedTxIns)
+        (Haskell.Data.Maps.Timeline.difference (created old) prunedTxIns)
+        spent1
+        (boot old)
+  where
+    pruned :: (Set TxIn, Timeline SlotNo TxIn)
+    pruned =
+        Haskell.Data.Maps.Timeline.dropWhileAntitone
+            (<= newFinality)
+            (spent old)
+    prunedTxIns :: Set TxIn
+    prunedTxIns = fst pruned
+    spent1 :: Timeline SlotNo TxIn
+    spent1 = snd pruned

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.hs
@@ -7,6 +7,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Timeline
       -- * Operations
     , insertDeltaUTxO
     , dropAfter
+      -- $prop-insertDeltaUTxO-dropAfter-cancel
     , pruneBefore
 
       -- * Internal
@@ -157,3 +158,20 @@ pruneBefore newFinality old =
     prunedTxIns = fst pruned
     spent1 :: Timeline SlotNo TxIn
     spent1 = snd pruned
+
+-- * Properties
+
+-- $prop-insertDeltaUTxO-dropAfter-cancel
+-- #p:prop-insertDeltaUTxO-dropAfter-cancel#
+--
+-- [prop-insertDeltaUTxO-dropAfter-cancel]:
+--     Rolling backward will cancel rolling forward.
+--     Bare version.
+--
+--     @
+--     @0 prop-insertDeltaUTxO-dropAfter-cancel
+--       : ∀ (u : TimelineUTxO) (du : DeltaUTxO) (slot1 : Slot) (slot2 : SlotNo)
+--       → (slot1 < WithOrigin.At slot2) ≡ True
+--       → dropAfter slot1 (insertDeltaUTxO slot2 du u)
+--         ≡ dropAfter slot1 u
+--     @

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Type.hs
@@ -9,11 +9,8 @@ import Haskell.Data.Maps.Timeline (Timeline)
 import Prelude hiding (null, subtract)
 
 -- |
--- UTxO history.
--- Abstract history of the UTxO. We keep track of the creation
--- and spending of slot of each TxIn.
--- This allows us to rollback to a given slot
--- and prune the history to a given slot.
+-- 'UTxOHistory' represents a history of a UTxO set that can be
+-- rolled back (up to the 'finality' point).
 --
 -- NOTE: This is an abstract data type,
 -- its internals are only exported for technical reasons.


### PR DESCRIPTION
This pull request adds a data type `TimelineUTxO` which represents a timeline of changes to the `UTxO`. This type is similar to `UTxOHistory`, but does not involve a `RollbackWindow`.

The intention is that the type `UTxOHistory` will be built on top of the type `TimelineUTxO`.