### PR TITLE
Fix `keyHashFromXPub` to use `rawPublicKeyFromXPub`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519.agda
@@ -12,6 +12,7 @@ module Cardano.Wallet.Address.BIP32_Ed25519
 
   -- * Serialization
   ; rawSerialiseXPub
+  ; rawPublicKeyFromXPub
   ; rawSerialiseXPrv
   ; rawSerialiseXSignature
 
@@ -126,6 +127,23 @@ postulate
 {-# COMPILE AGDA2HS rawSerialiseXPub #-}
 {-# COMPILE AGDA2HS rawSerialiseXPrv #-}
 {-# COMPILE AGDA2HS rawSerialiseXSignature #-}
+
+-- | Extract and serialize the public key of an extended public key.
+rawPublicKeyFromXPub : XPub → ByteString
+rawPublicKeyFromXPub = CC.xpubPublicKey
+
+-- TODO: The following property is not actually true,
+-- as the same public key may be extended in different ways.
+-- However, this situation is unheard of, and for the purpose
+-- of arguing that the mapping from derived keys to
+-- addresses is injective, we can postulate this.
+postulate
+  prop-rawPublicKeyFromXPub-injective
+    : ∀ (x y : XPub)
+    → rawPublicKeyFromXPub x ≡ rawPublicKeyFromXPub y
+    → x ≡ y
+
+{-# COMPILE AGDA2HS rawPublicKeyFromXPub #-}
 
 {-----------------------------------------------------------------------------
     Key derivation

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/Encoding.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/Encoding.agda
@@ -26,8 +26,8 @@ open import Haskell.Prelude hiding (fromJust)
 
 open import Cardano.Wallet.Address.BIP32_Ed25519 using
   ( XPub
-  ; rawSerialiseXPub
-  ; prop-rawSerialiseXPub-injective
+  ; rawPublicKeyFromXPub
+  ; prop-rawPublicKeyFromXPub-injective
   )
 open import Cardano.Wallet.Address.Hash using
   ( blake2b'224
@@ -129,12 +129,12 @@ prop-KeyHashObj-injective x y refl = refl
 ------------------------------------------------------------------------------}
 -- | Hash a public key.
 keyHashFromXPub : XPub → KeyHash
-keyHashFromXPub xpub = toShort (blake2b'224 (rawSerialiseXPub xpub))
+keyHashFromXPub xpub = toShort (blake2b'224 (rawPublicKeyFromXPub xpub))
 
 -- | Hash a public key to obtain a 'Credential'.
 credentialFromXPub : XPub → Credential
 credentialFromXPub xpub =
-  KeyHashObj (toShort (blake2b'224 (rawSerialiseXPub xpub)))
+  KeyHashObj (keyHashFromXPub xpub)
 
 {-# COMPILE AGDA2HS keyHashFromXPub #-}
 {-# COMPILE AGDA2HS credentialFromXPub #-}
@@ -198,7 +198,7 @@ prop-credentialFromXPub-injective
   → x ≡ y
 --
 prop-credentialFromXPub-injective x y =
-  prop-rawSerialiseXPub-injective _ _
+  prop-rawPublicKeyFromXPub-injective _ _
   ∘ prop-blake2b'224-injective _ _
   ∘ prop-toShort-injective _ _
   ∘ prop-KeyHashObj-injective _ _

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Cardano/Crypto/Wallet.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Cardano/Crypto/Wallet.agda
@@ -36,6 +36,7 @@ postulate
   unXPub : XPub → ByteString
   unXSignature : XSignature → ByteString
 
+  xpubPublicKey : XPub → ByteString
   toXPub : XPrv → XPub
   xPrvChangePass : ByteString → ByteString → XPrv → XPrv
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519.hs
@@ -9,6 +9,7 @@ module Cardano.Wallet.Address.BIP32_Ed25519
 
       -- * Serialization
     , rawSerialiseXPub
+    , rawPublicKeyFromXPub
     , rawSerialiseXPrv
     , rawSerialiseXSignature
 
@@ -40,6 +41,7 @@ import qualified Haskell.Cardano.Crypto.Wallet as CC
     , verify
     , word32fromWord31High
     , word32fromWord31Low
+    , xpubPublicKey
     )
 import Haskell.Data.ByteString (ByteString)
 import qualified Haskell.Data.ByteString as BS (empty)
@@ -99,6 +101,11 @@ rawSerialiseXPrv = CC.unXPrv
 -- Serialize an 'XSignature' to a sequence of bytes.
 rawSerialiseXSignature :: XSignature -> ByteString
 rawSerialiseXSignature = CC.unXSignature
+
+-- |
+-- Extract and serialize the public key of an extended public key.
+rawPublicKeyFromXPub :: XPub -> ByteString
+rawPublicKeyFromXPub = CC.xpubPublicKey
 
 -- |
 -- Derive a child extended public key according to the

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
@@ -21,7 +21,7 @@ module Cardano.Wallet.Address.Encoding
     )
 where
 
-import Cardano.Wallet.Address.BIP32_Ed25519 (XPub, rawSerialiseXPub)
+import Cardano.Wallet.Address.BIP32_Ed25519 (XPub, rawPublicKeyFromXPub)
 import Cardano.Wallet.Address.Hash (blake2b'224)
 import Cardano.Wallet.Read.Address (CompactAddr, fromShortByteString)
 import Cardano.Wallet.Read.Chain (NetworkId (Mainnet, Testnet))
@@ -80,13 +80,12 @@ deriving instance Show EnterpriseAddr
 -- Hash a public key.
 keyHashFromXPub :: XPub -> KeyHash
 keyHashFromXPub xpub =
-    toShort (blake2b'224 (rawSerialiseXPub xpub))
+    toShort (blake2b'224 (rawPublicKeyFromXPub xpub))
 
 -- |
 -- Hash a public key to obtain a 'Credential'.
 credentialFromXPub :: XPub -> Credential
-credentialFromXPub xpub =
-    KeyHashObj (toShort (blake2b'224 (rawSerialiseXPub xpub)))
+credentialFromXPub xpub = KeyHashObj (keyHashFromXPub xpub)
 
 -- |
 -- Magic tag for enterprise addresses on testnet and mainnet.


### PR DESCRIPTION
This pull request fixes the mapping from `XPub` to `Addr` by hashing the public key rather than the full extended public key.