### PR TITLE
Change import of `Haskell.Cardano.Crypto.Wallet` to be vanilla

### DIFF
--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser/ExportList.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Agda/Parser/ExportList.hs
@@ -116,7 +116,7 @@ moduleName =
     L.lexeme space
         $ (:)
             <$> C.upperChar
-            <*> many (C.alphaNumChar <|> satisfy (`elem` ['.']))
+            <*> many (C.alphaNumChar <|> satisfy (`elem` ['_','.']))
 
 agdaNamePart :: Parser AgdaIdentifier
 agdaNamePart =

--- a/lib/customer-deposit-wallet-pure/agda/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Everything.agda
@@ -18,6 +18,8 @@ import Cardano.Wallet.Deposit.Pure.Experimental
 import Cardano.Wallet.Deposit.Implementation
 import Specification
 
+import Haskell.Cardano.Crypto.Wallet
+
 import Cardano.Wallet.Read.Block
 import Cardano.Wallet.Read.Chain
 import Cardano.Wallet.Read.Eras

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Cardano/Crypto/Wallet.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Cardano/Crypto/Wallet.agda
@@ -1,0 +1,56 @@
+{-# OPTIONS --erasure #-}
+
+-- Synchronized manually with the corresponding Haskell module.
+module Haskell.Cardano.Crypto.Wallet where
+
+open import Haskell.Prelude hiding (fromJust)
+
+open import Haskell.Data.Word using
+  ( Word32
+  )
+open import Haskell.Data.Word.Odd using
+  ( Word31
+  )
+open import Haskell.Data.ByteString using
+  ( ByteString
+  )
+
+postulate
+  word32fromWord31Low : Word31 → Word32
+  word32fromWord31High : Word31 → Word32
+
+{-----------------------------------------------------------------------------
+    Extended Private & Public keys
+------------------------------------------------------------------------------}
+
+data DerivationScheme : Set where
+  DerivationScheme1 : DerivationScheme
+  DerivationScheme2 : DerivationScheme
+
+postulate
+  XPub : Set
+  XPrv : Set
+  XSignature : Set
+
+  unXPrv : XPrv → ByteString
+  unXPub : XPub → ByteString
+  unXSignature : XSignature → ByteString
+
+  toXPub : XPrv → XPub
+  xPrvChangePass : ByteString → ByteString → XPrv → XPrv
+
+{-----------------------------------------------------------------------------
+    Derivation Function
+------------------------------------------------------------------------------}
+
+postulate
+  deriveXPrv : DerivationScheme → ByteString → XPrv → Word32 → XPrv
+  deriveXPub : DerivationScheme → XPub → Word32 → Maybe XPub
+
+{-----------------------------------------------------------------------------
+    Signature & Verification from extended types
+------------------------------------------------------------------------------}
+
+postulate
+  sign   : ByteString → XPrv → ByteString → XSignature
+  verify : XPub → ByteString → XSignature → Bool

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -88,6 +88,7 @@ library
     Data.Maps.Timeline
     Data.Map.Law
   other-modules:
+    Haskell.Cardano.Crypto.Wallet
     Haskell.Data.ByteString
     Haskell.Data.ByteString.Short
     Haskell.Data.List

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
@@ -1,31 +1,48 @@
-{-# LANGUAGE UnicodeSyntax #-}
+module Cardano.Wallet.Address.BIP32_Ed25519
+    ( -- * Types
+      XPub
+    , XPrv
+    , XSignature
+    , toXPub
+    , sign
+    , verify
 
-module Cardano.Wallet.Address.BIP32_Ed25519 where
+      -- * Serialization
+    , rawSerialiseXPub
+    , rawSerialiseXPrv
+    , rawSerialiseXSignature
 
+      -- * Key derivation
+    , deriveXPubSoft
+    , deriveXPrvSoft
+    , deriveXPrvHard
+    )
+where
+
+import Data.Word.Odd (Word31)
+import qualified Haskell.Cardano.Crypto.Wallet as CC
+    ( DerivationScheme (DerivationScheme2)
+    , XPrv
+    , XPub
+    , XSignature
+    , deriveXPrv
+    , deriveXPub
+    , sign
+    , toXPub
+    , unXPrv
+    , unXPub
+    , unXSignature
+    , verify
+    , word32fromWord31High
+    , word32fromWord31Low
+    )
+import Haskell.Data.ByteString (ByteString)
+import qualified Haskell.Data.ByteString as BS (empty)
+import Haskell.Data.Maybe (fromJust)
 import Prelude hiding (null, subtract)
 
-import qualified Cardano.Crypto.Wallet as CC
-import Data.ByteString
-    ( ByteString
-    )
-import qualified Data.ByteString as BS
-import Data.Maybe
-    ( fromJust
-    )
-import Data.Word
-    ( Word32
-    )
-import Data.Word.Odd
-    ( Word31
-    )
-
--- * Types
-
--- FIXME: We define type synonyms here so that
--- they can be exported. Ideally, we would re-export from
--- the Cardano.Wallet.Crypto module.
-
--- | Extended public key,
+-- |
+-- Extended public key,
 -- based on the elliptic curve cryptography
 -- [Ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519).
 --
@@ -34,51 +51,52 @@ import Data.Word.Odd
 -- standard.
 type XPub = CC.XPub
 
--- | Extended private key.
+-- |
+-- Private key, plaintext.
+type XPrv = CC.XPrv
+
+-- |
+-- Extended private key.
 -- based on the elliptic curve cryptography Ed25519.
 -- [Ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519).
 --
 -- Extended keys can be used to create child keys in line
 -- with the [BIP-32_Ed25519](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf)
 -- standard.
-type XPrv = CC.XPrv
-
--- | Signature created with an 'XPrv', and verifiable with 'XPub'.
-type XSignature = CC.XSignature
-
--- | Obtain the public key correspond to a private key.
 toXPub :: XPrv -> XPub
 toXPub = CC.toXPub
 
--- | Sign a sequence of bytes with a private key.
+-- |
+-- Signature created with an 'XPrv', and verifiable with 'XPub'.
+type XSignature = CC.XSignature
+
+-- |
+-- Sign a sequence of bytes with a private key.
 sign :: XPrv -> ByteString -> XSignature
 sign = CC.sign BS.empty
 
--- | Verify the signature for a sequence of bytes using the public key.
+-- |
+-- Verify the signature for a sequence of bytes using the public key.
 verify :: XPub -> ByteString -> XSignature -> Bool
 verify = CC.verify
 
--- * Serialization
-
--- | Serialize an 'XPub' to a sequence of bytes.
+-- |
+-- Serialize an 'XPub' to a sequence of bytes.
 rawSerialiseXPub :: XPub -> ByteString
 rawSerialiseXPub = CC.unXPub
 
--- | Serialize an 'XPrv' to a sequence of bytes.
+-- |
+-- Serialize an 'XPrv' to a sequence of bytes.
 rawSerialiseXPrv :: XPrv -> ByteString
 rawSerialiseXPrv = CC.unXPrv
 
--- | Serialize an 'XSignature' to a sequence of bytes.
+-- |
+-- Serialize an 'XSignature' to a sequence of bytes.
 rawSerialiseXSignature :: XSignature -> ByteString
 rawSerialiseXSignature = CC.unXSignature
 
--- * Key derivation
-
--- | Embed a smaller Word into a larger Word.
-word32fromWord31 :: Word31 -> Word32
-word32fromWord31 = fromInteger . toInteger
-
--- | Derive a child extended public key according to the
+-- |
+-- Derive a child extended public key according to the
 -- [BIP-32_Ed25519](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf) standard.
 deriveXPubSoft :: XPub -> Word31 -> XPub
 deriveXPubSoft xpub ix =
@@ -86,12 +104,11 @@ deriveXPubSoft xpub ix =
         ( CC.deriveXPub
             CC.DerivationScheme2
             xpub
-            (word32fromWord31 ix)
+            (CC.word32fromWord31Low ix)
         )
 
--- deriveXPub always returns Just on Word31
-
--- | Derive a child extended private key according to the
+-- |
+-- Derive a child extended private key according to the
 -- [BIP-32_Ed25519](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf) standard.
 deriveXPrvSoft :: XPrv -> Word31 -> XPrv
 deriveXPrvSoft xprv ix =
@@ -99,9 +116,10 @@ deriveXPrvSoft xprv ix =
         CC.DerivationScheme2
         BS.empty
         xprv
-        (word32fromWord31 ix)
+        (CC.word32fromWord31Low ix)
 
--- | Derive a hardened child extended private key according to the
+-- |
+-- Derive a hardened child extended private key according to the
 -- [BIP-32_Ed25519](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf) standard.
 deriveXPrvHard :: XPrv -> Word31 -> XPrv
 deriveXPrvHard xprv ix =
@@ -109,4 +127,4 @@ deriveXPrvHard xprv ix =
         CC.DerivationScheme2
         BS.empty
         xprv
-        (0x80000000 + word32fromWord31 ix)
+        (CC.word32fromWord31High ix)

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Cardano/Crypto/Wallet.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Cardano/Crypto/Wallet.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+module Haskell.Cardano.Crypto.Wallet
+    ( module Cardano.Crypto.Wallet
+    , xPrvChangePass
+    , deriveXPrv
+    , deriveXPub
+    , sign
+    , verify
+    , word32fromWord31Low
+    , word32fromWord31High
+    ) where
+
+import Cardano.Crypto.Wallet hiding
+    ( deriveXPrv
+    , deriveXPub
+    , sign
+    , verify
+    , xPrvChangePass
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Data.Word
+    ( Word32
+    )
+import Data.Word.Odd
+    ( Word31
+    )
+
+import qualified Cardano.Crypto.Wallet as CC
+
+-- | Convert 'Word31' into 'Word32' with highest bit @0@.
+word32fromWord31Low :: Word31 -> Word32
+word32fromWord31Low = fromInteger . toInteger
+
+-- | Convert 'Word31' into 'Word32' with highest bit @1@.
+word32fromWord31High :: Word31 -> Word32
+word32fromWord31High w = 0x80000000 + word32fromWord31Low w
+
+xPrvChangePass :: ByteString -> ByteString -> XPrv -> XPrv
+xPrvChangePass = CC.xPrvChangePass
+
+deriveXPrv :: DerivationScheme -> ByteString -> XPrv -> Word32 -> XPrv
+deriveXPrv = CC.deriveXPrv
+
+deriveXPub :: DerivationScheme -> XPub -> Word32 -> Maybe XPub
+deriveXPub = CC.deriveXPub
+
+sign :: ByteString -> XPrv -> ByteString -> XSignature
+sign = CC.sign
+
+verify :: XPub -> ByteString -> XSignature -> Bool
+verify = CC.verify


### PR DESCRIPTION
This pull request changes the import of the Haskell module `Cardano.Crypto.Wallet` to be (more) vanilla, where we postulate the functions (mostly) as exported, instead of trying to massage the module functions.

The module `Cardano.Wallet.Address.BIP32_Ed25519` then imports the `Haskell.Cardano.Crypto.Wallet` and does perform a massage.