### PR TITLE
Add documentation for continuous integration (CI)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,3 @@ Describe in more detail, in a few bullet points, of how this PR accomplishes its
 ### Comments
 
 <!-- Additional comments on the why of this pull request, links, or screenshots to attach, if any. -->
-
-### Issue Number
-
-<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,23 @@
 If you find a bug or you'd like to propose a feature, please feel free to raise an issue on our [issue tracker](https://github.com/cardano-foundation/cardano-wallet-agda/issues).
 
 Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+
+# Development
+
+## Branches
+
+We use [trunk-based development][trunk]: We merge features and improvements into the `main` branch frequently. If a large feature takes more than one pull request to develop, and is therefore incomplete, we hide it behind a feature flag. The `main` branch should be kept in a state where all checks pass, so that we can release it at any time.
+
+  [trunk]: https://martinfowler.com/articles/branching-patterns.html#Trunk-basedDevelopment
+
+## Continuous Integration (CI)
+
+We use [continuous integration][ci]: Checking proofs, building artifacts, and testing artifacts is done automatically before changes are admitted to the `main` branch.
+
+We use [Buildkite][] for automation.
+Our Buildkite pipeline is defined in [.buildkite/pipeline.yml](.buildkite/pipeline.yml). The build environment is provisioned using the [Nix package manager][nix]. The relevant build steps are grouped in the [`justfile`][just] under the `ci-` prefix.
+
+  [ci]: https://www.goodreads.com/book/show/17255186-the-phoenix-project
+  [nix]: https://nixos.org/download/
+  [buildkite]: https://buildkite.com/cardano-foundation/cardano-wallet-agda/
+  [just]: https://github.com/casey/just

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Each of the packages in the `lib/` directory may contain the following subdirect
 
 Prerequisites:
 
-* [Nix package manager][nix].
+* [Nix package manager][nix].  
+  As some dependencies, such as [agda2hs][], are still under development, we use [nix][] to ensure a working build environment.
 
 How to build:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 🚧 WORK IN PROGRESS 🚧
 
+[![Build status](https://badge.buildkite.com/307068367b3a4746737164e239dca22dd6b5288eb54c71ee0c.svg?branch=main)](https://buildkite.com/cardano-foundation/cardano-wallet-agda)
+
 ## Overview
 
 This repository contains wallet implementations for the Cardano blockchain that are formally verified to some degree. The implementations are [Haskell][] packages, but generated using [agda2hs][], with proofs in [Agda][].


### PR DESCRIPTION
This pull request adds documentation about our continuous integration (CI) approach to `CONTRIBUTING.md`. It also adds a build badge to the `README.md`.

Resolves #118