### PR TITLE
Change to `fromXPubAndCount`

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -13,7 +13,7 @@ module Cardano.Wallet.Deposit.Pure.Address
       ; getNetworkTag
       ; getXPub
       ; emptyFromXPub
-      ; fromXPubAndMax
+      ; fromXPubAndCount
 
     -- ** Address observation
       ; isCustomerAddress
@@ -706,17 +706,23 @@ emptyFromXPub net xpub =
 {-# COMPILE AGDA2HS emptyFromXPub #-}
 
 -- | Create an 'AddressState' for a given 'NetworkId' from a public key and
--- a maximum customer index.
-fromXPubAndMax : NetworkId → XPub → Word31 → AddressState
-fromXPubAndMax net xpub cmax =
+-- a customer count.
+fromXPubAndCount : NetworkId → XPub → Word31 → AddressState
+fromXPubAndCount net xpub count =
     foldl (λ s c → snd (createAddress c s)) s0 customers
   where
     s0 = emptyFromXPub net xpub
 
     customers : List Customer
-    customers = enumFromTo 0 cmax
+    customers =
+      if fromEnum count == 0
+      then []
+      else λ {{neq}} →
+        let @0 notMin : _
+            notMin = subst IsFalse (sym neq) IsFalse.itsFalse
+        in  enumFromTo 0 (pred count {{notMin}})
 
-{-# COMPILE AGDA2HS fromXPubAndMax #-}
+{-# COMPILE AGDA2HS fromXPubAndCount #-}
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Experimental.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Experimental.agda
@@ -164,9 +164,9 @@ deriveCustomerAddress =
     Addr.deriveCustomerAddress (fromNetworkId defaultNetworkId)
 
 -- Specification
-fromXPubAndMax : XPub → Word31 → WalletState
-fromXPubAndMax xpub cmax = record
-    { addresses = Addr.fromXPubAndMax defaultNetworkId xpub cmax 
+fromXPubAndCount : XPub → Word31 → WalletState
+fromXPubAndCount xpub count = record
+    { addresses = Addr.fromXPubAndCount defaultNetworkId xpub count 
     ; utxo = UTxO.empty
     ; txSummaries = Map.empty
     ; localTip = ChainPoint.GenesisPoint
@@ -204,7 +204,7 @@ isOurs : WalletState → Address → Bool
 isOurs s = Addr.isOurs (addresses s)
 
 {-# COMPILE AGDA2HS deriveCustomerAddress #-}
-{-# COMPILE AGDA2HS fromXPubAndMax #-}
+{-# COMPILE AGDA2HS fromXPubAndCount #-}
 {-# COMPILE AGDA2HS listCustomers #-}
 {-# COMPILE AGDA2HS isOurs #-}
 {-# COMPILE AGDA2HS knownCustomerAddress #-}

--- a/lib/customer-deposit-wallet-pure/agda/Implementation.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Implementation.agda
@@ -153,7 +153,7 @@ fromTxSummary x =
 operations : DepositWallet.Operations
 operations = record
   { deriveCustomerAddress = Wallet.deriveCustomerAddress
-  ; fromXPubAndMax = Wallet.fromXPubAndMax
+  ; fromXPubAndCount = Wallet.fromXPubAndCount
   ; listCustomers = Wallet.listCustomers
 
   ; getWalletSlot = Wallet.getWalletSlot
@@ -175,10 +175,10 @@ operations = record
 @0 properties : DepositWallet.Properties operations
 properties = record
     { prop-listCustomers-isBijection = {!   !}
-    ; prop-listCustomers-fromXPubAndMax-max = {!   !}
-    ; prop-listCustomers-fromXPubAndMax-xpub = {!   !}
+    ; prop-listCustomers-fromXPubAndCount-range = {!   !}
+    ; prop-listCustomers-fromXPubAndCount-xpub = {!   !}
 
-    ; prop-getWalletSlot-fromXPubAndMax = {!   !}
+    ; prop-getWalletSlot-fromXPubAndCount = {!   !}
     ; prop-getWalletSlot-applyTx = {!   !}
     ; prop-getWalletSlot-applyTx-past = {!   !}
     ; prop-listCustomers-applyTx = {!   !}
@@ -188,7 +188,7 @@ properties = record
 
     ; prop-getCustomerHistory-applyTx = {!   !}
     ; prop-getCustomerHistory-knownCustomer = {!   !}
-    ; prop-getCustomerHistory-fromXPubAndMax = {!   !}
+    ; prop-getCustomerHistory-fromXPubAndCount = {!   !}
 
     ; prop-createPayment-destinations = {!   !}
     ; prop-createPayment-isOurs = {!   !}

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -13,7 +13,7 @@ module Cardano.Wallet.Deposit.Pure.Address
     , getNetworkTag
     , getXPub
     , emptyFromXPub
-    , fromXPubAndMax
+    , fromXPubAndCount
 
       -- ** Address observation
     , isCustomerAddress
@@ -251,15 +251,15 @@ emptyFromXPub net xpub =
 
 -- |
 -- Create an 'AddressState' for a given 'NetworkId' from a public key and
--- a maximum customer index.
-fromXPubAndMax :: NetworkId -> XPub -> Word31 -> AddressState
-fromXPubAndMax net xpub cmax =
+-- a customer count.
+fromXPubAndCount :: NetworkId -> XPub -> Word31 -> AddressState
+fromXPubAndCount net xpub count =
     foldl (\s c -> snd (createAddress c s)) s0 customers
   where
     s0 :: AddressState
     s0 = emptyFromXPub net xpub
     customers :: [Customer]
-    customers = [0 .. cmax]
+    customers = if fromEnum count == 0 then [] else [0 .. pred count]
 
 -- |
 -- Change address generator employed by 'AddressState'.

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Experimental.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Experimental.hs
@@ -5,7 +5,7 @@ import Cardano.Wallet.Address.Encoding (NetworkTag, fromNetworkId)
 import Cardano.Wallet.Deposit.Pure.Address (AddressState, Customer)
 import qualified Cardano.Wallet.Deposit.Pure.Address as Addr
     ( deriveCustomerAddress
-    , fromXPubAndMax
+    , fromXPubAndCount
     , getNetworkTag
     , getXPub
     , isOurs
@@ -73,10 +73,10 @@ deriveCustomerAddress :: XPub -> Customer -> Address
 deriveCustomerAddress =
     Addr.deriveCustomerAddress (fromNetworkId defaultNetworkId)
 
-fromXPubAndMax :: XPub -> Word31 -> WalletState
-fromXPubAndMax xpub cmax =
+fromXPubAndCount :: XPub -> Word31 -> WalletState
+fromXPubAndCount xpub count =
     WalletState
-        (Addr.fromXPubAndMax defaultNetworkId xpub cmax)
+        (Addr.fromXPubAndCount defaultNetworkId xpub count)
         UTxO.empty
         Map.empty
         GenesisPoint


### PR DESCRIPTION
This pull request changes the specification and implementation to use `fromXPubAndCount` again, because that is more readily understandable to users.

After reworking the specification, the only property that can tell the difference between `fromXPubAndCount` and `fromXPubAndMax` is

```agda
      prop-listCustomers-fromXPubAndCount-range
        : ∀ (c : Customer) (xpub : XPub) (count : Word31)
        → knownCustomer c (fromXPubAndCount xpub count)
          ≡ (0 <= c && c < count)
```

The other parts of the specification do not require changes, basing them on `knownCustomer` was an effective move.
