### PR TITLE
Remove `createAddress` exports

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Address.agda
@@ -28,10 +28,6 @@ module Cardano.Wallet.Deposit.Pure.Address
       ; getMaxCustomer
 
     -- ** Address creation
-      ; createAddress
-      ; prop-create-derive
-      ; prop-create-known
-
       ; newChangeAddress
       ; prop-changeAddress-not-Customer
       ; mockMaxLengthChangeAddress
@@ -655,34 +651,6 @@ createAddress c s0 = ( addr , s1 )
       }
 
 {-# COMPILE AGDA2HS createAddress #-}
-
--- | Creating a customer address is deterministic,
--- and depends essentially on the 'XPub'.
-prop-create-derive
-  : ∀ (c : Customer)
-      (s0 : AddressState)
-  → let (address , _) = createAddress c s0
-    in  deriveCustomerAddress (getNetworkTag s0) (stateXPub s0) c ≡ address
---
-prop-create-derive = λ c s0 → refl
-
--- | Creating an address makes it known.
-@0 prop-create-known
-  : ∀ (c  : Customer)
-      (s0 : AddressState)
-  → let (address , s1) = createAddress c s0
-    in  knownCustomerAddress address s1 ≡ True
---
-prop-create-known c s0 =
-  let (a , s1) = createAddress c s0
-  in
-    begin
-      knownCustomerAddress a s1
-    ≡⟨ sym (lemma-isCustomerAddress-knownCustomerAddress s1 a) ⟩
-      isCustomerAddress s1 a
-    ≡⟨ cong isJust (lemma-lookup-insert-same a c (addresses s0)) ⟩
-      True
-    ∎
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Experimental.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Cardano/Wallet/Deposit/Pure/Experimental.agda
@@ -13,10 +13,6 @@ module Cardano.Wallet.Deposit.Pure.Experimental
       ; isOurs
       ; knownCustomerAddress
 
-      ; createAddress
-      ; prop-create-derive
-      ; prop-create-known
-
       ; availableBalance
       ; applyTx
 
@@ -175,24 +171,6 @@ fromXPubAndCount xpub count = record
 -- Specification
 listCustomers : WalletState → List (Customer × Address)
 listCustomers = Addr.listCustomers ∘ addresses
-
--- Specification
-createAddress : Customer → WalletState → (Address × WalletState)
-createAddress c s0 = ( addr , s1 )
-  where
-    pair : Address × AddressState
-    pair = Addr.createAddress c (addresses s0)
-
-    a1 = snd pair
-    addr = fst pair
-
-    s1 : WalletState
-    s1 = record
-      { addresses = a1
-      ; utxo = utxo s0
-      ; txSummaries = txSummaries s0
-      ; localTip = localTip s0
-      }
 
 -- Specification
 knownCustomerAddress : Address → WalletState → Bool

--- a/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Cardano/Wallet/Deposit/Pure/Address.hs
@@ -28,9 +28,6 @@ module Cardano.Wallet.Deposit.Pure.Address
     , getMaxCustomer
 
       -- ** Address creation
-    , createAddress
-      -- $prop-create-derive
-      -- $prop-create-known
     , newChangeAddress
       -- $prop-changeAddress-not-Customer
     , mockMaxLengthChangeAddress
@@ -296,31 +293,6 @@ mockMaxLengthChangeAddress s =
 --     >       (addr : Address)
 --     >   → knownCustomerAddress addr s ≡ True
 --     >   → ¬(isChange (newChangeAddress s) addr)
-
--- $prop-create-derive
--- #p:prop-create-derive#
---
--- [prop-create-derive]:
---     Creating a customer address is deterministic,
---     and depends essentially on the 'XPub'.
---
---     > prop-create-derive
---     >   : ∀ (c : Customer)
---     >       (s0 : AddressState)
---     >   → let (address , _) = createAddress c s0
---     >     in  deriveCustomerAddress (getNetworkTag s0) (stateXPub s0) c ≡ address
-
--- $prop-create-known
--- #p:prop-create-known#
---
--- [prop-create-known]:
---     Creating an address makes it known.
---
---     > @0 prop-create-known
---     >   : ∀ (c  : Customer)
---     >       (s0 : AddressState)
---     >   → let (address , s1) = createAddress c s0
---     >     in  knownCustomerAddress address s1 ≡ True
 
 -- $prop-isCustomerAddress-deriveCustomerAddress
 -- #p:prop-isCustomerAddress-deriveCustomerAddress#


### PR DESCRIPTION
This pull request removes exports of the `createAddress` function, as this function is no longer used by the specification. However, it is still used internally.
