### PR TITLE
Bump `adga2hs` to version 1.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,16 +39,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1727251249,
-        "narHash": "sha256-WlowZoR9k1vTJ9YH4/51PkS9mBvWSbqyR2P8Ou0P7uk=",
+        "lastModified": 1728047784,
+        "narHash": "sha256-OodnWde3oY84DJFVIn5O+oxHJeiAd7HR+w+vPAn3CzM=",
         "owner": "agda",
         "repo": "agda2hs",
-        "rev": "770f209c3e1aa94ba9d34c1488379e83190d589d",
+        "rev": "b5d7c0e30e15edf274ff0a26188bd1f9b26673ff",
         "type": "github"
       },
       "original": {
         "owner": "agda",
-        "ref": "770f209c3e1aa94ba9d34c1488379e83190d589d",
+        "ref": "v1.3",
         "repo": "agda2hs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
 
-    agda2hs.url = "github:agda/agda2hs?ref=770f209c3e1aa94ba9d34c1488379e83190d589d";
+    agda2hs.url = "github:agda/agda2hs?ref=v1.3";
 #    agda-tools.url = "github:HeinrichApfelmus/agda-notes?dir=nix/agda-hs-tools";
   };
 


### PR DESCRIPTION
This pull request bumps the `agda2hs` dependency to `v1.3`.