### PR TITLE
Add more `StrictData` annotations

### DIFF
--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Eras/EraValue.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Eras/EraValue.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Type.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/TxHistory/Type.agda
@@ -25,6 +25,10 @@ open import Haskell.Data.Maps.Timeline using
     ( Timeline
     )
 
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE StrictData #-}
+#-}
+
 {-----------------------------------------------------------------------------
     Data type
 ------------------------------------------------------------------------------}

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/Tx.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/Tx.agda
@@ -10,7 +10,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.Tx
   -- * Resolved Transactions
   ; ResolvedTx (..)
   ; resolveInputs
-  
+
   -- * Value transfer from transactions
   ; valueTransferFromDeltaUTxO
   ; valueTransferFromResolvedTx
@@ -49,6 +49,10 @@ import Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 import Cardano.Wallet.Read as Read
 import Haskell.Data.Map as Map
 import Haskell.Data.Set as Set
+
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE StrictData #-}
+#-}
 
 {-----------------------------------------------------------------------------
     UTxO utilities

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.agda
@@ -12,6 +12,10 @@ open import Cardano.Wallet.Read using
 
 import Cardano.Wallet.Read as Read
 
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE StrictData #-}
+#-}
+
 {-----------------------------------------------------------------------------
     ValueTransfer
 ------------------------------------------------------------------------------}
@@ -64,7 +68,7 @@ instance
     Properties
 ------------------------------------------------------------------------------}
 instance
-  
+
   iIsLawfulSemigroupValueTransfer : IsLawfulSemigroup ValueTransfer
   iIsLawfulSemigroupValueTransfer .associativity x y z
     rewrite associativity iIsLawfulSemigroupValue (spent x) (spent y) (spent z)
@@ -75,7 +79,7 @@ instance
   iIsLawfulMonoidValueTransfer .rightIdentity x
     rewrite rightIdentity iIsLawfulMonoidValue (spent x)
     rewrite rightIdentity iIsLawfulMonoidValue (received x)
-    = refl 
+    = refl
 
   iIsLawfulMonoidValueTransfer .leftIdentity x
     rewrite leftIdentity iIsLawfulMonoidValue (spent x)
@@ -90,7 +94,7 @@ instance
 
 -- |
 -- 'ValueTransfer' is a commutative semigroup.
--- 
+--
 prop-ValueTansfer-<>-comm
   : ∀ (x y : ValueTransfer)
   → x <> y ≡ y <> x

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
@@ -20,6 +20,10 @@ open import Haskell.Data.Set using
 
 import Haskell.Data.Map as Map
 
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE StrictData #-}
+#-}
+
 variable
   v : Set
 
@@ -114,23 +118,23 @@ prop-implicitEmpty-bind x (Just m1) = refl
 ------------------------------------------------------------------------------}
 
 lookup2
-  : {{_ : Ord a}} → {{_ : Ord b}} 
+  : {{_ : Ord a}} → {{_ : Ord b}}
   → a → b → Map a (Map b v) → Maybe v
 lookup2 a b m = Map.lookup a m >>= Map.lookup b
 
 insert2
-  : {{_ : Ord a}} → {{_ : Ord b}} 
+  : {{_ : Ord a}} → {{_ : Ord b}}
   → a → b → v → Map a (Map b v) → Map a (Map b v)
 insert2 ai bi v m =
   Map.insert ai (Map.insert bi v (implicitEmpty (Map.lookup ai m))) m
 
 delete2
-  : {{_ : Ord a}} → {{_ : Ord b}} 
+  : {{_ : Ord a}} → {{_ : Ord b}}
   → a → b → Map a (Map b v) → Map a (Map b v)
 delete2 a b = Map.update (explicitEmpty ∘ Map.delete b) a
 
 delete2s
-  : {{_ : Ord a}} → {{_ : Ord b}} 
+  : {{_ : Ord a}} → {{_ : Ord b}}
   → List a → b → Map a (Map b v) → Map a (Map b v)
 delete2s xs b m0 = foldr (λ a m → delete2 a b m) m0 xs
 -- fixme: use foldl'
@@ -158,7 +162,7 @@ prop-lookup2-eqB a b1 b2 m eq =
 
 --
 @0 prop-lookup2-insert2
-  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}} 
+  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}}
   → ∀ (a ai : A) (b bi : B) (v : V) (m : Map A (Map B V))
   → lookup2 a b (insert2 ai bi v m)
     ≡ (if a == ai && b == bi then Just v else lookup2 a b m)
@@ -220,7 +224,7 @@ prop-lookup2-insert2 a ai b bi v m = lem2
 
 --
 @0 prop-lookup2-delete2
-  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}} 
+  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}}
   → ∀ (a : A) (b : B) (ai : A) (bi : B) (m : Map A (Map B V))
   → lookup2 a b (delete2 ai bi m)
     ≡ (if a == ai && b == bi then Nothing else lookup2 a b m)
@@ -291,7 +295,7 @@ prop-lookup2-delete2 {A} {B} {V} a b ai bi m = lem2
 
 --
 @0 prop-lookup2-delete2s
-  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}} 
+  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}}
   → ∀ (a : A) (b : B) (as : List A) (bi : B) (m : Map A (Map B V))
   → lookup2 a b (delete2s as bi m)
     ≡ (if elem a as && b == bi then Nothing else lookup2 a b m)
@@ -312,7 +316,7 @@ prop-lookup2-delete2s a b (x ∷ xs) bi m =
     ≡⟨ lem-if-shuffle (a == x) (elem a xs) (b == bi) (lookup2 a b m) ⟩
       (if (a == x || elem a xs) && b == bi then Nothing else lookup2 a b m)
     ≡⟨⟩
-      (if elem a (x ∷ xs) && b == bi then Nothing else lookup2 a b m)      
+      (if elem a (x ∷ xs) && b == bi then Nothing else lookup2 a b m)
     ∎
   where
     lem-if-shuffle
@@ -330,7 +334,7 @@ prop-lookup2-delete2s a b (x ∷ xs) bi m =
 
 --
 @0 prop-lookup2-delete2all
-  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}} 
+  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}}
   → ∀ (a : A) (b : B) (as : List A) (bi : B) (m : Map A (Map B V))
   → (elem a as ≡ False → lookup2 a bi m ≡ Nothing)
   → lookup2 a b (delete2s as bi m)
@@ -338,7 +342,7 @@ prop-lookup2-delete2s a b (x ∷ xs) bi m =
 --
 prop-lookup2-delete2all a b as bi m conseq =
   case elem a as of λ
-    { True {{eq}} → 
+    { True {{eq}} →
       begin
         lookup2 a b (delete2s as bi m)
       ≡⟨ prop-lookup2-delete2s a b as bi m ⟩
@@ -364,7 +368,7 @@ prop-lookup2-delete2all a b as bi m conseq =
 
 --
 prop-lookup2-delete1all
-  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}} 
+  : {A B V : Set} {{_ : Ord A}} → {{_ : Ord B}}
   → ∀ (a : A) (b : B) (ai : A) (m : Map A (Map B V))
   → lookup2 a b (Map.delete ai m)
     ≡ (if a == ai then Nothing else lookup2 a b m)
@@ -417,7 +421,7 @@ module _ {a b v : Set} {{_ : Ord a}} {{_ : Ord b}} where
   empty = record
     { mab = Map.empty
     ; mba = Map.empty
-    ; invariant-equal = λ x y → 
+    ; invariant-equal = λ x y →
       begin
         Map.lookup x Map.empty >>= Map.lookup y
       ≡⟨ cong (λ m → m >>= _) (Map.prop-lookup-empty x) ⟩
@@ -489,7 +493,7 @@ module _ {a b v : Set} {{_ : Ord a}} {{_ : Ord b}} where
           Map.lookup ai (mab m) >>= Map.lookup y
         ≡⟨ prop-implicitEmpty-bind y (Map.lookup ai (mab m)) ⟩
           Map.lookup y (implicitEmpty (Map.lookup ai (mab m)))
-        ≡⟨ prop-elem-keys y (implicitEmpty (Map.lookup ai (mab m))) eq-elem ⟩ 
+        ≡⟨ prop-elem-keys y (implicitEmpty (Map.lookup ai (mab m))) eq-elem ⟩
           Nothing
         ∎
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/TxHistory/Type.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StrictData #-}
+
 module Cardano.Wallet.Deposit.Pure.TxHistory.Type where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer (ValueTransfer)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/Tx.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StrictData #-}
+
 module Cardano.Wallet.Deposit.Pure.UTxO.Tx
     ( -- * Applying Transactions to UTxO
       IsOurs

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StrictData #-}
 
 module Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer where
 

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/PairMap.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
 
 module Haskell.Data.Maps.PairMap where
 


### PR DESCRIPTION
- Add StrictData to `TxHistory`
- Add StrictData to `PairMap`
- Add StrictData to `ResolvedTx`
- Add StrictData to `EraValue`
- Add StrictData to `ValueTransfer`

### Comments

Some of these types appear unused from the deposit wallet (like this `TxHistory`), but presumably deserve increased strictness anyway.

### Issue Number

Related to https://github.com/cardano-foundation/cardano-wallet/issues/4876, but these changes didn't seem to be needed to fix the issue
