### PR TITLE
Prove `prop-union-sym` for `Data.Map`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Def.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Def.agda
@@ -185,8 +185,13 @@ module _ {k a b : Set} {{_ : Ord k}} where
     mapWithKey : (k → a → b) → Map k a → Map k b
     mapMaybeWithKey : (k → a → Maybe b) → Map k a → Map k b
 
+    intersection : Map k a → Map k b → Map k a
+
   map : (a → b) → Map k a → Map k b
   map = fmap
+
+  disjoint : Map k a → Map k b → Bool
+  disjoint m1 m2 = null (intersection m1 m2)
 
   postulate
     prop-lookup-fmap
@@ -203,6 +208,11 @@ module _ {k a b : Set} {{_ : Ord k}} where
       : ∀ (key : k) (m : Map k a) (f : k → a → Maybe b)
       → lookup key (mapMaybeWithKey f m)
         ≡ Maybe.mapMaybe (f key) (lookup key m)
+
+    prop-lookup-intersection
+      : ∀ (key : k) (m1 : Map k a) (m2 : Map k b)
+      → lookup key (intersection m1 m2)
+        ≡ Maybe.intersectionWith const (lookup key m1) (lookup key m2)
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
@@ -117,6 +117,41 @@ module _ {k a : Set} {{_ : Ord k}} where
         ∎
 
   --
+  prop-union-sym
+    : ∀ {ma mb : Map k a}
+    → disjoint ma mb ≡ True
+    → union ma mb ≡ union mb ma
+  --
+  prop-union-sym {ma} {mb} cond = prop-equality eq-key
+    where
+      lem1 : intersection ma mb ≡ empty
+      lem1 = prop-null-empty (intersection ma mb) cond
+
+      lem-disjoint = λ key →
+        begin
+          Maybe.disjoint (lookup key ma) (lookup key mb)
+        ≡⟨⟩
+          Maybe.null (Maybe.intersectionWith const (lookup key ma) (lookup key mb))
+        ≡⟨ cong Maybe.null (sym (prop-lookup-intersection key ma mb)) ⟩
+          Maybe.null (lookup key (intersection ma mb))
+        ≡⟨ cong (λ o → Maybe.null (lookup key o)) lem1 ⟩
+          Maybe.null (lookup key empty)
+        ≡⟨ cong Maybe.null (prop-lookup-empty key) ⟩
+          True
+        ∎
+
+      eq-key = λ key →
+        begin
+          lookup key (union ma mb)
+        ≡⟨ prop-lookup-unionWith key const _ _ ⟩
+          Maybe.union (lookup key ma) (lookup key mb)
+        ≡⟨ Maybe.prop-union-sym {_} {lookup key ma} {lookup key mb} (lem-disjoint key) ⟩
+          Maybe.union (lookup key mb) (lookup key ma)
+        ≡⟨ sym (prop-lookup-unionWith key const _ _) ⟩
+          lookup key (unionWith const mb ma)
+        ∎
+
+  --
   prop-union-assoc
     : ∀ {ma mb mc : Map k a}
     → union (union ma mb) mc ≡ union ma (union mb mc)

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
@@ -19,6 +19,10 @@ open import Haskell.Data.Maybe using
     Functions
 ------------------------------------------------------------------------------}
 
+null : Maybe a → Bool
+null Nothing = True
+null (Just x) = False
+
 update : (a → Maybe a) → Maybe a → Maybe a
 update f Nothing = Nothing
 update f (Just x) = f x
@@ -49,6 +53,9 @@ union = unionWith (λ x y → x)
 intersectionWith : (a → b → c) → Maybe a → Maybe b → Maybe c
 intersectionWith f (Just x) (Just y) = Just (f x y)
 intersectionWith _ _ _ = Nothing
+
+disjoint : Maybe a → Maybe b → Bool
+disjoint m = null ∘ intersectionWith const m
 
 {-# COMPILE AGDA2HS update #-}
 {-# COMPILE AGDA2HS filter #-}
@@ -90,6 +97,17 @@ prop-union-assoc {_} {Nothing} {mb} {mc} = refl
 prop-union-assoc {_} {Just x} {Nothing} {mc} = refl
 prop-union-assoc {_} {Just x} {Just y} {Nothing} = refl
 prop-union-assoc {_} {Just x} {Just y} {Just z} = refl
+
+-- | 'union' is symmetric if at most one argument is 'Just'.
+--
+prop-union-sym
+  : ∀ {ma mb : Maybe a}
+  → disjoint ma mb ≡ True
+  → union ma mb ≡ union mb ma
+--
+prop-union-sym {_} {Nothing} {Nothing} eq = refl
+prop-union-sym {_} {Nothing} {Just x} eq = refl
+prop-union-sym {_} {Just x} {Nothing} eq = refl
 
 --
 prop-union-left

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Maybe.agda
@@ -57,8 +57,8 @@ intersectionWith _ _ _ = Nothing
 {-# COMPILE AGDA2HS intersectionWith #-}
 
 {-----------------------------------------------------------------------------
-    Data.Maybe
     Properties
+    union
 ------------------------------------------------------------------------------}
 
 --
@@ -98,6 +98,20 @@ prop-union-left
 --
 prop-union-left x Nothing = refl
 prop-union-left x (Just y) = refl
+
+{-----------------------------------------------------------------------------
+    Properties
+    intersection
+------------------------------------------------------------------------------}
+--
+prop-isJust-intersectionWith
+  : ∀ {ma : Maybe a} {mb : Maybe b} {f : a → b → c}
+  → isJust (intersectionWith f ma mb)
+    ≡ (isJust ma && isJust mb)
+--
+prop-isJust-intersectionWith {_} {_} {_} {Nothing} = refl
+prop-isJust-intersectionWith {_} {_} {_} {Just x} {Nothing} = refl
+prop-isJust-intersectionWith {_} {_} {_} {Just x} {Just y} = refl
 
 {-----------------------------------------------------------------------------
     Properties

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
@@ -109,6 +109,9 @@ module _ {a : Set} {{_ : Ord a}} where
   singleton : a → ℙ a
   singleton = λ x → insert x empty
 
+  disjoint : ℙ a → ℙ a → Bool
+  disjoint m = null ∘ intersection m
+
 foldMap' : ∀ {{_ : Monoid b}} → (a → b) → ℙ a → b
 foldMap' f = foldMap f ∘ toAscList
 

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
@@ -48,6 +48,8 @@ module _ {a : Set} {{_ : Ord a}} where
     difference   : ℙ a → ℙ a → ℙ a
     filter       : (a → Bool) → ℙ a → ℙ a
 
+    isSubsetOf   : ℙ a → ℙ a → Bool
+
     prop-member-null
       : ∀ (s : ℙ a)
           (_ : ∀ (x : a) → member x s ≡ False)
@@ -105,6 +107,16 @@ module _ {a : Set} {{_ : Ord a}} where
       : ∀ (x : a) (p : a → Bool) (s : ℙ a)
       → member x (filter p s)
         ≡ (p x && member x s)
+
+    prop-isSubsetOf→intersection
+      : ∀ (s1 s2 : ℙ a)
+      → isSubsetOf s1 s2 ≡ True
+      → intersection s1 s2 ≡ s1
+
+    prop-intersection→isSubsetOf
+      : ∀ (s1 s2 : ℙ a)
+      → intersection s1 s2 ≡ s1
+      → isSubsetOf s1 s2 ≡ True
 
   singleton : a → ℙ a
   singleton = λ x → insert x empty

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
@@ -75,6 +75,19 @@ intersectionWith _ _ _ = Nothing
 --         ≡ union (filter p m1) (filter p m2)
 --     @
 
+-- $prop-union-sym
+-- #p:prop-union-sym#
+--
+-- [prop-union-sym]:
+--     'union' is symmetric if at most one argument is 'Just'.
+--
+--     @
+--     prop-union-sym
+--       : ∀ {ma mb : Maybe a}
+--       → disjoint ma mb ≡ True
+--       → union ma mb ≡ union mb ma
+--     @
+
 -- $prop-unionWith-sym
 -- #p:prop-unionWith-sym#
 --


### PR DESCRIPTION
This pull request proves the fact that the function `Data.Map.union` is symmetric if the maps are disjoint:

```agda
  prop-union-sym
    : ∀ {ma mb : Map k a}
    → disjoint ma mb ≡ True
    → union ma mb ≡ union mb ma
```

In turn, we define

```agda
  disjoint : Map k a → Map k b → Bool
  disjoint m1 m2 = null (intersection m1 m2)
```

and `intersection`, and add helper proofs.