### PR TITLE
Add CI for `containers`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,6 +55,16 @@ steps:
     depends_on: linux-nix
     steps:
 
+    - label: "Check .agda"
+      key: check-agda
+      depends_on: []
+      command: |
+        ${nix} --command bash -c 'just ci-check-agda'
+      agents:
+        system: ${linux}
+      env:
+        TMPDIR: "/tmp"
+
     - label: "Build .agda"
       key: build-agda
       depends_on: []

--- a/justfile
+++ b/justfile
@@ -23,6 +23,10 @@ doc:
 test:
     cabal test -v0 -O0 -j all
 
+ci-check-agda:
+    just agda2hs-libraries
+    ./scripts/check-agda.sh lib/containers
+
 ci-build-agda:
     just haskell && git diff --exit-code
 

--- a/lib/containers/agda/EverythingContainers.agda
+++ b/lib/containers/agda/EverythingContainers.agda
@@ -1,3 +1,4 @@
 module EverythingContainers where
 
+import Data.Map
 import Data.Set

--- a/lib/containers/agda/Haskell/Data/Map.agda
+++ b/lib/containers/agda/Haskell/Data/Map.agda
@@ -3,7 +3,7 @@
 -- | Postulates and definitions of the operations supported by 'Map'.
 module Haskell.Data.Map where
 
-open import Haskell.Reasoning
+open import Haskell.Law.Equality
 open import Haskell.Prelude hiding (lookup; null; map; filter)
 import Haskell.Prelude as L using (map)
 

--- a/lib/containers/agda/Haskell/Data/Map/Law.agda
+++ b/lib/containers/agda/Haskell/Data/Map/Law.agda
@@ -3,7 +3,8 @@
 -- | Proofs on 'Map'.
 module Haskell.Data.Map.Law where
 
-open import Haskell.Reasoning
+open import Haskell.Law.Bool
+open import Haskell.Law.Equality
 open import Haskell.Prelude hiding (lookup; null; map; filter)
 
 open import Haskell.Data.Map

--- a/lib/containers/agda/Haskell/Data/Map/Maybe.agda
+++ b/lib/containers/agda/Haskell/Data/Map/Maybe.agda
@@ -7,7 +7,7 @@ module Haskell.Data.Map.Maybe
     This is used to make proofs for 'Data.Map' more transparent.
     -} where
 
-open import Haskell.Reasoning
+open import Haskell.Law.Equality
 open import Haskell.Prelude hiding (null; map; filter)
 
 open import Haskell.Data.Maybe using

--- a/scripts/agda2hs-libraries.sh
+++ b/scripts/agda2hs-libraries.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+# This script generates the `agda2hs-libraries` file
+# which brings both the current global libraries
+# and the local libraries in this repository into scope.
 
 # We should do: cat the known libraries file in the local one
 #AGDA2HS_LIB=/nix/store/xxxx-libraries

--- a/scripts/check-agda.sh
+++ b/scripts/check-agda.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script checks the `Everything*.agda` file
+# in the directory "$1/agda".
+
+ROOT_DIR="$PWD"
+DIR="$1"
+
+echo "Type checking $DIR."
+
+cd "$DIR" && agda2hs \
+    --local-interfaces \
+    --no-default-libraries \
+    --library-file "$ROOT_DIR/agda2hs-libraries" \
+    --disable-backend \
+    ./agda/Everything*.agda \


### PR DESCRIPTION
This pull request adds continuous integration for the local `containers.agda-lib` library. We do not generate Haskell code, but we do need to typecheck the proofs.
