### PR TITLE
Add `DeltaUTxO` properties to documentation

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -16,7 +16,6 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
 open import Haskell.Reasoning
 open import Haskell.Prelude hiding
     ( null
-    ; concat
     )
 
 open import Cardano.Wallet.Deposit.Pure.UTxO.UTxO using
@@ -106,8 +105,8 @@ append x y = record
     received'y = UTxO.excluding (received y) (excluded x)
 
 -- | Combine a sequence of 'DeltaUTxO' using `append`
-concat : List DeltaUTxO → DeltaUTxO
-concat = foldr append empty
+appends : List DeltaUTxO → DeltaUTxO
+appends = foldr append empty
 
 {-# COMPILE AGDA2HS DeltaUTxO #-}
 {-# COMPILE AGDA2HS null #-}
@@ -116,7 +115,7 @@ concat = foldr append empty
 {-# COMPILE AGDA2HS excludingD #-}
 {-# COMPILE AGDA2HS receiveD #-}
 {-# COMPILE AGDA2HS append #-}
-{-# COMPILE AGDA2HS concat #-}
+{-# COMPILE AGDA2HS appends #-}
 
 {-----------------------------------------------------------------------------
     Properties
@@ -291,9 +290,9 @@ prop-apply-append x y utxo cond =
       ∎
 
 --
--- Unit test for 'concat'.
-prop-concat-two
+-- Unit test for 'appends'.
+prop-appends-two
   : ∀ (x y : DeltaUTxO)
-  → concat (x ∷ y ∷ []) ≡ append x (append y empty)
+  → appends (x ∷ y ∷ []) ≡ append x (append y empty)
 --
-prop-concat-two x y = refl
+prop-appends-two x y = refl

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -257,7 +257,7 @@ prop-apply-receiveD {ua} {u0} =
 --
 @0 prop-apply-append
   : ∀ (x y : DeltaUTxO) (utxo : UTxO)
-  → Set.intersection (dom (received y)) (dom utxo) ≡ Set.empty
+  → UTxO.disjoint (received y) utxo ≡ True
   → apply (append x y) utxo ≡ apply x (apply y utxo)
 --
 prop-apply-append x y utxo cond =

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -1,15 +1,22 @@
 {-# OPTIONS --erasure #-}
 
 module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
-    {-
-    ; DeltaUTxO
+    {-|
+    ; DeltaUTxO (..)
       ; null
+        ; prop-null-empty
       ; empty
+        ; prop-apply-empty
       ; apply
       ; excludingD
+        ; prop-excluding-excludingD
+        ; prop-apply-excludingD
       ; receiveD
-      ; instance Semigroup DeltaUTxO
-      ; instance Monoid DeltaUTxO
+        ; prop-union-receiveD
+        ; prop-apply-receiveD
+      ; append
+        ; prop-apply-append
+      ; appends
     -}
     where
 
@@ -36,7 +43,7 @@ import Haskell.Data.Map as Map
 import Haskell.Data.Set as Set
 
 {-----------------------------------------------------------------------------
-    DeltaUTxO
+    Type and Functions
 ------------------------------------------------------------------------------}
 -- | Representation of a change (delta) to a 'UTxO'.
 --
@@ -127,7 +134,8 @@ lemma-intro-DeltaUTxO-≡
   → dd ≡ record { excluded = a; received = b }
 lemma-intro-DeltaUTxO-≡ dd refl refl = refl
 
---
+-- |
+-- 'null' tests whether the delta is 'empty'.
 prop-null-empty
   : ∀ (du : DeltaUTxO)
   → null du ≡ True
@@ -146,7 +154,7 @@ prop-null-empty du eq =
     lem2 = projr (prop-&&-⋀ eq)
 
 -- |
--- Applying the empty delta does nothing.
+-- Applying the 'empty' delta does nothing.
 @0 prop-apply-empty
   : ∀ (utxo : UTxO)
   → apply empty utxo ≡ utxo

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
@@ -296,7 +296,7 @@ postulate
 postulate
  prop-restrictedBy-disjoint
   : ∀ {x : Set.ℙ TxIn} {utxo : UTxO} 
-  → Set.intersection x (dom utxo) ≡ Set.empty
+  → Set.disjoint x (dom utxo) ≡ True
   → restrictedBy utxo x ≡ empty
 --
 
@@ -354,7 +354,7 @@ postulate
 --
 prop-excluding-excludingS
   : ∀ {x : Set.ℙ TxIn} {ua ub : UTxO}
-  → Set.intersection (dom ua) (dom ub) ≡ Set.empty
+  → disjoint ua ub ≡ True
   → (excludingS x ua) ⋪ ub ≡ x ⋪ ub
 --
 prop-excluding-excludingS {x} {ua} {ub} cond =
@@ -364,11 +364,20 @@ prop-excluding-excludingS {x} {ua} {ub} cond =
     ((Set.difference x (dom ua)) ⋪ ub)
   ≡⟨ prop-excluding-difference ⟩
     ((x ⋪ ub) ∪ restrictedBy ub (dom ua))
-  ≡⟨ cong (λ o → (x ⋪ ub) ∪ o) (prop-restrictedBy-disjoint {dom ua} {ub} cond) ⟩
+  ≡⟨ cong (λ o → (x ⋪ ub) ∪ o) (prop-restrictedBy-disjoint {dom ua} {ub} lem1) ⟩
     (x ⋪ ub) ∪ empty
   ≡⟨ prop-union-empty-right {x ⋪ ub} ⟩
     (x ⋪ ub)
   ∎
+ where
+  lem1 =
+    begin
+      Set.disjoint (dom ua) (dom ub)
+    ≡⟨ sym prop-disjoint-dom ⟩
+      disjoint ua ub
+    ≡⟨ cond ⟩
+      True
+    ∎
 
 -- |
 -- Those outputs whose address satisfies the predicate are kept.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -108,7 +108,7 @@ appends = foldr append empty
 --
 --     > @0 prop-apply-append
 --     >   : ∀ (x y : DeltaUTxO) (utxo : UTxO)
---     >   → Set.intersection (dom (received y)) (dom utxo) ≡ Set.empty
+--     >   → UTxO.disjoint (received y) utxo ≡ True
 --     >   → apply (append x y) utxo ≡ apply x (apply y utxo)
 
 -- $prop-apply-empty

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -75,8 +75,8 @@ append x y =
 
 -- |
 -- Combine a sequence of 'DeltaUTxO' using `append`
-concat :: [DeltaUTxO] -> DeltaUTxO
-concat = foldr append empty
+appends :: [DeltaUTxO] -> DeltaUTxO
+appends = foldr append empty
 
 -- * Properties
 

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -1,6 +1,23 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
-module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO where
+module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
+    ( DeltaUTxO (..)
+    , null
+      -- $prop-null-empty
+    , empty
+      -- $prop-apply-empty
+    , apply
+    , excludingD
+      -- $prop-excluding-excludingD
+      -- $prop-apply-excludingD
+    , receiveD
+      -- $prop-union-receiveD
+      -- $prop-apply-receiveD
+    , append
+      -- $prop-apply-append
+    , appends
+    )
+where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO, dom)
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
@@ -99,7 +116,7 @@ appends = foldr append empty
 --
 -- [prop-apply-empty]:
 --
---     Applying the empty delta does nothing.
+--     Applying the 'empty' delta does nothing.
 --
 --     > @0 prop-apply-empty
 --     >   : ∀ (utxo : UTxO)
@@ -139,6 +156,18 @@ appends = foldr append empty
 --     >   : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
 --     >   → let (du , u1) = excludingD u0 txins
 --     >     in  u1 ≡ UTxO.excluding u0 txins
+
+-- $prop-null-empty
+-- #p:prop-null-empty#
+--
+-- [prop-null-empty]:
+--
+--     'null' tests whether the delta is 'empty'.
+--
+--     > prop-null-empty
+--     >   : ∀ (du : DeltaUTxO)
+--     >   → null du ≡ True
+--     >   → du ≡ empty
 
 -- $prop-union-receiveD
 -- #p:prop-union-receiveD#

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -193,7 +193,7 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --
 --     > prop-excluding-excludingS
 --     >   : ∀ {x : Set.ℙ TxIn} {ua ub : UTxO}
---     >   → Set.intersection (dom ua) (dom ub) ≡ Set.empty
+--     >   → disjoint ua ub ≡ True
 --     >   → (excludingS x ua) ⋪ ub ≡ x ⋪ ub
 
 -- $prop-excluding-intersection


### PR DESCRIPTION
This pull request adds properties of `DeltaUTxO` to the documentation of the Haskell code. This pull request also performs a small cleanup by using `UTxO.disjoint` in preconditions, as opposed to the more verbose `Set.intersection` of the domains.