### PR TITLE
Prove that `map` preserves `isDeduplicated` for injective functions

### DIFF
--- a/lib/customer-deposit-wallet-pure/agda/Data/Function.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Data/Function.agda
@@ -1,0 +1,6 @@
+{-# OPTIONS --erasure #-}
+
+module Data.Function where
+
+open import Data.Function.Law public 
+open import Haskell.Law.Def public using (Injective)

--- a/lib/customer-deposit-wallet-pure/agda/Data/Function/Law.agda
+++ b/lib/customer-deposit-wallet-pure/agda/Data/Function/Law.agda
@@ -1,0 +1,33 @@
+{-# OPTIONS --erasure #-}
+
+module Data.Function.Law
+    {-|
+    ; prop-==-Injective
+    -}
+    where
+
+open import Haskell.Prelude
+open import Haskell.Law.Eq
+open import Haskell.Law.Equality
+open import Haskell.Law.Def public using (Injective)
+
+{-# FOREIGN AGDA2HS
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+dummy :: ()
+dummy = ()
+#-}
+
+-- | Injective functions preserve equality.
+prop-==-Injective
+  : ∀ ⦃ _ : Eq a ⦄ ⦃ _ : IsLawfulEq a ⦄
+      ⦃ _ : Eq b ⦄ ⦃ _ : IsLawfulEq b ⦄
+  → ∀ (f : a → b) → Injective f
+  → ∀ (x y : a)
+  → (x == y)
+    ≡ (f x == f y)
+--
+prop-==-Injective f inj x y
+  with f x == f y in eqf
+... | True  = equality' _ _ (inj (equality _ _ eqf))
+... | False = nequality' _ _ (nequality (f x) (f y) eqf ∘ cong f)

--- a/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
+++ b/lib/customer-deposit-wallet-pure/customer-deposit-wallet-pure.cabal
@@ -85,6 +85,7 @@ library
     Cardano.Wallet.Deposit.Pure.TxSummary
     Cardano.Wallet.Deposit.Read.Temp
     Cardano.Write.Tx.Balance
+    Data.Function.Law
     Data.List.Law
     Data.Maps.InverseMap
     Data.Maps.PairMap

--- a/lib/customer-deposit-wallet-pure/haskell/Data/Function/Law.hs
+++ b/lib/customer-deposit-wallet-pure/haskell/Data/Function/Law.hs
@@ -1,0 +1,27 @@
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+module Data.Function.Law
+    ( -- $prop-==-Injective
+    )
+where
+
+import Prelude hiding (null, subtract)
+
+dummy :: ()
+dummy = ()
+
+-- * Properties
+
+-- $prop-==-Injective
+-- #p:prop-==-Injective#
+--
+-- [prop-==-Injective]:
+--     Injective functions preserve equality.
+--
+--     > prop-==-Injective
+--     >   : ∀ ⦃ _ : Eq a ⦄ ⦃ _ : IsLawfulEq a ⦄
+--     >       ⦃ _ : Eq b ⦄ ⦃ _ : IsLawfulEq b ⦄
+--     >   → ∀ (f : a → b) → Injective f
+--     >   → ∀ (x y : a)
+--     >   → (x == y)
+--     >     ≡ (f x == f y)


### PR DESCRIPTION
This pull request adds a proof to `Data.List.Law` that `map` preserves `isDeduplicated` for injective functions.

```agda
prop-isDeduplicated-map
  : ∀ ⦃ _ : Eq a ⦄ ⦃ _ : IsLawfulEq a ⦄
      ⦃ _ : Eq b ⦄ ⦃ _ : IsLawfulEq b ⦄
  → ∀ (f : a → b) → Injective f
  → ∀ (xs : List a)
  → isDeduplicated xs ≡ True
  → isDeduplicated (map f xs) ≡ True
```

In order to prove this property, it was easier to rework the definition `isDeduplicated` to be primitively recursive. The previous definition `isDeduplicated xs = (nub xs == xs)` is now a proven property rather than a definition.