### PR TITLE
Update specification of mapping `Customer` → `Address`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Implementation.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Implementation.agda
@@ -13,6 +13,12 @@ open import Haskell.Reasoning
 
 open import Specification.Common using (_⇔_; _∈_; isSubsetOf)
 
+open import Cardano.Wallet.Address.Encoding using
+    ( NetworkTag
+    )
+open import Cardano.Wallet.Address.BIP32_Ed25519 using
+    ( XPub
+    )
 open import Cardano.Wallet.Deposit.Pure.Experimental using
     ( TxSummary
     ; ValueTransfer
@@ -35,6 +41,7 @@ open import Cardano.Wallet.Read using
     )
 
 import Cardano.Wallet.Deposit.Pure.Experimental as Wallet
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 import Cardano.Wallet.Read as Read
 import Data.Map as Map
 
@@ -85,6 +92,15 @@ SigCardano = record
   ; SigTx = SigTx
   }
 
+import Specification.Wallet.UTxO
+
+SigWallet : Specification.Wallet.UTxO.Signature SigCardano
+SigWallet = record
+  { UTxO = UTxO.UTxO
+  ; balance = UTxO.balance
+  ; applyTxToUTxO = {!   !}
+  }
+
 {-----------------------------------------------------------------------------
     Module
     DepositWallet
@@ -95,7 +111,9 @@ import Specification
 module DepositWallet =
     Specification.DepositWallet
         WalletState
+        XPub
         SigCardano
+        SigWallet
 
 {-----------------------------------------------------------------------------
     Operations
@@ -116,10 +134,15 @@ fromTxSummary x =
 
 operations : DepositWallet.Operations
 operations = record
-  { listCustomers = Wallet.listCustomers
-  ; createAddress = Wallet.createAddress
-  ; availableBalance = Wallet.availableBalance
+  { deriveCustomerAddress = λ xpub addr →
+      Wallet.deriveCustomerAddress NetworkTag.MainnetTag xpub addr
+  ; fromXPubAndMax = {!   !}
+  ; listCustomers = Wallet.listCustomers
+
+  ; totalUTxO = {!   !}
   ; applyTx = Wallet.applyTx {{iIsEraConway}}
+  ; isOurs = {!   !}
+
   ; getCustomerHistory = λ customer →
     map fromTxSummary ∘ Wallet.getCustomerHistory customer
   ; createPayment = λ destinations tt s →
@@ -132,10 +155,13 @@ operations = record
 
 @0 properties : DepositWallet.Properties operations
 properties = record
-    { prop-create-known = Wallet.prop-create-known
-    ; deriveAddress = λ s →
-        Wallet.deriveCustomerAddress (Wallet.getNetworkTag s) (Wallet.getXPub s)
-    ; prop-create-derive = Wallet.prop-create-derive
+    { prop-listCustomers-isBijection = {!   !}
+    ; prop-listCustomers-fromXPubAndMax-max = {!   !}
+    ; prop-listCustomers-fromXPubAndMax-xpub = {!   !}
+
+    ; prop-knownCustomerAddress-isOurs = {!   !}
+    ; prop-totalUTxO-applyTx = {!   !}
+    ; prop-listCustomers-applyTx = {!   !}
 
     ; summarize = {!  !}
     ; prop-getAddressHistory-summary = {!  !}

--- a/lib/customer-deposit-wallet-pure/agda/Specification.lagda.md
+++ b/lib/customer-deposit-wallet-pure/agda/Specification.lagda.md
@@ -443,7 +443,7 @@ Finally, we expose an operation
 
 which constructs a transaction that sends given values to given addresses.
 Here, `PParams` are protocol parameters needed for computation the fee to
-include in the `Tx`.
+include in the transaction.
 
 First, as the main purpose of a wallet is to be able to send funds,
 it would be most desirable to require that this function always **succeeds**
@@ -493,3 +493,8 @@ In other words, we have
           → ¬ (address ∈ map getAddress (outputs tx))
 ```
 
+This property is not guarantee for other wallets,
+such as [cardano-wallet][].
+Unfortunately, this led to a very expensive bug.
+
+  [cardano-wallet]: https://github.com/cardano-foundation/cardano-wallet

--- a/lib/customer-deposit-wallet-pure/agda/Specification.lagda.md
+++ b/lib/customer-deposit-wallet-pure/agda/Specification.lagda.md
@@ -78,7 +78,7 @@ and also
 In addition, we also need to import concepts that are specific to Cardano:
 
 * [Specification.Cardano](Specification/Cardano.lagda.md)
-  * [Specification.Cardano.Tx](Specification/Cardano/Value.lagda.md)
+  * [Specification.Cardano.Tx](Specification/Cardano/Tx.lagda.md)
   — Transaction type `Tx`.
   * [Specification.Cardano.Value](Specification/Cardano/Value.lagda.md)
   — Monetary `Value`. Includes both native coins (ADA) and
@@ -111,9 +111,9 @@ We define a `module` `DepositWallet` which is parametrized by
 
 * the abstract data type `WalletState` that we wish to specify,
 * an implementation `SigCardano` of concepts that are related to Cardano,
-and which we need to express the specification.
+and which we need to express the specification, and
 * a specification `SigWallet` of wallet-related concepts that are
-  not the focus of this document, and
+  not the focus of this document.
 
 ```agda
 module
@@ -407,7 +407,8 @@ The behavior of this function is best specified in terms of a function
       map snd ∘ filter (λ x → fst x == address)
 ```
 
-which summarizes a single transaction. Specifically, the result of `getCustomerHistory` an aggregate of all previous transaction summaries.
+which summarizes a single transaction.
+Specifically, the result of `getCustomerHistory` is an aggregate of all previous transaction summaries.
 
 ```agda
     field
@@ -422,7 +423,7 @@ which summarizes a single transaction. Specifically, the result of `getCustomerH
               ++ getCustomerHistory s c
 ```
 
-Importantly, we only track an address if and only if it is a `knownCustomerAddress`.
+Importantly, track an address if and only if it is a `knownCustomerAddress`.
 
 ```agda
       prop-tx-known-address
@@ -469,7 +470,7 @@ Second, the transaction sends funds as indicated
 Third, and most importantly, the operation `createPayment` never creates a transaction
 whose `received` summary for any tracked index/address pair is non-zero.
 In other words, `createPayment` uses change addresses that are distinct
-from any address obtained via `createAddress`.
+from any address listed in `listCustomers`.
 
 That said, `createPayment` is free to contribute to the `spent` summary of any address
 — the deposit wallet spends funds from any address as it sees fit.

--- a/lib/customer-deposit-wallet-pure/agda/Specification.lagda.md
+++ b/lib/customer-deposit-wallet-pure/agda/Specification.lagda.md
@@ -428,22 +428,3 @@ In other words, we have
           → ¬ (address ∈ map getAddress (outputs tx))
 ```
 
-## Derived Properties
-
-TODO
-From the properties above, one can prove various other properties.
-However, this requires and induction principle on `WalletState`,
-where we can be certain that other operations do not interfere
-with the given ones.
-
-```agda
-{-
-prop-getAddressHistory-unknown : Set
-prop-getAddressHistory-unknown
-  = ∀ (s : WalletState)
-      (addr : Address)
-  → knownAddress addr s ≡ False
-  → getAddressHistory addr s ≡ []
--}
-```
-

--- a/lib/customer-deposit-wallet-pure/agda/Specification/Cardano.lagda.md
+++ b/lib/customer-deposit-wallet-pure/agda/Specification/Cardano.lagda.md
@@ -50,3 +50,11 @@ and re-export the existing ones from `Specification.Cardano.*`
   open ModValue.Signature SigValue public
   open ModTx.Signature SigTx public
 ```
+
+For improved readability, we use the synonym
+
+```agda
+  Address = CompactAddr
+```
+
+to refer to addresses on Cardano.

--- a/lib/customer-deposit-wallet-pure/agda/Specification/Common.lagda.md
+++ b/lib/customer-deposit-wallet-pure/agda/Specification/Common.lagda.md
@@ -13,6 +13,7 @@ We rely on common Haskell types, such as pairs, lists, …
 ```agda
 open import Haskell.Prelude
 open import Haskell.Reasoning
+open import Haskell.Data.Maybe using (isJust) public
 ```
 
 ## Additions
@@ -40,4 +41,12 @@ one list are also contained in the other list.
 ```agda
 isSubsetOf : ∀ {a : Set} {{_ : Eq a}} → List a → List a → Bool
 isSubsetOf xs ys = all (λ x → elem x ys) xs
+```
+
+The function `nub` is missing from `agda2hs`:
+
+```agda
+nub : {{Eq a}} → List a → List a
+nub [] = []
+nub (x ∷ xs) = x ∷ filter (x /=_) (nub xs)
 ```

--- a/lib/customer-deposit-wallet-pure/agda/Specification/Wallet/UTxO.lagda.md
+++ b/lib/customer-deposit-wallet-pure/agda/Specification/Wallet/UTxO.lagda.md
@@ -53,13 +53,13 @@ and functions
     applyTxToUTxO : (Address → Bool) → Tx → UTxO → UTxO
 ```
 
-The function `balance` computes the total value contain in the
+The function `balance` computes the total value contained in the
 unspent outputs.
 
 The function `applyTxToUTxO isOurs tx utxo` applies the given
-transaction `tx` to the unspect transction outputs in `utxo`.
+transaction `tx` to the unspent transction outputs in `utxo`.
 The predicate `isOurs` indicates whether the address of an output
-belongs to the wallet, i.e. because the wallet owner knows
+belongs to the wallet, typically because the wallet owner knows
 the corresponding signing key.
 Only those outputs that satisfy `isOurs` are included in the
 updated `UTxO`.

--- a/lib/customer-deposit-wallet-pure/agda/Specification/Wallet/UTxO.lagda.md
+++ b/lib/customer-deposit-wallet-pure/agda/Specification/Wallet/UTxO.lagda.md
@@ -1,0 +1,68 @@
+# Specification: UTxO
+
+This document provides an entrypoint to the specification
+of UTxO-style accounting for cryptocurrency wallets.
+
+This topic is discussed in-depth in
+
+* D. Coutts and E. de Vries. [Formal specification for a Cardano wallet][wallet]. (2018)
+
+In light of this prior art, the specification of the Deposit Wallet
+focuses on other topics; here, we just collect the most basic notions.
+
+  [wallet]: https://iohk.io/en/research/library/papers/formal-specification-for-a-cardano-wallet/
+
+```agda
+module Specification.Wallet.UTxO where
+```
+
+## Imports
+
+```agda
+open import Haskell.Prelude
+
+import Specification.Cardano
+```
+
+## Signature
+
+A signature records data types, operations,
+and the properties that these operations should satisfy.
+
+```agda
+record
+  Signature
+    (SigCardano : Specification.Cardano.Signature)
+    : Set₁
+  where
+  open Specification.Cardano.Signature SigCardano
+  field
+```
+
+We introduce new types
+
+```agda
+    UTxO : Set
+```
+
+and functions
+
+```agda
+    balance : UTxO → Value
+
+    applyTxToUTxO : (Address → Bool) → Tx → UTxO → UTxO
+```
+
+The function `balance` computes the total value contain in the
+unspent outputs.
+
+The function `applyTxToUTxO isOurs tx utxo` applies the given
+transaction `tx` to the unspect transction outputs in `utxo`.
+The predicate `isOurs` indicates whether the address of an output
+belongs to the wallet, i.e. because the wallet owner knows
+the corresponding signing key.
+Only those outputs that satisfy `isOurs` are included in the
+updated `UTxO`.
+
+At this level of detail, we cannot formulate any properties
+— we would need a definition of `Tx` for that purpose.


### PR DESCRIPTION
This pull request updates the specification of the mapping between `Customer` and `Address` to match what we have implemented.

This pull request does not yet address the sections on

* `TxHistory`
* `createPayment`