### PR TITLE
Use `>` instead of `@` in Haddock for properties

### DIFF
--- a/lib/agda2hs-fixer/haskell/Language/Agda2hs/Documentation.hs
+++ b/lib/agda2hs-fixer/haskell/Language/Agda2hs/Documentation.hs
@@ -106,8 +106,8 @@ renderAgdaProperty doc =
   where
     prettyAnchor = "#p:" <> identifier doc <> "#"
     prettyDoc = lines (docString doc)
-    prettyType = ["@"] <> lines (typeSignature doc) <> ["@"]
- 
+    prettyType = map ("> " <>) . lines $ typeSignature doc
+
 dropNewLinesAtEnd :: [Line] -> [Line]
 dropNewLinesAtEnd = reverse . dropWhile (== newline) . reverse
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519/Encrypted.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/BIP32_Ed25519/Encrypted.hs
@@ -217,12 +217,10 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 -- [prop-check-decrypt]:
 --     A key matches a passphrase iff it can be decrypted.
 --
---     @
---     prop-check-decrypt
---       : ∀ (key : EncryptedXPrv) (pass : Passphrase)
---       → check pass key
---         ≡ isJust (decrypt pass key)
---     @
+--     > prop-check-decrypt
+--     >   : ∀ (key : EncryptedXPrv) (pass : Passphrase)
+--     >   → check pass key
+--     >     ≡ isJust (decrypt pass key)
 
 -- $prop-check-mkEncryptedXPrv
 -- #p:prop-check-mkEncryptedXPrv#
@@ -231,12 +229,10 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 --     'mkEncryptedXPrv' will generate a key that matches the
 --     given passphrase.
 --
---     @
---     prop-check-mkEncryptedXPrv
---       : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
---       → check pass (mkEncryptedXPrv pass salt xprv)
---         ≡ True
---     @
+--     > prop-check-mkEncryptedXPrv
+--     >   : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
+--     >   → check pass (mkEncryptedXPrv pass salt xprv)
+--     >     ≡ True
 
 -- $prop-decrypt-encrypt
 -- #p:prop-decrypt-encrypt#
@@ -244,12 +240,10 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 -- [prop-decrypt-encrypt]:
 --     Decrypting an encrypted 'XPrv' will return the original.
 --
---     @
---     prop-decrypt-encrypt
---       : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
---       → decrypt pass (encrypt pass salt xprv)
---         ≡ Just xprv
---     @
+--     > prop-decrypt-encrypt
+--     >   : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
+--     >   → decrypt pass (encrypt pass salt xprv)
+--     >     ≡ Just xprv
 
 -- $prop-decrypt-mkEncryptedXPrv
 -- #p:prop-decrypt-mkEncryptedXPrv#
@@ -258,12 +252,10 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 --     Decrypting 'mkEncryptedXPrv' will yield
 --     the decrypted key.
 --
---     @
---     prop-decrypt-mkEncryptedXPrv
---       : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
---       → decrypt pass (mkEncryptedXPrv pass salt xprv)
---         ≡ Just (decryptXPrv pass xprv)
---     @
+--     > prop-decrypt-mkEncryptedXPrv
+--     >   : ∀ (pass : Passphrase) (salt : ByteString) (xprv : XPrv)
+--     >   → decrypt pass (mkEncryptedXPrv pass salt xprv)
+--     >     ≡ Just (decryptXPrv pass xprv)
 
 -- $prop-deriveEncryptedXPrvHard-decrypt
 -- #p:prop-deriveEncryptedXPrvHard-decrypt#
@@ -272,14 +264,12 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 --     Key derivation of an encrypted private key
 --     yields the same result as the plain variant.
 --
---     @
---     prop-deriveEncryptedXPrvHard-decrypt
---       : ∀ (pass : Passphrase)
---           (key : EncryptedXPrv)
---           (ix : Word31)
---       → (decrypt pass =<< deriveEncryptedXPrvHard pass key ix)
---         ≡ ((λ xprv → BIP32_Ed25519.deriveXPrvHard xprv ix) <$> decrypt pass key)
---     @
+--     > prop-deriveEncryptedXPrvHard-decrypt
+--     >   : ∀ (pass : Passphrase)
+--     >       (key : EncryptedXPrv)
+--     >       (ix : Word31)
+--     >   → (decrypt pass =<< deriveEncryptedXPrvHard pass key ix)
+--     >     ≡ ((λ xprv → BIP32_Ed25519.deriveXPrvHard xprv ix) <$> decrypt pass key)
 
 -- $prop-deriveEncryptedXPrvSoft-decrypt
 -- #p:prop-deriveEncryptedXPrvSoft-decrypt#
@@ -288,14 +278,12 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 --     Key derivation of an encrypted private key
 --     yields the same result as the plain variant.
 --
---     @
---     prop-deriveEncryptedXPrvSoft-decrypt
---       : ∀ (pass : Passphrase)
---           (key : EncryptedXPrv)
---           (ix : Word31)
---       → (decrypt pass =<< deriveEncryptedXPrvSoft pass key ix)
---         ≡ ((λ xprv → BIP32_Ed25519.deriveXPrvSoft xprv ix) <$> decrypt pass key)
---     @
+--     > prop-deriveEncryptedXPrvSoft-decrypt
+--     >   : ∀ (pass : Passphrase)
+--     >       (key : EncryptedXPrv)
+--     >       (ix : Word31)
+--     >   → (decrypt pass =<< deriveEncryptedXPrvSoft pass key ix)
+--     >     ≡ ((λ xprv → BIP32_Ed25519.deriveXPrvSoft xprv ix) <$> decrypt pass key)
 
 -- $prop-deserialize-serializeEncryptedXPrv
 -- #p:prop-deserialize-serializeEncryptedXPrv#
@@ -303,12 +291,10 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 -- [prop-deserialize-serializeEncryptedXPrv]:
 --     'deserializeEncryptedXPrv' always deserializes 'serializeEncryptedXPrv'.
 --
---     @
---     prop-deserialize-serializeEncryptedXPrv
---       : ∀ (x : EncryptedXPrv)
---       → deserializeEncryptedXPrv (serializeEncryptedXPrv x)
---         ≡ Right x
---     @
+--     > prop-deserialize-serializeEncryptedXPrv
+--     >   : ∀ (x : EncryptedXPrv)
+--     >   → deserializeEncryptedXPrv (serializeEncryptedXPrv x)
+--     >     ≡ Right x
 
 -- $prop-sign-decrypt
 -- #p:prop-sign-decrypt#
@@ -317,12 +303,10 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 --     Signing with an encrypted key is the same as signing with
 --     the unencrypted key.
 --
---     @
---     prop-sign-decrypt
---       : ∀ (key : EncryptedXPrv) (pass : Passphrase) (msg : ByteString)
---       → sign pass key msg
---         ≡ ((λ xprv → BIP32_Ed25519.sign xprv msg) <$> decrypt pass key)
---     @
+--     > prop-sign-decrypt
+--     >   : ∀ (key : EncryptedXPrv) (pass : Passphrase) (msg : ByteString)
+--     >   → sign pass key msg
+--     >     ≡ ((λ xprv → BIP32_Ed25519.sign xprv msg) <$> decrypt pass key)
 
 -- $prop-toXPub-decrypt
 -- #p:prop-toXPub-decrypt#
@@ -331,9 +315,7 @@ deriveEncryptedXPrvBIP32Path pass key (Segment path Soft ix) =
 --     The extended public key can be obtained by first decrypting the key
 --     and then taking extended public key.
 --
---     @
---     prop-toXPub-decrypt
---       : ∀ (key : EncryptedXPrv) (pass : Passphrase)
---       → toXPub pass key
---         ≡ (BIP32_Ed25519.toXPub <$> decrypt pass key)
---     @
+--     > prop-toXPub-decrypt
+--     >   : ∀ (key : EncryptedXPrv) (pass : Passphrase)
+--     >   → toXPub pass key
+--     >     ≡ (BIP32_Ed25519.toXPub <$> decrypt pass key)

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Address/Encoding.hs
@@ -119,12 +119,10 @@ compactAddrFromEnterpriseAddr addr =
 --     Two 'EnterpriseAddr' with the same serialized 'CompactAddr' are equal
 --     — assuming that inverting a cryptographic hash is difficult.
 --
---     @
---     @0 prop-compactAddrFromEnterpriseAddr-injective
---       : ∀ (x y : EnterpriseAddr)
---       → compactAddrFromEnterpriseAddr x ≡ compactAddrFromEnterpriseAddr y
---       → x ≡ y
---     @
+--     > @0 prop-compactAddrFromEnterpriseAddr-injective
+--     >   : ∀ (x y : EnterpriseAddr)
+--     >   → compactAddrFromEnterpriseAddr x ≡ compactAddrFromEnterpriseAddr y
+--     >   → x ≡ y
 
 -- $prop-credentialFromXPub-injective
 -- #p:prop-credentialFromXPub-injective#
@@ -134,9 +132,7 @@ compactAddrFromEnterpriseAddr addr =
 --     Two 'XPub' that yield the same credential are equal
 --     — assuming that inverting a cryptographic hash is difficult.
 --
---     @
---     prop-credentialFromXPub-injective
---       : ∀ (x y : XPub)
---       → credentialFromXPub x ≡ credentialFromXPub y
---       → x ≡ y
---     @
+--     > prop-credentialFromXPub-injective
+--     >   : ∀ (x y : XPub)
+--     >   → credentialFromXPub x ≡ credentialFromXPub y
+--     >   → x ≡ y

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -301,13 +301,11 @@ mockMaxLengthChangeAddress s =
 --
 --     Customer addresses are never change addresses.
 --
---     @
---     @0 prop-changeAddress-not-Customer
---       : ∀ (s : AddressState)
---           (addr : Address)
---       → knownCustomerAddress addr s ≡ True
---       → ¬(isChange (newChangeAddress s) addr)
---     @
+--     > @0 prop-changeAddress-not-Customer
+--     >   : ∀ (s : AddressState)
+--     >       (addr : Address)
+--     >   → knownCustomerAddress addr s ≡ True
+--     >   → ¬(isChange (newChangeAddress s) addr)
 
 -- $prop-create-derive
 -- #p:prop-create-derive#
@@ -316,13 +314,11 @@ mockMaxLengthChangeAddress s =
 --     Creating a customer address is deterministic,
 --     and depends essentially on the 'XPub'.
 --
---     @
---     prop-create-derive
---       : ∀ (c : Customer)
---           (s0 : AddressState)
---       → let (address , _) = createAddress c s0
---         in  deriveCustomerAddress (getNetworkTag s0) (stateXPub s0) c ≡ address
---     @
+--     > prop-create-derive
+--     >   : ∀ (c : Customer)
+--     >       (s0 : AddressState)
+--     >   → let (address , _) = createAddress c s0
+--     >     in  deriveCustomerAddress (getNetworkTag s0) (stateXPub s0) c ≡ address
 
 -- $prop-create-known
 -- #p:prop-create-known#
@@ -330,13 +326,11 @@ mockMaxLengthChangeAddress s =
 -- [prop-create-known]:
 --     Creating an address makes it known.
 --
---     @
---     @0 prop-create-known
---       : ∀ (c  : Customer)
---           (s0 : AddressState)
---       → let (address , s1) = createAddress c s0
---         in  knownCustomerAddress address s1 ≡ True
---     @
+--     > @0 prop-create-known
+--     >   : ∀ (c  : Customer)
+--     >       (s0 : AddressState)
+--     >   → let (address , s1) = createAddress c s0
+--     >     in  knownCustomerAddress address s1 ≡ True
 
 -- $prop-isCustomerAddress-deriveCustomerAddress
 -- #p:prop-isCustomerAddress-deriveCustomerAddress#
@@ -345,13 +339,11 @@ mockMaxLengthChangeAddress s =
 --     If an address is a known customer address,
 --     then it was derived from a 'Customer' ID.
 --
---     @
---     @0 prop-isCustomerAddress-deriveCustomerAddress
---       : ∀ (s : AddressState)
---           (addr : Address)
---       → isCustomerAddress s addr ≡ True
---       → ∃ (λ c → addr ≡ deriveCustomerAddress (getNetworkTag s) (getXPub s) c)
---     @
+--     > @0 prop-isCustomerAddress-deriveCustomerAddress
+--     >   : ∀ (s : AddressState)
+--     >       (addr : Address)
+--     >   → isCustomerAddress s addr ≡ True
+--     >   → ∃ (λ c → addr ≡ deriveCustomerAddress (getNetworkTag s) (getXPub s) c)
 
 -- $prop-isOurs
 -- #p:prop-isOurs#
@@ -360,13 +352,11 @@ mockMaxLengthChangeAddress s =
 --     It's ours if it's an internal change address or a known
 --     customer address.
 --
---     @
---     @0 prop-isOurs
---       : ∀ (s : AddressState)
---           (addr : Address)
---       → isOurs s addr
---         ≡ (isChangeAddress s addr || isCustomerAddress s addr)
---     @
+--     > @0 prop-isOurs
+--     >   : ∀ (s : AddressState)
+--     >       (addr : Address)
+--     >   → isOurs s addr
+--     >     ≡ (isChangeAddress s addr || isCustomerAddress s addr)
 
 -- $prop-isOurs-from-isCustomerAddress
 -- #p:prop-isOurs-from-isCustomerAddress#
@@ -374,13 +364,11 @@ mockMaxLengthChangeAddress s =
 -- [prop-isOurs-from-isCustomerAddress]:
 --     If known customer address belongs to the wallet.
 --
---     @
---     @0 prop-isOurs-from-isCustomerAddress
---       : ∀ (s : AddressState)
---           (addr : Address)
---       → isCustomerAddress s addr ≡ True
---       → isOurs s addr ≡ True
---     @
+--     > @0 prop-isOurs-from-isCustomerAddress
+--     >   : ∀ (s : AddressState)
+--     >       (addr : Address)
+--     >   → isCustomerAddress s addr ≡ True
+--     >   → isOurs s addr ≡ True
 
 -- $prop-isOurs-mockMaxLengthChangeAddress-False
 -- #p:prop-isOurs-mockMaxLengthChangeAddress-False#
@@ -388,8 +376,6 @@ mockMaxLengthChangeAddress s =
 -- [prop-isOurs-mockMaxLengthChangeAddress-False]:
 --     'mockMaxLengthChangeAddress' never belongs to the 'AddressState'.
 --
---     @
---     @0 prop-isOurs-mockMaxLengthChangeAddress-False
---       : ∀ (s : AddressState)
---       → isOurs s (mockMaxLengthChangeAddress s) ≡ False
---     @
+--     > @0 prop-isOurs-mockMaxLengthChangeAddress-False
+--     >   : ∀ (s : AddressState)
+--     >   → isOurs s (mockMaxLengthChangeAddress s) ≡ False

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/RollbackWindow.hs
@@ -148,12 +148,10 @@ intersection w1 w2 =
 --
 --     Invariant: 'finality' is always before or equal to the 'tip'.
 --
---     @
---     @0 prop-RollbackWindow-invariant
---       : ∀ {time} {{_ : Ord time}}
---           (w : RollbackWindow time)
---       → (finality w <= tip w) ≡ True
---     @
+--     > @0 prop-RollbackWindow-invariant
+--     >   : ∀ {time} {{_ : Ord time}}
+--     >       (w : RollbackWindow time)
+--     >   → (finality w <= tip w) ≡ True
 
 -- $prop-isJust-rollForward
 -- #p:prop-isJust-rollForward#
@@ -162,12 +160,10 @@ intersection w1 w2 =
 --
 --     'rollForward' returns 'Just' if and only if the tip is moved forward.
 --
---     @
---     @0 prop-isJust-rollForward
---       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
---           (newTip : time) (w : RollbackWindow time)
---       → isJust (rollForward newTip w) ≡ (tip w < newTip)
---     @
+--     > @0 prop-isJust-rollForward
+--     >   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--     >       (newTip : time) (w : RollbackWindow time)
+--     >   → isJust (rollForward newTip w) ≡ (tip w < newTip)
 
 -- $prop-member-finality
 -- #p:prop-member-finality#
@@ -176,12 +172,10 @@ intersection w1 w2 =
 --
 --     The 'finality' is always a 'member' of a 'RollbackWindow'.
 --
---     @
---     @0 prop-member-finality
---       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
---           (w : RollbackWindow time)
---       → member (finality w) w ≡ True
---     @
+--     > @0 prop-member-finality
+--     >   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--     >       (w : RollbackWindow time)
+--     >   → member (finality w) w ≡ True
 
 -- $prop-member-intersection
 -- #p:prop-member-intersection#
@@ -191,14 +185,12 @@ intersection w1 w2 =
 --     A time @t@ is a 'member' of an intersection
 --     if it is a member of both 'RollbackWindow's.
 --
---     @
---     @0 prop-member-intersection
---       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
---           (w1 w2 w3 : RollbackWindow time)
---           (t : time)
---       → intersection w1 w2 ≡ Just w3
---       → member t w3 ≡ (member t w1 && member t w2)
---     @
+--     > @0 prop-member-intersection
+--     >   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--     >       (w1 w2 w3 : RollbackWindow time)
+--     >       (t : time)
+--     >   → intersection w1 w2 ≡ Just w3
+--     >   → member t w3 ≡ (member t w1 && member t w2)
 
 -- $prop-member-singleton
 -- #p:prop-member-singleton#
@@ -207,12 +199,10 @@ intersection w1 w2 =
 --
 --     'singleton' contains exactly one point.
 --
---     @
---     @0 prop-member-singleton
---       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
---           (t1 t2 : time)
---       → member t1 (singleton t2) ≡ (t1 == t2)
---     @
+--     > @0 prop-member-singleton
+--     >   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--     >       (t1 t2 : time)
+--     >   → member t1 (singleton t2) ≡ (t1 == t2)
 
 -- $prop-member-tip
 -- #p:prop-member-tip#
@@ -221,12 +211,10 @@ intersection w1 w2 =
 --
 --     The 'tip' is always a 'member' of a 'RollbackWindow'.
 --
---     @
---     @0 prop-member-tip
---       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
---           (w : RollbackWindow time)
---       → member (tip w) w ≡ True
---     @
+--     > @0 prop-member-tip
+--     >   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--     >       (w : RollbackWindow time)
+--     >   → member (tip w) w ≡ True
 
 -- $prop-rollBackward-Future→tip
 -- #p:prop-rollBackward-Future→tip#
@@ -236,13 +224,11 @@ intersection w1 w2 =
 --     If 'rollBackward' returns 'Future',
 --     then the new tip was more recent than the current tip.
 --
---     @
---     @0 prop-rollBackward-Future→tip
---       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
---           (newTip : time) (w : RollbackWindow time)
---       → rollBackward newTip w ≡ Future
---       → (tip w <= newTip) ≡ True
---     @
+--     > @0 prop-rollBackward-Future→tip
+--     >   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--     >       (newTip : time) (w : RollbackWindow time)
+--     >   → rollBackward newTip w ≡ Future
+--     >   → (tip w <= newTip) ≡ True
 
 -- $prop-rollBackward-tip→Future
 -- #p:prop-rollBackward-tip→Future#
@@ -252,13 +238,11 @@ intersection w1 w2 =
 --     If the new tip is more recent than the current tip,
 --     'rollBackward' returns 'Future'.
 --
---     @
---     prop-rollBackward-tip→Future
---       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
---           (newTip : time) (w : RollbackWindow time)
---       → (tip w <= newTip) ≡ True
---       → rollBackward newTip w ≡ Future
---     @
+--     > prop-rollBackward-tip→Future
+--     >   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--     >       (newTip : time) (w : RollbackWindow time)
+--     >   → (tip w <= newTip) ≡ True
+--     >   → rollBackward newTip w ≡ Future
 
 -- $prop-tip-rollForward
 -- #p:prop-tip-rollForward#
@@ -267,10 +251,8 @@ intersection w1 w2 =
 --
 --     'rollForward' moves the tip to the new tip.
 --
---     @
---     @0 prop-tip-rollForward
---       : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
---           (newTip : time) (w w' : RollbackWindow time)
---       → rollForward newTip w ≡ Just w'
---       → tip w' ≡ newTip
---     @
+--     > @0 prop-tip-rollForward
+--     >   : ∀ {time} {{_ : Ord time}} {{@0 _ : IsLawfulOrd time}}
+--     >       (newTip : time) (w w' : RollbackWindow time)
+--     >   → rollForward newTip w ≡ Just w'
+--     >   → tip w' ≡ newTip

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -89,12 +89,10 @@ concat = foldr append empty
 --     applying each delta in turn (right-to-left),
 --     assuming that the delta and the utxo have disjoint 'TxIn's.
 --
---     @
---     @0 prop-apply-append
---       : ∀ (x y : DeltaUTxO) (utxo : UTxO)
---       → Set.intersection (dom (received y)) (dom utxo) ≡ Set.empty
---       → apply (append x y) utxo ≡ apply x (apply y utxo)
---     @
+--     > @0 prop-apply-append
+--     >   : ∀ (x y : DeltaUTxO) (utxo : UTxO)
+--     >   → Set.intersection (dom (received y)) (dom utxo) ≡ Set.empty
+--     >   → apply (append x y) utxo ≡ apply x (apply y utxo)
 
 -- $prop-apply-empty
 -- #p:prop-apply-empty#
@@ -103,11 +101,9 @@ concat = foldr append empty
 --
 --     Applying the empty delta does nothing.
 --
---     @
---     @0 prop-apply-empty
---       : ∀ (utxo : UTxO)
---       → apply empty utxo ≡ utxo
---     @
+--     > @0 prop-apply-empty
+--     >   : ∀ (utxo : UTxO)
+--     >   → apply empty utxo ≡ utxo
 
 -- $prop-apply-excludingD
 -- #p:prop-apply-excludingD#
@@ -116,12 +112,10 @@ concat = foldr append empty
 --     Applying the 'DeltaUTxO' returned by 'excludingD'
 --     to the argument 'UTxO' yields the result 'UTxO'.
 --
---     @
---     @0 prop-apply-excludingD
---       : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
---       → let (du , u1) = excludingD u0 txins
---         in  apply du u0 ≡ u1
---     @
+--     > @0 prop-apply-excludingD
+--     >   : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
+--     >   → let (du , u1) = excludingD u0 txins
+--     >     in  apply du u0 ≡ u1
 
 -- $prop-apply-receiveD
 -- #p:prop-apply-receiveD#
@@ -130,12 +124,10 @@ concat = foldr append empty
 --     Applying the 'DeltaUTxO' returned by 'receiveD'
 --     to the argument 'UTxO' yields the result 'UTxO'.
 --
---     @
---     @0 prop-apply-receiveD
---       : ∀ {ua : UTxO} {u0 : UTxO}
---       → let (du , u1) = receiveD u0 ua
---         in  apply du u0 ≡ u1
---     @
+--     > @0 prop-apply-receiveD
+--     >   : ∀ {ua : UTxO} {u0 : UTxO}
+--     >   → let (du , u1) = receiveD u0 ua
+--     >     in  apply du u0 ≡ u1
 
 -- $prop-excluding-excludingD
 -- #p:prop-excluding-excludingD#
@@ -143,12 +135,10 @@ concat = foldr append empty
 -- [prop-excluding-excludingD]:
 --     The 'UTxO' returned by 'excludingD' is the same as 'excluding'.
 --
---     @
---     prop-excluding-excludingD
---       : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
---       → let (du , u1) = excludingD u0 txins
---         in  u1 ≡ UTxO.excluding u0 txins
---     @
+--     > prop-excluding-excludingD
+--     >   : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
+--     >   → let (du , u1) = excludingD u0 txins
+--     >     in  u1 ≡ UTxO.excluding u0 txins
 
 -- $prop-union-receiveD
 -- #p:prop-union-receiveD#
@@ -156,9 +146,7 @@ concat = foldr append empty
 -- [prop-union-receiveD]:
 --     The 'UTxO' returned by 'receiveD' is the same as 'union'.
 --
---     @
---     prop-union-receiveD
---       : ∀ {ua : UTxO} {u0 : UTxO}
---       → let (du , u1) = receiveD u0 ua
---         in  u1 ≡ UTxO.union ua u0
---     @
+--     > prop-union-receiveD
+--     >   : ∀ {ua : UTxO} {u0 : UTxO}
+--     >   → let (du , u1) = receiveD u0 ua
+--     >     in  u1 ≡ UTxO.union ua u0

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -113,11 +113,9 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     Taking the union of a 'UTxO' with one of its exclusions
 --     does nothing.
 --
---     @
---     @0 prop-excluding-absorb
---       : ∀ {x : Set.ℙ TxIn} {utxo : UTxO}
---       → (x ⋪ utxo) ∪ utxo ≡ utxo
---     @
+--     > @0 prop-excluding-absorb
+--     >   : ∀ {x : Set.ℙ TxIn} {utxo : UTxO}
+--     >   → (x ⋪ utxo) ∪ utxo ≡ utxo
 
 -- $prop-excluding-difference
 -- #p:prop-excluding-difference#
@@ -127,12 +125,10 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     Excluding the difference is the same as excluding
 --     everything and putting back the difference.
 --
---     @
---     prop-excluding-difference
---       : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
---       → (Set.difference x y) ⋪ utxo
---         ≡ (x ⋪ utxo) ∪ (restrictedBy utxo y)
---     @
+--     > prop-excluding-difference
+--     >   : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
+--     >   → (Set.difference x y) ⋪ utxo
+--     >     ≡ (x ⋪ utxo) ∪ (restrictedBy utxo y)
 
 -- $prop-excluding-dom
 -- #p:prop-excluding-dom#
@@ -141,11 +137,9 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     Excluding the entire domain gives the empty 'UTxO'.
 --
---     @
---     prop-excluding-dom
---       : ∀ {utxo : UTxO}
---       → dom utxo ⋪ utxo ≡ empty
---     @
+--     > prop-excluding-dom
+--     >   : ∀ {utxo : UTxO}
+--     >   → dom utxo ⋪ utxo ≡ empty
 
 -- $prop-excluding-empty
 -- #p:prop-excluding-empty#
@@ -154,11 +148,9 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     Excluding the empty set does nothing.
 --
---     @
---     @0 prop-excluding-empty
---       : ∀ (utxo : UTxO)
---       → excluding utxo Set.empty ≡ utxo
---     @
+--     > @0 prop-excluding-empty
+--     >   : ∀ (utxo : UTxO)
+--     >   → excluding utxo Set.empty ≡ utxo
 
 -- $prop-excluding-excluding
 -- #p:prop-excluding-excluding#
@@ -167,11 +159,9 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     Excluding from an exclusion is the same as excluding the union.
 --
---     @
---     prop-excluding-excluding
---       : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
---       → x ⋪ (y ⋪ utxo) ≡ (Set.union x y) ⋪ utxo
---     @
+--     > prop-excluding-excluding
+--     >   : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
+--     >   → x ⋪ (y ⋪ utxo) ≡ (Set.union x y) ⋪ utxo
 
 -- $prop-excluding-excludingS
 -- #p:prop-excluding-excludingS#
@@ -181,12 +171,10 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     Not excluding inputs makes no difference if these
 --     inputs have nothing in common with the 'UTxO'.
 --
---     @
---     prop-excluding-excludingS
---       : ∀ {x : Set.ℙ TxIn} {ua ub : UTxO}
---       → Set.intersection (dom ua) (dom ub) ≡ Set.empty
---       → (excludingS x ua) ⋪ ub ≡ x ⋪ ub
---     @
+--     > prop-excluding-excludingS
+--     >   : ∀ {x : Set.ℙ TxIn} {ua ub : UTxO}
+--     >   → Set.intersection (dom ua) (dom ub) ≡ Set.empty
+--     >   → (excludingS x ua) ⋪ ub ≡ x ⋪ ub
 
 -- $prop-excluding-intersection
 -- #p:prop-excluding-intersection#
@@ -195,11 +183,9 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     Excluding the intersection is the same as the union of the exclusions.
 --
---     @
---     @0 prop-excluding-intersection
---       : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
---       → (Set.intersection x y) ⋪ utxo ≡ (x ⋪ utxo) ∪ (y ⋪ utxo)
---     @
+--     > @0 prop-excluding-intersection
+--     >   : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
+--     >   → (Set.intersection x y) ⋪ utxo ≡ (x ⋪ utxo) ∪ (y ⋪ utxo)
 
 -- $prop-excluding-sym
 -- #p:prop-excluding-sym#
@@ -208,11 +194,9 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     Excluding two sets of 'TxIn's can be done in either order.
 --
---     @
---     prop-excluding-sym
---       : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
---       → x ⋪ (y ⋪ utxo) ≡ y ⋪ (x ⋪ utxo)
---     @
+--     > prop-excluding-sym
+--     >   : ∀ {x y : Set.ℙ TxIn} {utxo : UTxO}
+--     >   → x ⋪ (y ⋪ utxo) ≡ y ⋪ (x ⋪ utxo)
 
 -- $prop-excluding-union
 -- #p:prop-excluding-union#
@@ -222,11 +206,9 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     Excluding from a union is the same as excluding
 --     from each member of the union.
 --
---     @
---     @0 prop-excluding-union
---       : ∀ {x : Set.ℙ TxIn} {ua ub : UTxO}
---       → x ⋪ (ua ∪ ub) ≡ (x ⋪ ua) ∪ (x ⋪ ub)
---     @
+--     > @0 prop-excluding-union
+--     >   : ∀ {x : Set.ℙ TxIn} {ua ub : UTxO}
+--     >   → x ⋪ (ua ∪ ub) ≡ (x ⋪ ua) ∪ (x ⋪ ub)
 
 -- $prop-filterByAddress-filters
 -- #p:prop-filterByAddress-filters#
@@ -235,14 +217,12 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     Those outputs whose address satisfies the predicate are kept.
 --
---     @
---     prop-filterByAddress-filters
---         : ∀ (p : Address → Bool)
---             (utxo : UTxO) (txin : TxIn) (txout : TxOut)
---         → Map.lookup txin utxo ≡ Just txout
---         → Map.member txin (filterByAddress p utxo)
---             ≡ p (getCompactAddr txout)
---     @
+--     > prop-filterByAddress-filters
+--     >     : ∀ (p : Address → Bool)
+--     >         (utxo : UTxO) (txin : TxIn) (txout : TxOut)
+--     >     → Map.lookup txin utxo ≡ Just txout
+--     >     → Map.member txin (filterByAddress p utxo)
+--     >         ≡ p (getCompactAddr txout)
 
 -- $prop-union-assoc
 -- #p:prop-union-assoc#
@@ -251,11 +231,9 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     'union' is associative.
 --
---     @
---     prop-union-assoc
---       : ∀ {ua ub uc : UTxO}
---       → (ua ∪ ub) ∪ uc ≡ ua ∪ (ub ∪ uc)
---     @
+--     > prop-union-assoc
+--     >   : ∀ {ua ub uc : UTxO}
+--     >   → (ua ∪ ub) ∪ uc ≡ ua ∪ (ub ∪ uc)
 
 -- $prop-union-empty-left
 -- #p:prop-union-empty-left#
@@ -264,11 +242,9 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     'empty' is a left identity of 'union'.
 --
---     @
---     prop-union-empty-left
---       : ∀ {utxo : UTxO}
---       → union empty utxo ≡ utxo
---     @
+--     > prop-union-empty-left
+--     >   : ∀ {utxo : UTxO}
+--     >   → union empty utxo ≡ utxo
 
 -- $prop-union-empty-right
 -- #p:prop-union-empty-right#
@@ -277,8 +253,6 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     'empty' is a right identity of 'union'.
 --
---     @
---     prop-union-empty-right
---       : ∀ {utxo : UTxO}
---       → union utxo empty ≡ utxo
---     @
+--     > prop-union-empty-right
+--     >   : ∀ {utxo : UTxO}
+--     >   → union utxo empty ≡ utxo

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Core.hs
@@ -286,12 +286,10 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 -- [prop-rollBackward-future]:
 --     Rolling backward to the future does nothing.
 --
---     @
---     prop-rollBackward-future
---       : ∀ (u : UTxOHistory) (slot : Slot)
---       → (getTip u <= slot) ≡ True
---       → rollBackward slot u ≡ u
---     @
+--     > prop-rollBackward-future
+--     >   : ∀ (u : UTxOHistory) (slot : Slot)
+--     >   → (getTip u <= slot) ≡ True
+--     >   → rollBackward slot u ≡ u
 
 -- $prop-rollBackward-rollForward-cancel
 -- #p:prop-rollBackward-rollForward-cancel#
@@ -300,13 +298,11 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 --     /Essential property:/
 --     Rolling backward will cancel rolling forward.
 --
---     @
---     @0 prop-rollBackward-rollForward-cancel
---       : ∀ (u : UTxOHistory) (du : DeltaUTxO) (slot1 : Slot) (slot2 : SlotNo)
---       → (slot1 < WithOrigin.At slot2) ≡ True
---       → rollBackward slot1 (rollForward slot2 du u)
---         ≡ rollBackward slot1 u
---     @
+--     > @0 prop-rollBackward-rollForward-cancel
+--     >   : ∀ (u : UTxOHistory) (du : DeltaUTxO) (slot1 : Slot) (slot2 : SlotNo)
+--     >   → (slot1 < WithOrigin.At slot2) ≡ True
+--     >   → rollBackward slot1 (rollForward slot2 du u)
+--     >     ≡ rollBackward slot1 u
 
 -- $prop-rollBackward-tip
 -- #p:prop-rollBackward-tip#
@@ -315,11 +311,9 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 --     Rolling backward to the tip does nothing, as we are already at the tip.
 --     Special case of __prop-rollBackward-future__.
 --
---     @
---     prop-rollBackward-tip
---       : ∀ (u : UTxOHistory)
---       → rollBackward (getTip u) u ≡ u
---     @
+--     > prop-rollBackward-tip
+--     >   : ∀ (u : UTxOHistory)
+--     >   → rollBackward (getTip u) u ≡ u
 
 -- $prop-rollBackward-tip-rollForward
 -- #p:prop-rollBackward-tip-rollForward#
@@ -327,11 +321,9 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 -- [prop-rollBackward-tip-rollForward]:
 --     Rolling backward after a 'rollForward' will restore the original state.
 --
---     @
---     @0 prop-rollBackward-tip-rollForward
---       : ∀ (u : UTxOHistory) (du : DeltaUTxO) (slot : SlotNo)
---       → rollBackward (getTip u) (rollForward slot du u) ≡ u
---     @
+--     > @0 prop-rollBackward-tip-rollForward
+--     >   : ∀ (u : UTxOHistory) (du : DeltaUTxO) (slot : SlotNo)
+--     >   → rollBackward (getTip u) (rollForward slot du u) ≡ u
 
 -- $prop-rollForward-present
 -- #p:prop-rollForward-present#
@@ -339,9 +331,7 @@ applyDeltaUTxOHistory (Prune newFinality) = prune newFinality
 -- [prop-rollForward-present]:
 --     Rolling forward to the tip or before the tip does nothing.
 --
---     @
---     @0 prop-rollForward-present
---       : ∀ (u : UTxOHistory) (du : DeltaUTxO) (slot : SlotNo)
---       → (WithOrigin.At slot <= getTip u) ≡ True
---       → rollForward slot du u ≡ u
---     @
+--     > @0 prop-rollForward-present
+--     >   : ∀ (u : UTxOHistory) (du : DeltaUTxO) (slot : SlotNo)
+--     >   → (WithOrigin.At slot <= getTip u) ≡ True
+--     >   → rollForward slot du u ≡ u

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxOHistory/Timeline.hs
@@ -170,10 +170,8 @@ pruneBefore newFinality old =
 --     Rolling backward will cancel rolling forward.
 --     Bare version.
 --
---     @
---     @0 prop-insertDeltaUTxO-dropAfter-cancel
---       : ∀ (u : TimelineUTxO) (du : DeltaUTxO) (slot1 : Slot) (slot2 : SlotNo)
---       → (slot1 < WithOrigin.At slot2) ≡ True
---       → dropAfter slot1 (insertDeltaUTxO slot2 du u)
---         ≡ dropAfter slot1 u
---     @
+--     > @0 prop-insertDeltaUTxO-dropAfter-cancel
+--     >   : ∀ (u : TimelineUTxO) (du : DeltaUTxO) (slot1 : Slot) (slot2 : SlotNo)
+--     >   → (slot1 < WithOrigin.At slot2) ≡ True
+--     >   → dropAfter slot1 (insertDeltaUTxO slot2 du u)
+--     >     ≡ dropAfter slot1 u

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/ValueTransfer.hs
@@ -45,8 +45,6 @@ instance Monoid ValueTransfer where
 --
 --     'ValueTransfer' is a commutative semigroup.
 --
---     @
---     prop-ValueTansfer-<>-comm
---       : ∀ (x y : ValueTransfer)
---       → x <> y ≡ y <> x
---     @
+--     > prop-ValueTansfer-<>-comm
+--     >   : ∀ (x y : ValueTransfer)
+--     >   → x <> y ≡ y <> x

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Maybe.hs
@@ -36,12 +36,10 @@ intersectionWith _ _ _ = Nothing
 --
 --     If the predicate is not constant, there are counterexamples.
 --
---     @
---     prop-filt-||
---       : ∀ (x y : Bool) {m : Maybe a}
---       → filt (x || y) m
---         ≡ union (filt x m) (filt y m)
---     @
+--     > prop-filt-||
+--     >   : ∀ (x y : Bool) {m : Maybe a}
+--     >   → filt (x || y) m
+--     >     ≡ union (filt x m) (filt y m)
 
 -- $prop-filter-filt
 -- #p:prop-filter-filt#
@@ -50,12 +48,10 @@ intersectionWith _ _ _ = Nothing
 --
 --     'filt' is a special case of 'filter'.
 --
---     @
---     prop-filter-filt
---       : ∀ (b : Bool) (m : Maybe a)
---       → filter (λ x → b) m
---         ≡ filt b m
---     @
+--     > prop-filter-filt
+--     >   : ∀ (b : Bool) (m : Maybe a)
+--     >   → filter (λ x → b) m
+--     >     ≡ filt b m
 
 -- $prop-filter-union
 -- #p:prop-filter-union#
@@ -67,13 +63,11 @@ intersectionWith _ _ _ = Nothing
 --
 --     If the predicate is not constant, there are counterexamples.
 --
---     @
---     prop-filter-union
---       : ∀ (p : a → Bool) {m1 m2 : Maybe a}
---       → (∀ (x y : a) → p x ≡ p y)
---       → filter p (union m1 m2)
---         ≡ union (filter p m1) (filter p m2)
---     @
+--     > prop-filter-union
+--     >   : ∀ (p : a → Bool) {m1 m2 : Maybe a}
+--     >   → (∀ (x y : a) → p x ≡ p y)
+--     >   → filter p (union m1 m2)
+--     >     ≡ union (filter p m1) (filter p m2)
 
 -- $prop-union-sym
 -- #p:prop-union-sym#
@@ -81,12 +75,10 @@ intersectionWith _ _ _ = Nothing
 -- [prop-union-sym]:
 --     'union' is symmetric if at most one argument is 'Just'.
 --
---     @
---     prop-union-sym
---       : ∀ {ma mb : Maybe a}
---       → disjoint ma mb ≡ True
---       → union ma mb ≡ union mb ma
---     @
+--     > prop-union-sym
+--     >   : ∀ {ma mb : Maybe a}
+--     >   → disjoint ma mb ≡ True
+--     >   → union ma mb ≡ union mb ma
 
 -- $prop-unionWith-sym
 -- #p:prop-unionWith-sym#
@@ -95,8 +87,6 @@ intersectionWith _ _ _ = Nothing
 --     'unionWith' is symmetric if we 'flip' the function.
 --     Note that 'union' is left-biased, not symmetric.
 --
---     @
---     prop-unionWith-sym
---       : ∀ {f : a → a → a} {ma mb : Maybe a}
---       → unionWith f ma mb ≡ unionWith (flip f) mb ma
---     @
+--     > prop-unionWith-sym
+--     >   : ∀ {f : a → a → a} {ma mb : Maybe a}
+--     >   → unionWith f ma mb ≡ unionWith (flip f) mb ma


### PR DESCRIPTION
This pull request changes the Haddock documentation for properties to use bird tracks `>` instead of `@`, as the latter introduce unwanted formatting when the type signature of the property involves special symbols such as `@`, `<`, `>`.