### PR TITLE
Add `Cardano.Wallet.Address.BIP32_Ed25519.Encrypted`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519/Encrypted.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Address/BIP32_Ed25519/Encrypted.agda
@@ -1,0 +1,294 @@
+{-# OPTIONS --erasure #-}
+
+module Cardano.Wallet.Address.BIP32_Ed25519.Encrypted
+  {-|
+  -- * Types
+  ; Passphrase
+  ; EncryptedXPrv
+    ; check
+    ; decrypt
+      ; prop-check-decrypt
+    ; encrypt
+      ; prop-decrypt-encrypt
+    ; toXPub
+      ; prop-toXPub-decrypt
+    ; sign
+      ; prop-sign-decrypt
+
+  -- * Serialization
+  ; rawSerialiseEncryptedXPrv
+
+  -- * Key derivation
+  ; deriveEncryptedXPrvSoft
+  ; deriveEncryptedXPrvHard
+  ; deriveEncryptedXPrvBIP32Path
+  -} where
+
+open import Haskell.Prelude hiding (fromJust)
+open import Haskell.Reasoning
+
+open import Cardano.Wallet.Address.BIP32_Ed25519 using
+  ( XPrv
+  ; XPub
+  ; XSignature
+  ; verify
+    ; prop-verify-sign
+  )
+open import Cardano.Wallet.Address.BIP32 using
+  ( BIP32Path
+  ; DerivationType
+  )
+open DerivationType
+open import Haskell.Data.ByteString using
+  ( ByteString
+  )
+open import Haskell.Data.Maybe using
+  ( isJust
+  )
+open import Haskell.Data.Word using
+  ( Word32
+  )
+open import Haskell.Data.Word.Odd using
+  ( Word31
+  )
+
+import Cardano.Wallet.Address.BIP32_Ed25519 as BIP32_Ed25519
+import Haskell.Cardano.Crypto.Wallet as CC
+import Haskell.Data.ByteString as BS
+
+{-----------------------------------------------------------------------------
+    Types
+------------------------------------------------------------------------------}
+-- | A passphrase for encrypting a private key.
+-- Any string of bytes is a valid passphrase.
+Passphrase : Set
+Passphrase = ByteString
+
+{-# COMPILE AGDA2HS Passphrase #-}
+
+-- | Extended private key in memory, encrypted with a passphrase.
+--
+-- The point of encrypting a private key with a passphrase in memory is 
+-- that an adversary who has acces to a memory dump of the running program
+-- will have a difficult time trying to extract the key,
+-- unless they can also get access to the passphrase.
+--
+-- Note: Operations are slightly slower than on plain private keys,
+-- because each operation checks whether the passphrase decrypts
+-- the key before operating on it.
+record EncryptedXPrv : Set where
+  field
+    encryptedXPrv : XPrv
+    salt : ByteString
+    saltSigned : XSignature
+
+open EncryptedXPrv public
+
+{-# COMPILE AGDA2HS EncryptedXPrv #-}
+
+{-----------------------------------------------------------------------------
+    Encrypted private keys
+------------------------------------------------------------------------------}
+-- | Internal.
+--
+-- Make an 'EncryptedXPrv' from an encrypted 'XPrv'
+-- by also signing a passphrase.
+mkEncryptedXPrv : Passphrase → ByteString → XPrv → EncryptedXPrv
+mkEncryptedXPrv pass saltToSign xprv = record
+  { encryptedXPrv = xprv
+  ; salt = saltToSign
+  ; saltSigned = CC.sign pass xprv saltToSign
+  }
+
+{-# COMPILE AGDA2HS mkEncryptedXPrv #-}
+
+-- | Internal.
+-- Decrypt an encrypted 'XPrv' regardless of whether the passphrase
+-- is correct.
+decryptXPrv : Passphrase → XPrv → XPrv
+decryptXPrv pass = CC.xPrvChangePass pass BS.empty
+
+-- | Check whether this 'Passphrase' decrypts the given 'EncryptedXPrv'.
+--
+-- TODO: Don't decrypt the key here for checking!!
+-- Instead, simply check signatures for equality.
+--
+check : Passphrase → EncryptedXPrv → Bool
+check pass key = verify xpub (salt key) (saltSigned key)
+  where
+    xpub = CC.toXPub $ decryptXPrv pass (encryptedXPrv key)
+
+-- | Decrypt the encrypted private key.
+--
+-- Try not to use this function, as the decrypted key may linger in memory.
+-- See note at 'EncryptedXPrv'.
+decrypt : Passphrase → EncryptedXPrv → Maybe XPrv
+decrypt pass key =
+  if check pass key
+  then Just (decryptXPrv pass $ encryptedXPrv key)
+  else Nothing
+
+-- | Encrypt a plaintext private key
+-- using a passphrase and a salt.
+encrypt : Passphrase → ByteString → XPrv → EncryptedXPrv
+encrypt pass saltToSign =
+  mkEncryptedXPrv pass saltToSign ∘ CC.xPrvChangePass BS.empty pass
+
+-- | Obtain the public key corresponding to a private key.
+--
+toXPub : Passphrase → EncryptedXPrv → Maybe XPub
+toXPub pass key = CC.toXPub <$> decrypt pass key
+
+-- | Sign a sequence of bytes with a private key.
+sign : Passphrase → EncryptedXPrv → ByteString → Maybe XSignature
+sign pass key msg =
+    if check pass key
+    then Just (CC.sign pass (encryptedXPrv key) msg)
+    else Nothing
+
+{-# COMPILE AGDA2HS check #-}
+{-# COMPILE AGDA2HS decryptXPrv #-}
+{-# COMPILE AGDA2HS decrypt #-}
+{-# COMPILE AGDA2HS encrypt #-}
+{-# COMPILE AGDA2HS toXPub #-}
+{-# COMPILE AGDA2HS sign #-}
+
+{-----------------------------------------------------------------------------
+    Properties
+    Internal
+------------------------------------------------------------------------------}
+-- | 'mkEncryptedXPrv' will generate a key that matches the
+-- given passphrase.
+prop-check-mkEncryptedXPrv
+  : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
+  → check pass (mkEncryptedXPrv pass salt xprv)
+    ≡ True
+--
+prop-check-mkEncryptedXPrv pass salt xprv
+  rewrite sym (CC.prop-sign-xPrvChangePass pass BS.empty xprv salt)
+  = prop-verify-sign (decryptXPrv pass xprv) salt
+
+-- | Decrypting 'mkEncryptedXPrv' will yield
+-- the decrypted key.
+prop-decrypt-mkEncryptedXPrv
+  : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
+  → decrypt pass (mkEncryptedXPrv pass salt xprv)
+    ≡ Just (decryptXPrv pass xprv)
+--
+prop-decrypt-mkEncryptedXPrv pass salt xprv
+  rewrite prop-check-mkEncryptedXPrv pass salt xprv
+  = refl
+
+{-----------------------------------------------------------------------------
+    Properties
+    Exported
+------------------------------------------------------------------------------}
+-- | A key matches a passphrase iff it can be decrypted.
+prop-check-decrypt
+  : ∀ (key : EncryptedXPrv) (pass : Passphrase)
+  → check pass key
+    ≡ isJust (decrypt pass key)
+--
+prop-check-decrypt key pass
+  with check pass key
+... | True = refl
+... | False = refl
+
+-- | Decrypting an encrypted 'XPrv' will return the original.
+prop-decrypt-encrypt
+  : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
+  → decrypt pass (encrypt pass salt xprv)
+    ≡ Just xprv
+--
+prop-decrypt-encrypt pass salt xprv
+  rewrite prop-decrypt-mkEncryptedXPrv pass salt (CC.xPrvChangePass BS.empty pass xprv)
+  rewrite CC.prop-xPrvChangePass-trans pass BS.empty pass xprv
+  rewrite CC.prop-xPrvChangePass-refl pass xprv
+  = refl
+
+-- | The extended public key can be obtained by first decrypting the key
+-- and then taking extended public key.
+prop-toXPub-decrypt
+  : ∀ (key : EncryptedXPrv) (pass : Passphrase)
+  → toXPub pass key
+    ≡ (BIP32_Ed25519.toXPub <$> decrypt pass key)
+--
+prop-toXPub-decrypt key pass = refl
+
+-- | Signing with an encrypted key is the same as signing with
+-- the unencrypted key.
+prop-sign-decrypt
+  : ∀ (key : EncryptedXPrv) (pass : Passphrase) (msg : ByteString)
+  → sign pass key msg
+    ≡ ((λ xprv → BIP32_Ed25519.sign xprv msg) <$> decrypt pass key)
+--
+prop-sign-decrypt key pass msg
+  with check pass key
+... | True = cong Just (sym (CC.prop-sign-xPrvChangePass pass BS.empty (encryptedXPrv key) msg))
+... | False = refl
+
+{-----------------------------------------------------------------------------
+    Serialization
+------------------------------------------------------------------------------}
+-- | Serialize an 'EncryptedXPrv'.
+--
+-- TODO: Choose a different serialization format so that we can deserialize
+-- again.
+rawSerialiseEncryptedXPrv : EncryptedXPrv → ByteString
+rawSerialiseEncryptedXPrv key =
+  CC.unXPrv (encryptedXPrv key)
+  <> salt key
+  <> CC.unXSignature (saltSigned key)
+
+{-# COMPILE AGDA2HS rawSerialiseEncryptedXPrv #-}
+
+{-----------------------------------------------------------------------------
+    Key derivation
+------------------------------------------------------------------------------}
+-- | Derive a child extended private key according to the
+-- [BIP-32_Ed25519](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf) standard.
+deriveEncryptedXPrvSoft
+  : Passphrase → EncryptedXPrv → Word31 → Maybe EncryptedXPrv
+deriveEncryptedXPrvSoft pass key ix =
+  if check pass key
+  then Just
+    $ mkEncryptedXPrv pass (salt key)
+    $ CC.deriveXPrv
+        CC.DerivationScheme2
+        pass
+        (encryptedXPrv key)
+        (CC.word32fromWord31Low ix)
+  else Nothing
+
+-- | Derive a hardened child extended private key according to the
+-- [BIP-32_Ed25519](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf) standard.
+deriveEncryptedXPrvHard
+  : Passphrase → EncryptedXPrv → Word31 → Maybe EncryptedXPrv
+deriveEncryptedXPrvHard pass key ix =
+  if check pass key
+  then Just
+    $ mkEncryptedXPrv pass (salt key)
+    $ CC.deriveXPrv
+        CC.DerivationScheme2
+        pass
+        (encryptedXPrv key)
+        (CC.word32fromWord31High ix)
+  else Nothing
+
+-- | Derive an extended private key from a root private key
+-- along a path as described in the
+-- [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#user-content-The_key_tree) standard.
+--
+deriveEncryptedXPrvBIP32Path
+  : Passphrase → EncryptedXPrv → BIP32Path → Maybe EncryptedXPrv
+deriveEncryptedXPrvBIP32Path pass key BIP32Path.Root = Just key
+deriveEncryptedXPrvBIP32Path pass key (BIP32Path.Segment path Hardened ix) =
+  deriveEncryptedXPrvBIP32Path pass key path
+    >>= λ key' → deriveEncryptedXPrvHard pass key' ix
+deriveEncryptedXPrvBIP32Path pass key (BIP32Path.Segment path Soft ix) =
+  deriveEncryptedXPrvBIP32Path pass key path
+    >>= λ key' → deriveEncryptedXPrvSoft pass key' ix
+
+{-# COMPILE AGDA2HS deriveEncryptedXPrvSoft #-}
+{-# COMPILE AGDA2HS deriveEncryptedXPrvHard #-}
+{-# COMPILE AGDA2HS deriveEncryptedXPrvBIP32Path #-}

--- a/lib/customer-deposit-wallet-pure/agda/Everything.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Everything.agda
@@ -2,6 +2,7 @@ module Everything where
 
 import Cardano.Wallet.Address.BIP32
 import Cardano.Wallet.Address.BIP32_Ed25519
+import Cardano.Wallet.Address.BIP32_Ed25519.Encrypted
 import Cardano.Wallet.Address.Hash
 
 import Cardano.Wallet.Deposit.Pure.TxHistory

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Cardano/Crypto/Wallet.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Cardano/Crypto/Wallet.agda
@@ -13,6 +13,7 @@ open import Haskell.Data.Word.Odd using
   )
 open import Haskell.Data.ByteString using
   ( ByteString
+  ; empty
   )
 
 postulate
@@ -55,3 +56,45 @@ postulate
 postulate
   sign   : ByteString → XPrv → ByteString → XSignature
   verify : XPub → ByteString → XSignature → Bool
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+-- | Password changes with 'xPrvChangePass' are reflexive.
+postulate
+ prop-xPrvChangePass-refl
+  : ∀ (pa : ByteString) (xprv : XPrv)
+  → xPrvChangePass pa pa xprv
+    ≡ xprv
+
+-- | Password changes with 'xPrvChangePass' are transitive.
+postulate
+ prop-xPrvChangePass-trans
+  : ∀ (pa pb pc : ByteString) (xprv : XPrv)
+  → xPrvChangePass pa pb (xPrvChangePass pb pc xprv)
+    ≡ xPrvChangePass pa pc xprv
+
+-- | Password changes with 'xPrvChangePass'
+-- commute with 'sign'.
+postulate
+ prop-sign-xPrvChangePass
+  : ∀ (pa pb : ByteString) (xprv : XPrv) (msg : ByteString)
+  → sign pb (xPrvChangePass pa pb xprv) msg
+    ≡ sign pa xprv msg
+
+-- | Password needs to be changed to the empty 'ByteString'
+-- to get the correct 'XPub'.
+postulate
+ prop-verify-xPrvChangePass
+  : ∀ (xprv : XPrv) (pass : ByteString) (msg : ByteString)
+  → let xpub = toXPub (xPrvChangePass pass empty xprv)
+    in  verify xpub msg (sign pass xprv msg)
+          ≡ True
+
+-- | Password changes with 'xPrvChangePass'
+-- commute with 'deriveXPrv'.
+postulate
+  prop-deriveXPrv-xPrvChangePass
+   : ∀ (pa pb : ByteString) (xprv : XPrv) (ix : Word32)
+   → deriveXPrv DerivationScheme2 pb (xPrvChangePass pa pb xprv) ix
+     ≡ xPrvChangePass pa pb (deriveXPrv DerivationScheme2 pa xprv ix)

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Cardano/Crypto/Wallet.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Cardano/Crypto/Wallet.agda
@@ -37,6 +37,10 @@ postulate
   unXPub : XPub → ByteString
   unXSignature : XSignature → ByteString
 
+  xpub : ByteString → Either String XPub
+  xprv : ByteString → Either String XPrv
+  xsignature : ByteString → Either String XSignature
+
   xpubPublicKey : XPub → ByteString
   toXPub : XPrv → XPub
   xPrvChangePass : ByteString → ByteString → XPrv → XPrv
@@ -59,6 +63,7 @@ postulate
 
 {-----------------------------------------------------------------------------
     Properties
+    xPrvChangePass
 ------------------------------------------------------------------------------}
 -- | Password changes with 'xPrvChangePass' are reflexive.
 postulate
@@ -98,3 +103,25 @@ postulate
    : ∀ (pa pb : ByteString) (xprv : XPrv) (ix : Word32)
    → deriveXPrv DerivationScheme2 pb (xPrvChangePass pa pb xprv) ix
      ≡ xPrvChangePass pa pb (deriveXPrv DerivationScheme2 pa xprv ix)
+
+{-----------------------------------------------------------------------------
+    Properties
+    Serialization
+------------------------------------------------------------------------------}
+-- | 'xpub' always deserializes 'unXPub'.
+postulate
+  prop-xpub-unXPub
+    : ∀ (x : XPub)
+    → xpub (unXPub x) ≡ Right x
+
+-- | 'xprv' always deserializes 'unXPrv'.
+postulate
+  prop-xprv-unXPrv
+    : ∀ (x : XPrv)
+    → xprv (unXPrv x) ≡ Right x
+
+-- | 'xsignature' always deserializes 'unXSignature'.
+postulate
+  prop-xsignature-unXSignature
+    : ∀ (x : XSignature)
+    → xsignature (unXSignature x) ≡ Right x

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -64,6 +64,7 @@ library
   exposed-modules:
     Cardano.Wallet.Address.BIP32
     Cardano.Wallet.Address.BIP32_Ed25519
+    Cardano.Wallet.Address.BIP32_Ed25519.Encrypted
     Cardano.Wallet.Address.Encoding
     Cardano.Wallet.Address.Hash
     Cardano.Wallet.Deposit.Pure.Experimental

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519/Encrypted.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519/Encrypted.hs
@@ -1,0 +1,272 @@
+module Cardano.Wallet.Address.BIP32_Ed25519.Encrypted
+    ( -- * Types
+      Passphrase
+    , EncryptedXPrv
+    , check
+    , decrypt
+      -- $prop-check-decrypt
+    , encrypt
+      -- $prop-decrypt-encrypt
+    , toXPub
+      -- $prop-toXPub-decrypt
+    , sign
+      -- $prop-sign-decrypt
+
+      -- * Serialization
+    , rawSerialiseEncryptedXPrv
+
+      -- * Key derivation
+    , deriveEncryptedXPrvSoft
+    , deriveEncryptedXPrvHard
+    , deriveEncryptedXPrvBIP32Path
+    )
+where
+
+import Cardano.Wallet.Address.BIP32
+    ( BIP32Path (Root, Segment)
+    , DerivationType (Hardened, Soft)
+    )
+import Cardano.Wallet.Address.BIP32_Ed25519 (XPrv, XPub, XSignature, verify)
+import Data.Word.Odd (Word31)
+import qualified Haskell.Cardano.Crypto.Wallet as CC
+    ( DerivationScheme (DerivationScheme2)
+    , XPub
+    , deriveXPrv
+    , sign
+    , toXPub
+    , unXPrv
+    , unXSignature
+    , word32fromWord31High
+    , word32fromWord31Low
+    , xPrvChangePass
+    )
+import Haskell.Data.ByteString (ByteString)
+import qualified Haskell.Data.ByteString as BS (empty)
+import Prelude hiding (null, subtract)
+
+-- |
+-- A passphrase for encrypting a private key.
+-- Any string of bytes is a valid passphrase.
+type Passphrase = ByteString
+
+-- |
+-- Extended private key in memory, encrypted with a passphrase.
+--
+-- The point of encrypting a private key with a passphrase in memory is
+-- that an adversary who has acces to a memory dump of the running program
+-- will have a difficult time trying to extract the key,
+-- unless they can also get access to the passphrase.
+--
+-- Note: Operations are slightly slower than on plain private keys,
+-- because each operation checks whether the passphrase decrypts
+-- the key before operating on it.
+data EncryptedXPrv = EncryptedXPrv
+    { encryptedXPrv :: XPrv
+    , salt :: ByteString
+    , saltSigned :: XSignature
+    }
+
+-- |
+-- Internal.
+--
+-- Make an 'EncryptedXPrv' from an encrypted 'XPrv'
+-- by also signing a passphrase.
+mkEncryptedXPrv
+    :: Passphrase -> ByteString -> XPrv -> EncryptedXPrv
+mkEncryptedXPrv pass saltToSign xprv =
+    EncryptedXPrv xprv saltToSign (CC.sign pass xprv saltToSign)
+
+-- |
+-- Internal.
+-- Decrypt an encrypted 'XPrv' regardless of whether the passphrase
+-- is correct.
+decryptXPrv :: Passphrase -> XPrv -> XPrv
+decryptXPrv pass = CC.xPrvChangePass pass BS.empty
+
+-- |
+-- Check whether this 'Passphrase' decrypts the given 'EncryptedXPrv'.
+--
+-- TODO: Don't decrypt the key here for checking!!
+-- Instead, simply check signatures for equality.
+check :: Passphrase -> EncryptedXPrv -> Bool
+check pass key = verify xpub (salt key) (saltSigned key)
+  where
+    xpub :: CC.XPub
+    xpub = CC.toXPub $ decryptXPrv pass (encryptedXPrv key)
+
+-- |
+-- Decrypt the encrypted private key.
+--
+-- Try not to use this function, as the decrypted key may linger in memory.
+-- See note at 'EncryptedXPrv'.
+decrypt :: Passphrase -> EncryptedXPrv -> Maybe XPrv
+decrypt pass key =
+    if check pass key
+        then Just (decryptXPrv pass $ encryptedXPrv key)
+        else Nothing
+
+-- |
+-- Encrypt a plaintext private key
+-- using a passphrase and a salt.
+encrypt :: Passphrase -> ByteString -> XPrv -> EncryptedXPrv
+encrypt pass saltToSign =
+    mkEncryptedXPrv pass saltToSign . CC.xPrvChangePass BS.empty pass
+
+-- |
+-- Obtain the public key corresponding to a private key.
+toXPub :: Passphrase -> EncryptedXPrv -> Maybe XPub
+toXPub pass key = CC.toXPub <$> decrypt pass key
+
+-- |
+-- Sign a sequence of bytes with a private key.
+sign
+    :: Passphrase -> EncryptedXPrv -> ByteString -> Maybe XSignature
+sign pass key msg =
+    if check pass key
+        then Just (CC.sign pass (encryptedXPrv key) msg)
+        else Nothing
+
+-- |
+-- Serialize an 'EncryptedXPrv'.
+--
+-- TODO: Choose a different serialization format so that we can deserialize
+-- again.
+rawSerialiseEncryptedXPrv :: EncryptedXPrv -> ByteString
+rawSerialiseEncryptedXPrv key =
+    CC.unXPrv (encryptedXPrv key)
+        <> salt key
+        <> CC.unXSignature (saltSigned key)
+
+-- |
+-- Derive a child extended private key according to the
+-- [BIP-32_Ed25519](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf) standard.
+deriveEncryptedXPrvSoft
+    :: Passphrase -> EncryptedXPrv -> Word31 -> Maybe EncryptedXPrv
+deriveEncryptedXPrvSoft pass key ix =
+    if check pass key
+        then
+            Just
+                $ mkEncryptedXPrv pass (salt key)
+                $ CC.deriveXPrv
+                    CC.DerivationScheme2
+                    pass
+                    (encryptedXPrv key)
+                    (CC.word32fromWord31Low ix)
+        else Nothing
+
+-- |
+-- Derive a hardened child extended private key according to the
+-- [BIP-32_Ed25519](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf) standard.
+deriveEncryptedXPrvHard
+    :: Passphrase -> EncryptedXPrv -> Word31 -> Maybe EncryptedXPrv
+deriveEncryptedXPrvHard pass key ix =
+    if check pass key
+        then
+            Just
+                $ mkEncryptedXPrv pass (salt key)
+                $ CC.deriveXPrv
+                    CC.DerivationScheme2
+                    pass
+                    (encryptedXPrv key)
+                    (CC.word32fromWord31High ix)
+        else Nothing
+
+-- |
+-- Derive an extended private key from a root private key
+-- along a path as described in the
+-- [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#user-content-The_key_tree) standard.
+deriveEncryptedXPrvBIP32Path
+    :: Passphrase -> EncryptedXPrv -> BIP32Path -> Maybe EncryptedXPrv
+deriveEncryptedXPrvBIP32Path pass key Root = Just key
+deriveEncryptedXPrvBIP32Path pass key (Segment path Hardened ix) =
+    do
+        key' <- deriveEncryptedXPrvBIP32Path pass key path
+        deriveEncryptedXPrvHard pass key' ix
+deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
+    do
+        key' <- deriveEncryptedXPrvBIP32Path pass key path
+        deriveEncryptedXPrvSoft pass key' ix
+
+-- * Properties
+
+-- $prop-check-decrypt
+-- #p:prop-check-decrypt#
+--
+-- [prop-check-decrypt]:
+--     A key matches a passphrase iff it can be decrypted.
+--
+--     @
+--     prop-check-decrypt
+--       : ∀ (key : EncryptedXPrv) (pass : Passphrase)
+--       → check pass key
+--         ≡ isJust (decrypt pass key)
+--     @
+
+-- $prop-check-mkEncryptedXPrv
+-- #p:prop-check-mkEncryptedXPrv#
+--
+-- [prop-check-mkEncryptedXPrv]:
+--     'mkEncryptedXPrv' will generate a key that matches the
+--     given passphrase.
+--
+--     @
+--     prop-check-mkEncryptedXPrv
+--       : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
+--       → check pass (mkEncryptedXPrv pass salt xprv)
+--         ≡ True
+--     @
+
+-- $prop-decrypt-encrypt
+-- #p:prop-decrypt-encrypt#
+--
+-- [prop-decrypt-encrypt]:
+--     Decrypting an encrypted 'XPrv' will return the original.
+--
+--     @
+--     prop-decrypt-encrypt
+--       : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
+--       → decrypt pass (encrypt pass salt xprv)
+--         ≡ Just xprv
+--     @
+
+-- $prop-decrypt-mkEncryptedXPrv
+-- #p:prop-decrypt-mkEncryptedXPrv#
+--
+-- [prop-decrypt-mkEncryptedXPrv]:
+--     Decrypting 'mkEncryptedXPrv' will yield
+--     the decrypted key.
+--
+--     @
+--     prop-decrypt-mkEncryptedXPrv
+--       : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
+--       → decrypt pass (mkEncryptedXPrv pass salt xprv)
+--         ≡ Just (decryptXPrv pass xprv)
+--     @
+
+-- $prop-sign-decrypt
+-- #p:prop-sign-decrypt#
+--
+-- [prop-sign-decrypt]:
+--     Signing with an encrypted key is the same as signing with
+--     the unencrypted key.
+--
+--     @
+--     prop-sign-decrypt
+--       : ∀ (key : EncryptedXPrv) (pass : Passphrase) (msg : ByteString)
+--       → sign pass key msg
+--         ≡ ((λ xprv → BIP32_Ed25519.sign xprv msg) <$> decrypt pass key)
+--     @
+
+-- $prop-toXPub-decrypt
+-- #p:prop-toXPub-decrypt#
+--
+-- [prop-toXPub-decrypt]:
+--     The extended public key can be obtained by first decrypting the key
+--     and then taking extended public key.
+--
+--     @
+--     prop-toXPub-decrypt
+--       : ∀ (key : EncryptedXPrv) (pass : Passphrase)
+--       → toXPub pass key
+--         ≡ (BIP32_Ed25519.toXPub <$> decrypt pass key)
+--     @

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519/Encrypted.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519/Encrypted.hs
@@ -17,7 +17,9 @@ module Cardano.Wallet.Address.BIP32_Ed25519.Encrypted
 
       -- * Key derivation
     , deriveEncryptedXPrvSoft
+      -- $prop-deriveEncryptedXPrvSoft-decrypt
     , deriveEncryptedXPrvHard
+      -- $prop-deriveEncryptedXPrvHard-decrypt
     , deriveEncryptedXPrvBIP32Path
     )
 where
@@ -241,6 +243,38 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 --       : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
 --       → decrypt pass (mkEncryptedXPrv pass salt xprv)
 --         ≡ Just (decryptXPrv pass xprv)
+--     @
+
+-- $prop-deriveEncryptedXPrvHard-decrypt
+-- #p:prop-deriveEncryptedXPrvHard-decrypt#
+--
+-- [prop-deriveEncryptedXPrvHard-decrypt]:
+--     Key derivation of an encrypted private key
+--     yields the same result as the plain variant.
+--
+--     @
+--     prop-deriveEncryptedXPrvHard-decrypt
+--       : ∀ (pass : Passphrase)
+--           (key : EncryptedXPrv)
+--           (ix : Word31)
+--       → (decrypt pass =<< deriveEncryptedXPrvHard pass key ix)
+--         ≡ ((λ xprv → BIP32_Ed25519.deriveXPrvHard xprv ix) <$> decrypt pass key)
+--     @
+
+-- $prop-deriveEncryptedXPrvSoft-decrypt
+-- #p:prop-deriveEncryptedXPrvSoft-decrypt#
+--
+-- [prop-deriveEncryptedXPrvSoft-decrypt]:
+--     Key derivation of an encrypted private key
+--     yields the same result as the plain variant.
+--
+--     @
+--     prop-deriveEncryptedXPrvSoft-decrypt
+--       : ∀ (pass : Passphrase)
+--           (key : EncryptedXPrv)
+--           (ix : Word31)
+--       → (decrypt pass =<< deriveEncryptedXPrvSoft pass key ix)
+--         ≡ ((λ xprv → BIP32_Ed25519.deriveXPrvSoft xprv ix) <$> decrypt pass key)
 --     @
 
 -- $prop-sign-decrypt

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Cardano/Crypto/Wallet.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Cardano/Crypto/Wallet.hs
@@ -2,6 +2,7 @@
 
 module Haskell.Cardano.Crypto.Wallet
     ( module Cardano.Crypto.Wallet
+    , xpub
     , xPrvChangePass
     , deriveXPrv
     , deriveXPub
@@ -17,6 +18,7 @@ import Cardano.Crypto.Wallet hiding
     , sign
     , verify
     , xPrvChangePass
+    , xpub
     )
 import Data.ByteString
     ( ByteString
@@ -37,6 +39,9 @@ word32fromWord31Low = fromInteger . toInteger
 -- | Convert 'Word31' into 'Word32' with highest bit @1@.
 word32fromWord31High :: Word31 -> Word32
 word32fromWord31High w = 0x80000000 + word32fromWord31Low w
+
+xpub :: ByteString -> Either String XPub
+xpub = CC.xpub
 
 xPrvChangePass :: ByteString -> ByteString -> XPrv -> XPrv
 xPrvChangePass = CC.xPrvChangePass


### PR DESCRIPTION
This pull request implements a data type `EncryptedXPrv` that captures the notion of a private key that was encrypted in memory for an extra layer of protection against eavesdroppers.

The present implementation is essentially an indirection over `Cardano.Crypto.Wallet` from the `cardano-crypto` package, and makes explicit some assumptions and properties from that package.