### PR TITLE
Add properties to `Data.Maps.Timeline`.

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Map/Law.agda
@@ -315,6 +315,31 @@ module _ {k a : Set} {{_ : Ord k}} where
         ∎
 
   --
+  prop-keysSet-union
+    : ∀ {ma mb : Map k a}
+    → keysSet (union ma mb)
+      ≡ Set.union (keysSet ma) (keysSet mb)
+  -- 
+  prop-keysSet-union {ma} {mb} = Set.prop-equality lem1
+    where
+      lem1
+        : ∀ (key : k)
+        → Set.member key (keysSet (union ma mb))
+          ≡ Set.member key (Set.union (keysSet ma) (keysSet mb))
+      lem1 key
+        rewrite prop-member-keysSet {key} {union ma mb}
+        rewrite prop-lookup-union key ma mb
+        rewrite Set.prop-member-union {k} key (keysSet ma) (keysSet mb)
+        rewrite prop-member-keysSet {key} {ma}
+        rewrite prop-member-keysSet {key} {mb}
+        with lookup key ma
+        with lookup key mb
+      ... | Nothing | Nothing = refl
+      ... | Just a  | Nothing = refl
+      ... | Nothing | Just b  = refl 
+      ... | Just a  | Just b  = refl
+
+  --
   prop-disjoint-keysSet
     : ∀ {ma mb : Map k a}
     → disjoint ma mb

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
@@ -313,6 +313,14 @@ prop-items-insertMany {time} {a} {{_}} {{iOrda}} t ys xs =
     ... | False | False = refl
 
 postulate
+ -- | 'deleteAfter' returns the 'items' that were deleted.
+ prop-fst-snd-deleteAfter
+  : ∀ {{_ : Ord time}} {{_ : Ord a}} {{_ : IsLawfulOrd time}}
+      (t : time) (xs : Timeline time a)
+  → let (deleted , ys) = deleteAfter t xs 
+    in  Set.union deleted (items ys) ≡ items xs
+
+postulate
  -- | 'dropAfter' cancels 'insertMany' from the future.
  prop-dropAfter-insertMany
   : ∀ {{_ : Ord time}} {{_ : Ord a}} {{_ : IsLawfulOrd time}}

--- a/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Haskell/Data/Maps/Timeline.agda
@@ -1,6 +1,39 @@
 {-# OPTIONS --erasure #-}
 
-module Haskell.Data.Maps.Timeline where
+module Haskell.Data.Maps.Timeline
+    {-|
+      -- * Type
+    ; Timeline
+
+      -- * Construction
+    ; empty
+
+      -- * Observation
+    ; lookupByTime
+    ; lookupByItem
+      ; prop-lookupByItem
+
+    ; getMapTime
+    ; items
+        ; prop-items-empty
+
+    ; toAscList
+
+      -- * Operations
+    ; insert
+    ; insertMany
+    ; difference
+    ; restrictRange
+    ; takeWhileAntitone
+    ; dropWhileAntitone
+    ; deleteAfter
+    ; dropAfter
+      ; prop-dropAfter-deleteAfter
+
+      -- * Internal
+    ; insertManyKeys
+    -}
+    where
 
 open import Haskell.Prelude hiding (fromMaybe)
 open import Haskell.Reasoning
@@ -48,6 +81,7 @@ insertManyKeys keys v m0 =
     Timeline
 ------------------------------------------------------------------------------}
 -- | A 'Timeline' is a set of items that are associated with a timestamp.
+--
 -- Each item is unique.
 -- Multiple items can have the same timestamp associated with it.
 record Timeline (time a : Set) {{@0 _ : Ord time}} {{@0 _ : Ord a}} : Set where
@@ -179,8 +213,6 @@ deleteAfter
 deleteAfter t = takeWhileAntitone (_<= t)
 
 -- | Drop all items whose timestamp is after a given time.
---
--- > dropAfter t = snd ∘ deleteAfter t
 dropAfter
     : ∀ {{_ : Ord time}} {{_ : Ord a}}
     → time → Timeline time a → Timeline time a
@@ -212,6 +244,33 @@ restrictRange (from , to) =
 {-# COMPILE AGDA2HS deleteAfter #-}
 {-# COMPILE AGDA2HS dropAfter #-}
 {-# COMPILE AGDA2HS restrictRange #-}
+
+{-----------------------------------------------------------------------------
+    Properties
+    Basic
+------------------------------------------------------------------------------}
+-- | Definition of 'lookupByItem'.
+prop-lookupByItem
+  : ∀ {{_ : Ord time}} {{_ : Ord a}}
+  → ∀ (x : a) (xs : Timeline time a)
+  → lookupByItem x xs ≡ Map.lookup x (getMapTime xs)
+--
+prop-lookupByItem xs x = refl
+
+-- | Definition of 'dropAfter' in terms of 'deleteAfter'.
+prop-dropAfter-deleteAfter
+  : ∀ {{_ : Ord time}} {{_ : Ord a}}
+  → ∀ (t : time) (xs : Timeline time a)
+  → dropAfter t xs ≡ snd (deleteAfter t xs)
+--
+prop-dropAfter-deleteAfter t xs = refl
+
+-- | The 'empty' 'Timeline' does not contain any items.
+prop-items-empty
+  : ∀ {{_ : Ord time}} {{_ : Ord a}}
+  → items {time} empty ≡ Set.empty {a}
+--
+prop-items-empty = Map.prop-keysSet-empty
 
 {-----------------------------------------------------------------------------
     Properties

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
@@ -2,7 +2,37 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StrictData #-}
 
-module Haskell.Data.Maps.Timeline where
+module Haskell.Data.Maps.Timeline
+    ( -- * Type
+      Timeline
+
+      -- * Construction
+    , empty
+
+      -- * Observation
+    , lookupByTime
+    , lookupByItem
+      -- $prop-lookupByItem
+    , getMapTime
+    , items
+      -- $prop-items-empty
+    , toAscList
+
+      -- * Operations
+    , insert
+    , insertMany
+    , difference
+    , restrictRange
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , deleteAfter
+    , dropAfter
+      -- $prop-dropAfter-deleteAfter
+
+      -- * Internal
+    , insertManyKeys
+    )
+where
 
 import Data.Set (Set)
 import Haskell.Data.List (foldl')
@@ -38,6 +68,7 @@ insertManyKeys keys v m0 =
 
 -- |
 -- A 'Timeline' is a set of items that are associated with a timestamp.
+--
 -- Each item is unique.
 -- Multiple items can have the same timestamp associated with it.
 data Timeline time a = Timeline
@@ -188,8 +219,6 @@ deleteAfter t = takeWhileAntitone (<= t)
 
 -- |
 -- Drop all items whose timestamp is after a given time.
---
--- > dropAfter t = snd ∘ deleteAfter t
 dropAfter
     :: (Ord time, Ord a) => time -> Timeline time a -> Timeline time a
 dropAfter t = (\r -> snd r) . deleteAfter t
@@ -208,3 +237,37 @@ restrictRange (from, to) =
         . \case
             (_, s) -> s
         . takeWhileAntitone (<= to)
+
+-- * Properties
+
+-- $prop-dropAfter-deleteAfter
+-- #p:prop-dropAfter-deleteAfter#
+--
+-- [prop-dropAfter-deleteAfter]:
+--     Definition of 'dropAfter' in terms of 'deleteAfter'.
+--
+--     > prop-dropAfter-deleteAfter
+--     >   : ∀ {{_ : Ord time}} {{_ : Ord a}}
+--     >   → ∀ (t : time) (xs : Timeline time a)
+--     >   → dropAfter t xs ≡ snd (deleteAfter t xs)
+
+-- $prop-items-empty
+-- #p:prop-items-empty#
+--
+-- [prop-items-empty]:
+--     The 'empty' 'Timeline' does not contain any items.
+--
+--     > prop-items-empty
+--     >   : ∀ {{_ : Ord time}} {{_ : Ord a}}
+--     >   → items {time} empty ≡ Set.empty {a}
+
+-- $prop-lookupByItem
+-- #p:prop-lookupByItem#
+--
+-- [prop-lookupByItem]:
+--     Definition of 'lookupByItem'.
+--
+--     > prop-lookupByItem
+--     >   : ∀ {{_ : Ord time}} {{_ : Ord a}}
+--     >   → ∀ (x : a) (xs : Timeline time a)
+--     >   → lookupByItem x xs ≡ Map.lookup x (getMapTime xs)

--- a/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Haskell/Data/Maps/Timeline.hs
@@ -21,6 +21,7 @@ module Haskell.Data.Maps.Timeline
       -- * Operations
     , insert
     , insertMany
+      -- $prop-items-insertMany
     , difference
     , restrictRange
     , takeWhileAntitone
@@ -260,6 +261,18 @@ restrictRange (from, to) =
 --     > prop-items-empty
 --     >   : ∀ {{_ : Ord time}} {{_ : Ord a}}
 --     >   → items {time} empty ≡ Set.empty {a}
+
+-- $prop-items-insertMany
+-- #p:prop-items-insertMany#
+--
+-- [prop-items-insertMany]:
+--     'insertMany' adds all items to the total set of items.
+--
+--     > prop-items-insertMany
+--     >   : ∀ {time a} {{_ : Ord time}} {{iOrda : Ord a}} {{_ : IsLawfulOrd time}}
+--     >   → ∀ (t : time) (ys : ℙ a) (xs : Timeline time a)
+--     >   → items (insertMany t ys xs)
+--     >     ≡ Set.union ys (items xs)
 
 -- $prop-lookupByItem
 -- #p:prop-lookupByItem#


### PR DESCRIPTION
This pull request adds properties to the `Data.Maps.Timeline` data type — some with proofs, as postulates for now. It also polishes the documentation of the generated Haskell module.