### PR TITLE
Add `StrictData` to long-lived data structures

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -102,6 +102,10 @@ open import Haskell.Data.Word.Odd public using
 import Haskell.Data.ByteString as BS
 import Haskell.Data.Map as Map
 
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE StrictData #-}
+#-}
+
 {-----------------------------------------------------------------------------
     Customer
 ------------------------------------------------------------------------------}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/RollbackWindow.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/RollbackWindow.agda
@@ -45,6 +45,10 @@ open import Haskell.Data.Set using
 import Haskell.Data.Map as Map
 import Haskell.Data.Set as Set
 
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE StrictData #-}
+#-}
+
 {-----------------------------------------------------------------------------
     Helpers
 ------------------------------------------------------------------------------}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.agda
@@ -80,6 +80,9 @@ import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Type
     ( UTxOHistory (..)
     )
 #-}
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE StrictData #-}
+#-}
 
 {-----------------------------------------------------------------------------
     Helper stuff

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.agda
@@ -55,6 +55,10 @@ import Haskell.Data.Map as Map
 import Haskell.Data.Maps.Timeline as Timeline
 import Haskell.Data.Set as Set
 
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE StrictData #-}
+#-}
+
 {-----------------------------------------------------------------------------
     Type
 ------------------------------------------------------------------------------}

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
@@ -22,6 +22,10 @@ import Haskell.Data.Maps.InverseMap as InverseMap
 import Haskell.Data.Map as Map
 import Haskell.Data.Set as Set
 
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE StrictData #-}
+#-}
+
 variable
   time : Set
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StrictData #-}
 
 module Cardano.Wallet.Deposit.Pure.Address
     ( -- * Deriving addresses

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StrictData #-}
 
 module Cardano.Wallet.Deposit.Pure.RollbackWindow
     ( -- * Definition

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StrictData #-}
+
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Core
     ( -- * UTxOHistory
       UTxOHistory (..)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StrictData #-}
+
 module Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory.Timeline
     ( -- * TimelineUTxO
       TimelineUTxO (..)

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StrictData #-}
 
 module Haskell.Data.Maps.Timeline where
 


### PR DESCRIPTION
This pull request adds a pragma

```agda
{-# FOREIGN AGDA2HS
{-# LANGUAGE StrictData #-}
#-}
```

to long-lived data structure in order to control memory usage.