### PR TITLE
Add predicate `DeltaUTxO.fits`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -13,6 +13,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
       ; excludingD
         ; prop-excluding-excludingD
         ; prop-apply-excludingD
+        ; prop-fits-excludingD
       ; receiveD
         ; prop-union-receiveD
         ; prop-apply-receiveD
@@ -240,6 +241,18 @@ prop-apply-excludingD {txins} {u0} =
   where
     du = fst (excludingD u0 txins)
     u1 = snd (excludingD u0 txins)
+
+-- |
+-- The 'DeltaUTxO' returned by 'excludingD' 'fits' the 'UTxO'.
+prop-fits-excludingD
+  : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
+  → let (du , u1) = excludingD u0 txins
+    in  fits du u0 ≡ True
+--
+prop-fits-excludingD {txins} {u0}
+  rewrite UTxO.prop-disjoint-empty {u0}
+  rewrite Set.prop-intersection-isSubsetOf {TxIn} {txins} {dom u0}
+  = refl
 
 -- | The 'UTxO' returned by 'receiveD' is the same as 'union'.
 --

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -17,6 +17,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
       ; receiveD
         ; prop-union-receiveD
         ; prop-apply-receiveD
+        ; prop-fits-receiveD
       ; append
         ; prop-apply-append
       ; appends
@@ -284,6 +285,21 @@ prop-apply-receiveD {ua} {u0} =
   where
     du = fst (receiveD u0 ua)
     u1 = snd (receiveD u0 ua)
+
+-- |
+-- The 'DeltaUTxO' returned by 'receiveD' 'fits' the 'UTxO',
+-- but only if the 'received' 'UTxO' are 'disjoint'.
+prop-fits-receiveD
+  : ∀ {ua : UTxO} {u0 : UTxO}
+  → UTxO.disjoint ua u0 ≡ True
+  → let (du , u1) = receiveD u0 ua
+    in  fits du u0 ≡ True
+--
+prop-fits-receiveD {ua} {u0} cond
+  rewrite UTxO.prop-disjoint-empty {u0}
+  rewrite Set.prop-isSubsetOf-empty {TxIn} {dom u0}
+  rewrite cond
+  = refl
 
 -- | Defining property of 'append':
 -- Applying the combination of two deltas is the same as

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -4,7 +4,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     {-|
     ; DeltaUTxO (..)
       ; null
-        ; prop-null-empty
+        ; prop-null→empty
       ; empty
         ; prop-apply-empty
       ; apply
@@ -136,16 +136,16 @@ lemma-intro-DeltaUTxO-≡ dd refl refl = refl
 
 -- |
 -- 'null' tests whether the delta is 'empty'.
-prop-null-empty
+prop-null→empty
   : ∀ (du : DeltaUTxO)
   → null du ≡ True
   → du ≡ empty
 --
-prop-null-empty du eq =
+prop-null→empty du eq =
     lemma-intro-DeltaUTxO-≡
       du
-      (Set.prop-null-empty (excluded du) lem1)
-      (Map.prop-null-empty (received du) lem2)
+      (Set.prop-null→empty (excluded du) lem1)
+      (Map.prop-null→empty (received du) lem2)
   where
     lem1 : Set.null (excluded du) ≡ True
     lem1 = projl (prop-&&-⋀ eq)

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -8,6 +8,8 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
       ; empty
         ; prop-apply-empty
       ; apply
+      ; fits
+        ; prop-fits
       ; excludingD
         ; prop-excluding-excludingD
         ; prop-apply-excludingD
@@ -77,6 +79,14 @@ apply : DeltaUTxO → UTxO → UTxO
 apply du utxo =
    UTxO.union (received du) (UTxO.excluding utxo (excluded du))
 
+-- | Test whether a 'DeltaUTxO' fits onto a 'UTxO',
+-- that is whether it removes only existing 'TxIn',
+-- and adds only new 'Cardano.Wallet.Read.Tx.TxOut'.
+fits : DeltaUTxO → UTxO → Bool
+fits du u =
+  Set.isSubsetOf (excluded du) (dom u)
+  && UTxO.disjoint (received du) u
+
 -- | Variant of 'excluding' that also returns a delta.
 excludingD : UTxO → Set.ℙ TxIn → (DeltaUTxO × UTxO)
 excludingD utxo txins =
@@ -119,6 +129,7 @@ appends = foldr append empty
 {-# COMPILE AGDA2HS null #-}
 {-# COMPILE AGDA2HS empty #-}
 {-# COMPILE AGDA2HS apply #-}
+{-# COMPILE AGDA2HS fits #-}
 {-# COMPILE AGDA2HS excludingD #-}
 {-# COMPILE AGDA2HS receiveD #-}
 {-# COMPILE AGDA2HS append #-}
@@ -167,6 +178,17 @@ prop-apply-empty utxo =
   ≡⟨ UTxO.prop-excluding-empty utxo ⟩
     utxo
   ∎
+
+-- |
+-- Definition of 'fits'.
+prop-fits
+  : ∀ (du : DeltaUTxO) (u : UTxO)
+  → fits du u
+    ≡ ( Set.isSubsetOf (excluded du) (dom u)
+        && UTxO.disjoint (received du) u
+      )
+--
+prop-fits du u = refl
 
 --
 @0 lemma-excluding-intersection-dom

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.agda
@@ -272,19 +272,9 @@ prop-union-receiveD {ua} {u0} = refl
   → let (du , u1) = receiveD u0 ua
     in  apply du u0 ≡ u1
 --
-prop-apply-receiveD {ua} {u0} =
-  begin
-    apply du u0
-  ≡⟨⟩
-    (received du) ∪ (excluded du ⋪ u0)
-  ≡⟨ cong (λ o → received du ∪ o) (UTxO.prop-excluding-empty _) ⟩
-    (received du) ∪ u0
-  ≡⟨⟩
-    u1
-  ∎
-  where
-    du = fst (receiveD u0 ua)
-    u1 = snd (receiveD u0 ua)
+prop-apply-receiveD {ua} {u0}
+  rewrite UTxO.prop-excluding-empty u0
+  = refl
 
 -- |
 -- The 'DeltaUTxO' returned by 'receiveD' 'fits' the 'UTxO',

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.agda
@@ -8,6 +8,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.UTxO
       ; dom
       ; disjoint
         ; prop-disjoint-dom
+        ; prop-disjoint-empty
       ; balance
       ; union
         ; prop-union-empty-left
@@ -152,6 +153,25 @@ prop-disjoint-dom
   → disjoint ua ub ≡ Set.disjoint (dom ua) (dom ub)
 --
 prop-disjoint-dom = Map.prop-disjoint-keysSet
+
+-- |
+-- The 'empty' 'UTxO' is always 'disjoint'.
+prop-disjoint-empty
+  : ∀ {ua : UTxO}
+  → disjoint empty ua ≡ True
+--
+prop-disjoint-empty {ua} =
+  begin
+    disjoint empty ua
+  ≡⟨ prop-disjoint-dom ⟩
+    Set.null (Set.intersection (dom empty) (dom ua))
+  ≡⟨ cong (λ o → Set.null (Set.intersection o (dom ua))) Map.prop-keysSet-empty ⟩
+    Set.null (Set.intersection Set.empty (dom ua))
+  ≡⟨ cong Set.null Set.prop-intersection-empty-left ⟩
+    Set.null {TxIn} Set.empty
+  ≡⟨ Set.prop-null-empty ⟩
+    True
+  ∎
 
 -- |
 -- 'empty' is a left identity of 'union'.

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Def.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Def.agda
@@ -75,7 +75,7 @@ module _ {k a : Set} {{_ : Ord k}} where
           (_ : ∀ (key : k) → lookup key m ≡ Nothing)
       → null m ≡ True
 
-    prop-null-empty
+    prop-null→empty
       : ∀ (m : Map k a)
       → null m ≡ True
       → m ≡ empty

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
@@ -268,6 +268,22 @@ module _ {k a : Set} {{_ : Ord k}} where
       lem2 = prop-member-null m lem1
 
   --
+  prop-keysSet-empty
+    : keysSet {k} {a} empty ≡ Set.empty {k}
+  --
+  prop-keysSet-empty =
+      Set.prop-null→empty _ lem1
+    where
+      lem1 =
+        begin
+          Set.null (keysSet {k} {a} empty)
+        ≡⟨ prop-null-keysSet ⟩
+          null {k} {a} empty
+        ≡⟨ prop-null-empty ⟩
+          True
+        ∎
+
+  --
   prop-keysSet-intersection
       : ∀ {ma mb : Map k a}
       → keysSet (intersection ma mb)

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
@@ -125,7 +125,7 @@ module _ {k a : Set} {{_ : Ord k}} where
   prop-union-sym {ma} {mb} cond = prop-equality eq-key
     where
       lem1 : intersection ma mb ≡ empty
-      lem1 = prop-null-empty (intersection ma mb) cond
+      lem1 = prop-null→empty (intersection ma mb) cond
 
       lem-disjoint = λ key →
         begin
@@ -237,7 +237,7 @@ module _ {k a : Set} {{_ : Ord k}} where
           Set.member key (keysSet m)
         ≡⟨ prop-member-keysSet ⟩
           member key m
-        ≡⟨ cong (member key) (prop-null-empty m eql) ⟩
+        ≡⟨ cong (member key) (prop-null→empty m eql) ⟩
           member key empty
         ≡⟨ cong isJust (prop-lookup-empty key) ⟩
           False
@@ -251,7 +251,7 @@ module _ {k a : Set} {{_ : Ord k}} where
           member key m
         ≡⟨ sym prop-member-keysSet ⟩
           Set.member key (keysSet m)
-        ≡⟨ cong (Set.member key) (Set.prop-null-empty (keysSet m) eqr) ⟩
+        ≡⟨ cong (Set.member key) (Set.prop-null→empty (keysSet m) eqr) ⟩
           Set.member key Set.empty
         ≡⟨ Set.prop-member-empty key ⟩
           False

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
@@ -38,6 +38,15 @@ module _ {k a : Set} {{_ : Ord k}} where
       lem-isJust {Nothing} refl = refl
 
   --
+  prop-null-empty
+    : null (empty {k} {a}) ≡ True
+  --
+  prop-null-empty =
+    prop-member-null
+      (empty {k} {a})
+      (λ key → cong isJust (prop-lookup-empty key))
+
+  --
   prop-lookup-singleton
     : ∀ (key keyi : k) (x : a)
     → lookup key (singleton keyi x)

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/PairMap.agda
@@ -92,7 +92,7 @@ prop-explicitEmpty-bind x m = case Map.null m of λ
       Nothing
     ≡⟨ sym (Map.prop-lookup-empty x) ⟩
       Map.lookup x Map.empty
-    ≡⟨ cong (λ o → Map.lookup x o) (sym (Map.prop-null-empty m eq)) ⟩
+    ≡⟨ cong (λ o → Map.lookup x o) (sym (Map.prop-null→empty m eq)) ⟩
       Map.lookup x m
     ∎
   ; False {{eq}} →

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
@@ -257,3 +257,11 @@ module _ {a : Set} {{_ : Ord a}} where
         rewrite prop-member-intersection x s1 s2
         = lem1 (member x s1) (member x s2)
  
+  -- |
+  -- The 'empty' set is a subset of every set.
+  prop-isSubsetOf-empty
+    : ∀ {s : ℙ a}
+    → isSubsetOf empty s ≡ True
+  --
+  prop-isSubsetOf-empty {s} =
+    prop-intersection→isSubsetOf empty s prop-intersection-empty-left

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
@@ -206,3 +206,46 @@ module _ {a : Set} {{_ : Ord a}} where
         ≡⟨ sym (prop-member-empty x) ⟩
           member x empty
         ∎
+
+  --
+  prop-intersection-empty-left
+    : ∀ {s : ℙ a}
+    → intersection empty s ≡ empty
+  --
+  prop-intersection-empty-left {s} = prop-equality eq
+    where
+      eq = λ x → begin
+          member x (intersection empty s)
+        ≡⟨ prop-member-intersection x empty s ⟩
+          (member x empty && member x s)
+        ≡⟨ cong (λ o → o && member x s) (prop-member-empty x) ⟩
+          False
+        ≡⟨ sym (prop-member-empty x) ⟩
+          member x empty
+        ∎
+
+  --
+  prop-intersection-isSubsetOf
+    : ∀ {s1 s2 : ℙ a}
+    → isSubsetOf (intersection s1 s2) s2 ≡ True
+  --
+  prop-intersection-isSubsetOf {s1} {s2} =
+      prop-intersection→isSubsetOf _ _ (prop-equality lem2)
+    where
+      lem1
+        : (x y : Bool)
+        → ((x && y) && y) ≡ (x && y)
+      lem1 x y
+        rewrite prop-&&-assoc x y y
+        rewrite prop-&&-idem y
+        = refl
+
+      lem2
+        : ∀ (x : a)
+        → member x (intersection (intersection s1 s2) s2)
+            ≡ member x (intersection s1 s2)
+      lem2 x
+        rewrite prop-member-intersection x (intersection s1 s2) s2
+        rewrite prop-member-intersection x s1 s2
+        = lem1 (member x s1) (member x s2)
+ 

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
@@ -55,7 +55,7 @@ module _ {a : Set} {{_ : Ord a}} where
           (_ : ∀ (x : a) → member x s ≡ False)
       → null s ≡ True
 
-    prop-null-empty
+    prop-null→empty
       : ∀ (s : ℙ a)
       → null s ≡ True
       → s ≡ empty

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Set.agda
@@ -145,6 +145,14 @@ instance
   iSetMonoid = record {DefaultMonoid (record {mempty = empty})}
 
 module _ {a : Set} {{_ : Ord a}} where
+
+  --
+  prop-null-empty
+    : null {a} empty ≡ True
+  --
+  prop-null-empty =
+    prop-member-null empty prop-member-empty 
+
   --
   prop-union-sym
     : ∀ {s1 s2 : ℙ a}

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Reasoning/Bool.agda
@@ -83,6 +83,13 @@ prop-x-||-True False = refl
 {-----------------------------------------------------------------------------
     Algebraic laws for logical connectives
 ------------------------------------------------------------------------------}
+--
+prop-||-idem
+  : ∀ (a : Bool)
+  → (a || a) ≡ a
+--
+prop-||-idem False = refl
+prop-||-idem True = refl
 
 --
 prop-||-sym
@@ -101,6 +108,32 @@ prop-||-assoc
 --
 prop-||-assoc False b c = refl
 prop-||-assoc True b c = refl
+
+--
+prop-&&-idem
+  : ∀ (a : Bool)
+  → (a && a) ≡ a
+--
+prop-&&-idem False = refl
+prop-&&-idem True = refl
+
+--
+prop-&&-sym
+  : ∀ (a b : Bool)
+  → (a && b) ≡ (b && a)
+--
+prop-&&-sym False False = refl
+prop-&&-sym False True = refl
+prop-&&-sym True False = refl
+prop-&&-sym True True = refl
+
+--
+prop-&&-assoc
+  : ∀ (a b c : Bool)
+  → ((a && b) && c) ≡ (a && (b && c))
+--
+prop-&&-assoc False b c = refl
+prop-&&-assoc True b c = refl
 
 --
 prop-deMorgan-not-&&

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -7,6 +7,8 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     , empty
       -- $prop-apply-empty
     , apply
+    , fits
+      -- $prop-fits
     , excludingD
       -- $prop-excluding-excludingD
       -- $prop-apply-excludingD
@@ -21,7 +23,8 @@ where
 
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO (UTxO, dom)
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
-    ( empty
+    ( disjoint
+    , empty
     , excluding
     , excludingS
     , null
@@ -30,7 +33,13 @@ import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 import Cardano.Wallet.Read.Tx (TxIn)
 import Data.Set (Set)
 import qualified Haskell.Data.Map.Def as Map (empty)
-import qualified Haskell.Data.Set as Set (empty, intersection, null, union)
+import qualified Haskell.Data.Set as Set
+    ( empty
+    , intersection
+    , isSubsetOf
+    , null
+    , union
+    )
 import Prelude hiding (null, subtract)
 
 -- |
@@ -56,6 +65,15 @@ empty = DeltaUTxO Set.empty Map.empty
 apply :: DeltaUTxO -> UTxO -> UTxO
 apply du utxo =
     UTxO.union (received du) (UTxO.excluding utxo (excluded du))
+
+-- |
+-- Test whether a 'DeltaUTxO' fits onto a 'UTxO',
+-- that is whether it removes only existing 'TxIn',
+-- and adds only new 'Cardano.Wallet.Read.Tx.TxOut'.
+fits :: DeltaUTxO -> UTxO -> Bool
+fits du u =
+    Set.isSubsetOf (excluded du) (dom u)
+        && UTxO.disjoint (received du) u
 
 -- |
 -- Variant of 'excluding' that also returns a delta.
@@ -156,6 +174,20 @@ appends = foldr append empty
 --     >   : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
 --     >   → let (du , u1) = excludingD u0 txins
 --     >     in  u1 ≡ UTxO.excluding u0 txins
+
+-- $prop-fits
+-- #p:prop-fits#
+--
+-- [prop-fits]:
+--
+--     Definition of 'fits'.
+--
+--     > prop-fits
+--     >   : ∀ (du : DeltaUTxO) (u : UTxO)
+--     >   → fits du u
+--     >     ≡ ( Set.isSubsetOf (excluded du) (dom u)
+--     >         && UTxO.disjoint (received du) u
+--     >       )
 
 -- $prop-null→empty
 -- #p:prop-null→empty#

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -16,6 +16,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     , receiveD
       -- $prop-union-receiveD
       -- $prop-apply-receiveD
+      -- $prop-fits-receiveD
     , append
       -- $prop-apply-append
     , appends
@@ -200,6 +201,20 @@ appends = foldr append empty
 --     > prop-fits-excludingD
 --     >   : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
 --     >   → let (du , u1) = excludingD u0 txins
+--     >     in  fits du u0 ≡ True
+
+-- $prop-fits-receiveD
+-- #p:prop-fits-receiveD#
+--
+-- [prop-fits-receiveD]:
+--
+--     The 'DeltaUTxO' returned by 'receiveD' 'fits' the 'UTxO',
+--     but only if the 'received' 'UTxO' are 'disjoint'.
+--
+--     > prop-fits-receiveD
+--     >   : ∀ {ua : UTxO} {u0 : UTxO}
+--     >   → UTxO.disjoint ua u0 ≡ True
+--     >   → let (du , u1) = receiveD u0 ua
 --     >     in  fits du u0 ≡ True
 
 -- $prop-null→empty

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -12,6 +12,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     , excludingD
       -- $prop-excluding-excludingD
       -- $prop-apply-excludingD
+      -- $prop-fits-excludingD
     , receiveD
       -- $prop-union-receiveD
       -- $prop-apply-receiveD
@@ -188,6 +189,18 @@ appends = foldr append empty
 --     >     ≡ ( Set.isSubsetOf (excluded du) (dom u)
 --     >         && UTxO.disjoint (received du) u
 --     >       )
+
+-- $prop-fits-excludingD
+-- #p:prop-fits-excludingD#
+--
+-- [prop-fits-excludingD]:
+--
+--     The 'DeltaUTxO' returned by 'excludingD' 'fits' the 'UTxO'.
+--
+--     > prop-fits-excludingD
+--     >   : ∀ {txins : Set.ℙ TxIn} {u0 : UTxO}
+--     >   → let (du , u1) = excludingD u0 txins
+--     >     in  fits du u0 ≡ True
 
 -- $prop-null→empty
 -- #p:prop-null→empty#

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/DeltaUTxO.hs
@@ -3,7 +3,7 @@
 module Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     ( DeltaUTxO (..)
     , null
-      -- $prop-null-empty
+      -- $prop-null→empty
     , empty
       -- $prop-apply-empty
     , apply
@@ -157,14 +157,14 @@ appends = foldr append empty
 --     >   → let (du , u1) = excludingD u0 txins
 --     >     in  u1 ≡ UTxO.excluding u0 txins
 
--- $prop-null-empty
--- #p:prop-null-empty#
+-- $prop-null→empty
+-- #p:prop-null→empty#
 --
--- [prop-null-empty]:
+-- [prop-null→empty]:
 --
 --     'null' tests whether the delta is 'empty'.
 --
---     > prop-null-empty
+--     > prop-null→empty
 --     >   : ∀ (du : DeltaUTxO)
 --     >   → null du ≡ True
 --     >   → du ≡ empty

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/UTxO/UTxO.hs
@@ -5,6 +5,7 @@ module Cardano.Wallet.Deposit.Pure.UTxO.UTxO
     , dom
     , disjoint
       -- $prop-disjoint-dom
+      -- $prop-disjoint-empty
     , balance
     , union
       -- $prop-union-empty-left
@@ -124,6 +125,17 @@ filterByAddress p = Map.filter (p . getCompactAddr)
 --     > prop-disjoint-dom
 --     >   : ∀ {ua ub : UTxO}
 --     >   → disjoint ua ub ≡ Set.disjoint (dom ua) (dom ub)
+
+-- $prop-disjoint-empty
+-- #p:prop-disjoint-empty#
+--
+-- [prop-disjoint-empty]:
+--
+--     The 'empty' 'UTxO' is always 'disjoint'.
+--
+--     > prop-disjoint-empty
+--     >   : ∀ {ua : UTxO}
+--     >   → disjoint empty ua ≡ True
 
 -- $prop-excluding-absorb
 -- #p:prop-excluding-absorb#


### PR DESCRIPTION
This pull request adds a predicate

```agda
fits : DeltaUTxO → UTxO → Bool
fits du u =
  Set.isSubsetOf (excluded du) (dom u)
  && UTxO.disjoint (received du) u
```

that describes whether a given `DeltaUTxO` "fits" on top of a given `UTxO` by not removing transaction inputs that are not there, and by not adding transaction inputs that are already there. These conditions will always be satisfied when the `DeltaUTxO` is coming from a new block, but we have to make them explicit.

This predicate will be useful as a precondition for properties of `UTxOHistory`.